### PR TITLE
Make multi-user collaboration session-aware with MapSignal

### DIFF
--- a/src/main/java/com/example/signals/SessionIdHelper.java
+++ b/src/main/java/com/example/signals/SessionIdHelper.java
@@ -1,0 +1,33 @@
+package com.example.signals;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Helper class for generating globally unique session identifiers.
+ * Combines VaadinSession ID (HTTP session) with UI ID to ensure uniqueness
+ * across all browser tabs and sessions.
+ */
+public class SessionIdHelper {
+
+    /**
+     * Get the current globally unique session ID.
+     * Format: {vaadinSessionId}:{uiId}
+     *
+     * @return unique session identifier for the current UI instance
+     */
+    public static String getCurrentSessionId() {
+        VaadinSession session = VaadinSession.getCurrent();
+        UI ui = UI.getCurrent();
+
+        if (session == null || ui == null) {
+            throw new IllegalStateException(
+                    "Cannot get session ID outside of Vaadin request context");
+        }
+
+        String vaadinSessionId = session.getSession().getId();
+        int uiId = ui.getUIId();
+
+        return vaadinSessionId + ":" + uiId;
+    }
+}

--- a/src/main/java/com/example/signals/UserInfo.java
+++ b/src/main/java/com/example/signals/UserInfo.java
@@ -3,8 +3,16 @@ package com.example.signals;
 /**
  * Information about an active user session.
  */
