### PR TITLE
Fix UC09: Replace unsupported style attribute binding with individual style property bindings

### DIFF
--- a/src/main/java/com/example/views/UseCase09View.java
+++ b/src/main/java/com/example/views/UseCase09View.java
@@ -178,10 +178,10 @@ public class UseCase09View extends VerticalLayout {
         statusLabel.bindText(formValidSignal
                 .map(valid -> valid ? "Form is valid - Ready to submit"
                         : "Please complete all required fields correctly"));
-        statusLabel.getElement().bindAttribute("style",
-                formValidSignal
-                        .map(valid -> valid ? "color: green; font-weight: bold;"
-                                : "color: orange;"));
+        statusLabel.getStyle().bind("color",
+                formValidSignal.map(valid -> valid ? "green" : "orange"));
+        statusLabel.getStyle().bind("font-weight",
+                formValidSignal.map(valid -> valid ? "bold" : "normal"));
         statusDiv.add(statusLabel);
 
         add(title, description, usernameField, usernameError, emailField,


### PR DESCRIPTION
Binding the style attribute directly to a Signal causes UnsupportedOperationException. Changed to use getStyle().bind() for individual CSS properties (color and font-weight).
