### PR TITLE
Fix UC16 not appearing in menu by removing HasUrlParameter interface

### DIFF
--- a/src/main/java/com/example/views/UseCase16View.java
+++ b/src/main/java/com/example/views/UseCase16View.java
@@ -20,8 +20,6 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
-import com.vaadin.flow.router.BeforeEvent;
-import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.QueryParameters;
@@ -48,7 +46,7 @@ import com.vaadin.signals.WritableSignal;
 @Menu(order = 16, title = "UC 16: URL State Integration")
 @PermitAll
 public class UseCase16View extends VerticalLayout
-        implements HasUrlParameter<String>, BeforeEnterObserver {
+        implements BeforeEnterObserver {
 
     public static class Article {
         private final String id;
@@ -328,12 +326,6 @@ public class UseCase16View extends VerticalLayout
 
         // Initial filter
         updateFilteredResults();
-    }
-
-    @Override
-    public void setParameter(BeforeEvent event, String parameter) {
-        // URL parameter support (not used in this case, but required by
-        // interface)
     }
 
     private void updateUrl() {


### PR DESCRIPTION
The HasUrlParameter interface was preventing menu registration while not being used. The view uses BeforeEnterObserver for query parameters instead, making HasUrlParameter unnecessary.

Changes:
- Remove HasUrlParameter<String> interface from UseCase16View
- Remove unused setParameter() method
- Remove unused BeforeEvent import

This allows UC16 to properly appear in the menu with order = 16.