-public record UserInfo(String username, long sessionStartTime) {
-    public UserInfo(String username) {
-        this(username, System.currentTimeMillis());
+public record UserInfo(String username, String sessionId,
+        long sessionStartTime) {
+
+    // Convenience constructor
+    public UserInfo(String username, String sessionId) {
+        this(username, sessionId, System.currentTimeMillis());
+    }
+
+    // Generate composite key for tracking
+    public String getCompositeKey() {
+        return username + ":" + sessionId;
     }
 }

--- a/src/main/java/com/example/signals/UserSessionRegistry.java
+++ b/src/main/java/com/example/signals/UserSessionRegistry.java
@@ -3,6 +3,7 @@ package com.example.signals;
 import org.springframework.stereotype.Component;
 
 import com.vaadin.signals.ListSignal;
+import com.vaadin.signals.Signal;
 
 /**
  * Application-scoped registry of currently logged-in users. Provides a reactive
@@ -14,6 +15,41 @@ public class UserSessionRegistry {
     private final ListSignal<UserInfo> activeUsersSignal = new ListSignal<>(
             UserInfo.class);
 
+    // Computed signal for display names with session numbers
+    private final Signal<java.util.List<String>> displayNamesSignal = Signal
+            .computed(() -> {
+                var userSignals = activeUsersSignal.value();
+
+                // Count sessions per username
+                java.util.Map<String, Integer> sessionCounts = new java.util.HashMap<>();
+                java.util.Map<String, Integer> currentSessionNumber = new java.util.HashMap<>();
+
+                for (var userSignal : userSignals) {
+                    String username = userSignal.value().username();
+                    sessionCounts.merge(username, 1, Integer::sum);
+                }
+
+                // Generate display names with session numbers
+                java.util.List<String> displayNames = new java.util.ArrayList<>();
+                for (var userSignal : userSignals) {
+                    String username = userSignal.value().username();
+                    int sessionNum = currentSessionNumber.merge(username, 1,
+                            (a, b) -> a + 1);
+
+                    String displayName;
+                    if (sessionCounts.get(username) > 1) {
+                        // Multiple sessions - show number
+                        displayName = username + " #" + sessionNum;
+                    } else {
+                        // Single session - no number needed
+                        displayName = username;
+                    }
+                    displayNames.add(displayName);
+                }
+
+                return displayNames;
+            });
+
     /**
      * Get the signal containing the list of active users.
      */
@@ -22,32 +58,46 @@ public class UserSessionRegistry {
     }
 
     /**
-     * Register a user as active.
+     * Get the computed signal containing formatted display names with session
+     * numbers.
      */
-    public void registerUser(String username) {
-        if (username == null) {
-            throw new IllegalArgumentException("Username cannot be null");
+    public Signal<java.util.List<String>> getDisplayNamesSignal() {
+        return displayNamesSignal;
+    }
+
+    /**
+     * Register a user as active with a specific session ID.
+     */
+    public void registerUser(String username, String sessionId) {
+        if (username == null || sessionId == null) {
+            throw new IllegalArgumentException(
+                    "Username and sessionId cannot be null");
         }
 
-        // Check if user is already registered
+        // Check using composite key
+        String compositeKey = username + ":" + sessionId;
         boolean exists = activeUsersSignal.value().stream().anyMatch(
-                userSignal -> username.equals(userSignal.value().username()));
+                userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()));
 
         if (!exists) {
-            activeUsersSignal.insertLast(new UserInfo(username));
+            activeUsersSignal.insertLast(new UserInfo(username, sessionId));
         }
     }
 
     /**
      * Unregister a user (e.g., on logout or session timeout).
      */
-    public void unregisterUser(String username) {
-        if (username == null) {
-            throw new IllegalArgumentException("Username cannot be null");
+    public void unregisterUser(String username, String sessionId) {
+        if (username == null || sessionId == null) {
+            throw new IllegalArgumentException(
+                    "Username and sessionId cannot be null");
         }
 
-        activeUsersSignal.value().stream().filter(
-                userSignal -> username.equals(userSignal.value().username()))
+        String compositeKey = username + ":" + sessionId;
+        activeUsersSignal.value().stream()
+                .filter(userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()))
                 .findFirst().ifPresent(activeUsersSignal::remove);
     }
 
@@ -59,7 +109,7 @@ public class UserSessionRegistry {
     }
 
     /**
-     * Check if a user is currently active.
+     * Check if a user is currently active (any session).
      */
     public boolean isUserActive(String username) {
         if (username == null) {
@@ -69,4 +119,20 @@ public class UserSessionRegistry {
         return activeUsersSignal.value().stream().anyMatch(
                 userSignal -> username.equals(userSignal.value().username()));
     }
+
+    /**
+     * Check if a specific session is currently active.
+     */
+    public boolean isSessionActive(String username, String sessionId) {
+        if (username == null || sessionId == null) {
+            throw new IllegalArgumentException(
+                    "Username and sessionId cannot be null");
+        }
+
+        String compositeKey = username + ":" + sessionId;
+        return activeUsersSignal.value().stream().anyMatch(
+                userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()));
+    }
+
 }

--- a/src/main/java/com/example/views/MUC02View.java
+++ b/src/main/java/com/example/views/MUC02View.java
@@ -4,20 +4,26 @@ import jakarta.annotation.security.PermitAll;
 
 import java.util.Map;
 
+import com.example.MissingAPI;
 import com.example.security.CurrentUserSignal;
 import com.example.signals.CollaborativeSignals;
+import com.example.signals.SessionIdHelper;
 import com.example.signals.UserSessionRegistry;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.signals.Signal;
+import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
 /**
@@ -38,9 +44,10 @@ import com.vaadin.signals.WritableSignal;
 public class MUC02View extends VerticalLayout {
 
     private final String currentUser;
-    private final WritableSignal<CollaborativeSignals.CursorPosition> myCursorSignal;
+    private WritableSignal<CollaborativeSignals.CursorPosition> myCursorSignal;
     private final CollaborativeSignals collaborativeSignals;
     private final UserSessionRegistry userSessionRegistry;
+    private String sessionId;
 
     public MUC02View(CurrentUserSignal currentUserSignal,
             CollaborativeSignals collaborativeSignals,
@@ -54,10 +61,6 @@ public class MUC02View extends VerticalLayout {
         this.currentUser = userInfo.getUsername();
         this.collaborativeSignals = collaborativeSignals;
         this.userSessionRegistry = userSessionRegistry;
-
-        // Register this user's cursor signal
-        this.myCursorSignal = collaborativeSignals
-                .getCursorSignalForUser(currentUser);
 
         setSpacing(true);
         setPadding(true);
@@ -89,48 +92,85 @@ public class MUC02View extends VerticalLayout {
 
         // Track mouse movement
         canvas.getElement().addEventListener("mousemove", event -> {
-            // Get mouse position relative to canvas
-            double clientX = event.getEventData().get("event.offsetX")
-                    .asDouble();
-            double clientY = event.getEventData().get("event.offsetY")
-                    .asDouble();
-            myCursorSignal.value(new CollaborativeSignals.CursorPosition(
-                    (int) clientX, (int) clientY));
+            // Only update if attached (sessionId and myCursorSignal are set)
+            if (myCursorSignal != null) {
+                // Get mouse position relative to canvas
+                double clientX = event.getEventData().get("event.offsetX")
+                        .asDouble();
+                double clientY = event.getEventData().get("event.offsetY")
+                        .asDouble();
+                myCursorSignal.value(new CollaborativeSignals.CursorPosition(
+                        (int) clientX, (int) clientY));
+            }
         }).addEventData("event.offsetX").addEventData("event.offsetY");
 
-        // Current users list
-        H3 usersTitle = new H3("Active Users");
+        // Active sessions display
+        Div activeSessionsBox = new Div();
+        activeSessionsBox.getStyle().set("background-color", "#fff3e0")
+                .set("padding", "0.75em").set("border-radius", "4px")
+                .set("margin-bottom", "1em");
+
+        Span sessionCountLabel = new Span();
+        sessionCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
+                .map(displayNames -> {
+                    String usernames = String.join(", ", displayNames);
+                    return "👥 Active sessions: " + displayNames.size() + " ("
+                            + usernames + ")";
+                }));
+        sessionCountLabel.getStyle().set("font-weight", "500");
+
+        activeSessionsBox.add(sessionCountLabel);
+
+        // Current users list (cursor tracking)
+        H3 usersTitle = new H3("Cursor Tracking");
         Div usersList = new Div();
         usersList.getStyle().set("background-color", "#e3f2fd")
                 .set("padding", "1em").set("border-radius", "4px");
 
-        // Display all active users
-        for (Map.Entry<String, WritableSignal<CollaborativeSignals.CursorPosition>> entry : collaborativeSignals
-                .getUserCursors().entrySet()) {
-            String username = entry.getKey();
-            WritableSignal<CollaborativeSignals.CursorPosition> signal = entry
-                    .getValue();
+        // Display cursor positions per session - reactive
+        MissingAPI.bindChildren(usersList, Signal.computed(() -> {
+            var cursors = collaborativeSignals.getSessionCursorsSignal().value();
+            var users = userSessionRegistry.getActiveUsersSignal().value();
+            var displayNames = userSessionRegistry.getDisplayNamesSignal()
+                    .value();
 
-            Div userItem = new Div();
-            userItem.getStyle().set("display", "flex")
-                    .set("justify-content", "space-between")
-                    .set("margin-bottom", "0.5em");
+            // Build mapping from sessionKey to display name
+            java.util.Map<String, String> displayNameMap = new java.util.HashMap<>();
+            for (int i = 0; i < users.size() && i < displayNames.size(); i++) {
+                String sessionKey = users.get(i).value().getCompositeKey();
+                displayNameMap.put(sessionKey, displayNames.get(i));
+            }
 
-            Div userLabel = new Div();
-            userLabel.setText(
-                    username + (username.equals(currentUser) ? " (you)" : ""));
-            userLabel.getStyle().set("font-weight",
-                    username.equals(currentUser) ? "bold" : "normal");
+            return cursors.entrySet().stream().map(entry -> {
+                String sessionKey = entry.getKey();
+                ValueSignal<CollaborativeSignals.CursorPosition> positionSignal = entry
+                        .getValue();
 
-            Div positionLabel = new Div();
-            positionLabel.bindText(
-                    signal.map(CollaborativeSignals.CursorPosition::toString));
-            positionLabel.getStyle().set("font-family", "monospace")
-                    .set("color", "var(--lumo-secondary-text-color)");
+                // Get display name from mapping (fallback to full sessionKey for
+                // debugging)
+                String displayName = displayNameMap.getOrDefault(sessionKey,
+                        "[" + sessionKey + "]");
 
-            userItem.add(userLabel, positionLabel);
-            usersList.add(userItem);
-        }
+                Div userItem = new Div();
+                userItem.getStyle().set("display", "flex")
+                        .set("justify-content", "space-between")
+                        .set("margin-bottom", "0.5em");
+
+                Div userLabel = new Div();
+                userLabel.setText(displayName);
+                userLabel.getStyle().set("font-weight", "500");
+
+                Div positionLabel = new Div();
+                positionLabel.bindText(positionSignal
+                        .map(CollaborativeSignals.CursorPosition::toString));
+                positionLabel.getStyle().set("font-family", "monospace")
+                        .set("color",
+                                "var(--lumo-secondary-text-color)");
+
+                userItem.add(userLabel, positionLabel);
+                return userItem;
+            }).toList();
+        }));
 
         // Info box
         Div infoBox = new Div();
@@ -143,59 +183,87 @@ public class MUC02View extends VerticalLayout {
                         + "real-time collaborative awareness without complex synchronization code. "
                         + "With Vaadin Push, updates propagate automatically to all connected clients."));
 
-        add(title, description, canvas, usersTitle, usersList, infoBox);
+        add(title, description, activeSessionsBox, canvas, usersTitle, usersList,
+                infoBox);
     }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        userSessionRegistry.registerUser(currentUser);
+        this.sessionId = SessionIdHelper.getCurrentSessionId();
+        userSessionRegistry.registerUser(currentUser, sessionId);
+        this.myCursorSignal = collaborativeSignals
+                .getCursorSignalForUser(currentUser, sessionId);
     }
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser);
+        userSessionRegistry.unregisterUser(currentUser, sessionId);
+        collaborativeSignals.unregisterCursor(currentUser, sessionId);
     }
 
     private void renderAllCursors(Div container) {
-        for (Map.Entry<String, WritableSignal<CollaborativeSignals.CursorPosition>> entry : collaborativeSignals
-                .getUserCursors().entrySet()) {
-            String username = entry.getKey();
-            if (username.equals(currentUser)) {
-                continue; // Don't show own cursor
+        // Reactive rendering of cursor indicators
+        MissingAPI.bindChildren(container, Signal.computed(() -> {
+            var cursors = collaborativeSignals.getSessionCursorsSignal().value();
+            var users = userSessionRegistry.getActiveUsersSignal().value();
+            var displayNames = userSessionRegistry.getDisplayNamesSignal()
+                    .value();
+
+            // Build mapping from sessionKey to display name
+            java.util.Map<String, String> displayNameMap = new java.util.HashMap<>();
+            for (int i = 0; i < users.size() && i < displayNames.size(); i++) {
+                String sessionKey = users.get(i).value().getCompositeKey();
+                displayNameMap.put(sessionKey, displayNames.get(i));
             }
 
-            WritableSignal<CollaborativeSignals.CursorPosition> signal = entry
-                    .getValue();
+            return cursors.entrySet().stream()
+                    .filter(entry -> sessionId == null
+                            || !entry.getKey().equals(currentUser + ":" + sessionId))
+                    .map(entry -> {
+                        String sessionKey = entry.getKey();
+                        ValueSignal<CollaborativeSignals.CursorPosition> signal = entry
+                                .getValue();
 
-            Div cursorIndicator = new Div();
-            cursorIndicator.getStyle().set("position", "absolute")
-                    .set("width", "20px").set("height", "20px")
-                    .set("background-color", "var(--lumo-primary-color)")
-                    .set("border-radius", "50%")
-                    .set("border", "2px solid white")
-                    .set("pointer-events", "none")
-                    .set("transform", "translate(-50%, -50%)")
-                    .set("z-index", "1000");
+                        // Get display name from mapping (fallback to full sessionKey
+                        // for debugging)
+                        String displayName = displayNameMap.getOrDefault(sessionKey,
+                                "[" + sessionKey + "]");
 
-            // Bind position
-            cursorIndicator.getStyle().bind("left",
-                    signal.map(pos -> pos.x() + "px"));
-            cursorIndicator.getStyle().bind("top",
-                    signal.map(pos -> pos.y() + "px"));
+                        Div cursorIndicator = new Div();
+                        cursorIndicator.getStyle().set("position", "absolute")
+                                .set("width", "20px").set("height", "20px")
+                                .set("background-color",
+                                        "var(--lumo-primary-color)")
+                                .set("border-radius", "50%")
+                                .set("border", "2px solid white")
+                                .set("pointer-events", "none")
+                                .set("transform", "translate(-50%, -50%)")
+                                .set("z-index", "1000");
 
-            // Label
-            Div label = new Div();
-            label.setText(username);
-            label.getStyle().set("position", "absolute").set("top", "25px")
-                    .set("left", "0").set("white-space", "nowrap")
-                    .set("background-color", "rgba(0, 0, 0, 0.7)")
-                    .set("color", "white").set("padding", "2px 6px")
-                    .set("border-radius", "3px").set("font-size", "0.75em");
+                        // Bind position (with null guards)
+                        cursorIndicator.getStyle().bind("left", signal
+                                .map(pos -> pos != null ? pos.x() + "px" : "0px"));
+                        cursorIndicator.getStyle().bind("top", signal
+                                .map(pos -> pos != null ? pos.y() + "px" : "0px"));
 
-            cursorIndicator.add(label);
-            container.add(cursorIndicator);
-        }
+                        // Label with display name
+                        Div label = new Div();
+                        label.setText(displayName);
+                        label.getStyle().set("position", "absolute")
+                                .set("top", "25px").set("left", "0")
+                                .set("white-space", "nowrap")
+                                .set("background-color",
+                                        "rgba(0, 0, 0, 0.7)")
+                                .set("color", "white")
+                                .set("padding", "2px 6px")
+                                .set("border-radius", "3px")
+                                .set("font-size", "0.75em");
+
+                        cursorIndicator.add(label);
+                        return cursorIndicator;
+                    }).toList();
+        }));
     }
 }

--- a/src/main/java/com/example/views/MUC06View.java
+++ b/src/main/java/com/example/views/MUC06View.java
@@ -8,10 +8,12 @@ import java.util.UUID;
 import com.example.MissingAPI;
 import com.example.security.CurrentUserSignal;
 import com.example.signals.CollaborativeSignals;
+import com.example.signals.SessionIdHelper;
 import com.example.signals.UserSessionRegistry;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -101,12 +103,10 @@ public class MUC06View extends VerticalLayout {
                         "4px solid var(--lumo-warning-color)");
 
         Span userCountLabel = new Span();
-        userCountLabel.bindText(userSessionRegistry.getActiveUsersSignal()
-                .map(users -> {
-                    String usernames = users.stream()
-                            .map(u -> u.value().username()).toList().stream()
-                            .collect(java.util.stream.Collectors.joining(", "));
-                    return "👥 Active users: " + users.size() + " ("
+        userCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
+                .map(displayNames -> {
+                    String usernames = String.join(", ", displayNames);
+                    return "👥 Active users: " + displayNames.size() + " ("
                             + usernames + ")";
                 }));
         userCountLabel.getStyle().set("font-weight", "500");
@@ -182,13 +182,15 @@ public class MUC06View extends VerticalLayout {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        userSessionRegistry.registerUser(currentUser);
+        String sessionId = SessionIdHelper.getCurrentSessionId();
+        userSessionRegistry.registerUser(currentUser, sessionId);
     }
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser);
+        String sessionId = SessionIdHelper.getCurrentSessionId();
+        userSessionRegistry.unregisterUser(currentUser, sessionId);
     }
 
     private HorizontalLayout createTaskRow(

--- a/src/main/java/com/example/views/MainLayout.java
+++ b/src/main/java/com/example/views/MainLayout.java
@@ -35,14 +35,12 @@ public class MainLayout extends AppLayout {
                 .set("color", "var(--lumo-secondary-text-color)")
                 .set("font-size", "var(--lumo-font-size-s)");
         activeUsersDisplay.bindText(
-                userSessionRegistry.getActiveUsersSignal().map(userSignals -> {
-                    if (userSignals.isEmpty()) {
+                userSessionRegistry.getDisplayNamesSignal().map(displayNames -> {
+                    if (displayNames.isEmpty()) {
                         return "";
                     }
-                    String usernames = userSignals.stream()
-                            .map(userSignal -> userSignal.value().username())
-                            .collect(Collectors.joining(", "));
-                    return "👥 " + userSignals.size() + " online: " + usernames;
+                    String usernames = String.join(", ", displayNames);
+                    return "👥 " + displayNames.size() + " online: " + usernames;
                 }));
 
         // Current user display using signal


### PR DESCRIPTION
Convert all MUC views to track individual browser tabs/windows as separate sessions, fixing serialization issues and improving the multi-user experience.

Key changes:
- Add SessionIdHelper for unique session IDs (VaadinSession + UI ID)
- Update UserInfo to include sessionId and composite key tracking
- Add displayNamesSignal to show session numbers (e.g., "admin #1")
- Convert WritableSignal<Map> to MapSignal to fix serialization issues:
  * MUC-02: Cursor tracking (MapSignal<CursorPosition>)
  * MUC-03: Leaderboard (MapSignal<Integer>)
  * MUC-04: Field locking (MapSignal<FieldLock>)
- Update all MUC views to register/unregister with sessionId
- Show proper display names with session numbers in all views

This fixes LinkedHashMap serialization errors and allows the same user to open multiple tabs that are tracked and displayed separately.
