### PR TITLE
Centralize session management and add nickname/view tracking

### DIFF
--- a/src/main/java/com/example/signals/UserInfo.java
+++ b/src/main/java/com/example/signals/UserInfo.java
@@ -3,16 +3,35 @@ package com.example.signals;
 /**
  * Information about an active user session.
  */
-public record UserInfo(String username, String sessionId,
-        long sessionStartTime) {
+public record UserInfo(String username, String sessionId, String currentView,
+        String nickname, long sessionStartTime) {
 
-    // Convenience constructor
+    // Constructor with current view and nickname
+    public UserInfo(String username, String sessionId, String currentView,
+            String nickname) {
+        this(username, sessionId, currentView, nickname,
+                System.currentTimeMillis());
+    }
+
+    // Constructor without view or nickname (defaults to null)
     public UserInfo(String username, String sessionId) {
-        this(username, sessionId, System.currentTimeMillis());
+        this(username, sessionId, null, null, System.currentTimeMillis());
     }
 
     // Generate composite key for tracking
     public String getCompositeKey() {
         return username + ":" + sessionId;
+    }
+
+    // Helper to create updated instance with new view
+    public UserInfo withCurrentView(String newView) {
+        return new UserInfo(username, sessionId, newView, nickname,
+                sessionStartTime);
+    }
+
+    // Helper to create updated instance with new nickname
+    public UserInfo withNickname(String newNickname) {
+        return new UserInfo(username, sessionId, currentView, newNickname,
+                sessionStartTime);
     }
 }

--- a/src/main/java/com/example/signals/UserSessionRegistry.java
+++ b/src/main/java/com/example/signals/UserSessionRegistry.java
@@ -15,33 +15,40 @@ public class UserSessionRegistry {
     private final ListSignal<UserInfo> activeUsersSignal = new ListSignal<>(
             UserInfo.class);
 
-    // Computed signal for display names with session numbers
+    // Computed signal for display names with session numbers and nicknames
     private final Signal<java.util.List<String>> displayNamesSignal = Signal
             .computed(() -> {
                 var userSignals = activeUsersSignal.value();
 
-                // Count sessions per username
+                // Count sessions per username for auto-naming
                 java.util.Map<String, Integer> sessionCounts = new java.util.HashMap<>();
-                java.util.Map<String, Integer> currentSessionNumber = new java.util.HashMap<>();
-
                 for (var userSignal : userSignals) {
                     String username = userSignal.value().username();
                     sessionCounts.merge(username, 1, Integer::sum);
                 }
 
-                // Generate display names with session numbers
+                // Generate display names
+                java.util.Map<String, Integer> currentSessionNumber = new java.util.HashMap<>();
                 java.util.List<String> displayNames = new java.util.ArrayList<>();
+
                 for (var userSignal : userSignals) {
-                    String username = userSignal.value().username();
+                    UserInfo user = userSignal.value();
+
+                    // Check for nickname first
+                    if (user.nickname() != null && !user.nickname().isEmpty()) {
+                        displayNames.add(user.nickname());
+                        continue;
+                    }
+
+                    // Fall back to auto-generated name
+                    String username = user.username();
                     int sessionNum = currentSessionNumber.merge(username, 1,
                             (a, b) -> a + 1);
 
                     String displayName;
                     if (sessionCounts.get(username) > 1) {
-                        // Multiple sessions - show number
                         displayName = username + " #" + sessionNum;
                     } else {
-                        // Single session - no number needed
                         displayName = username;
                     }
                     displayNames.add(displayName);
@@ -133,6 +140,73 @@ public class UserSessionRegistry {
         return activeUsersSignal.value().stream().anyMatch(
                 userSignal -> compositeKey.equals(
                         userSignal.value().getCompositeKey()));
+    }
+
+    /**
+     * Set a custom nickname for a user session.
+     */
+    public void setNickname(String username, String sessionId, String nickname) {
+        String compositeKey = username + ":" + sessionId;
+        String trimmedNickname = (nickname == null || nickname.trim().isEmpty())
+                ? null
+                : nickname.trim();
+
+        activeUsersSignal.value().stream()
+                .filter(userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()))
+                .findFirst().ifPresent(userSignal -> {
+                    UserInfo oldInfo = userSignal.value();
+                    userSignal.value(oldInfo.withNickname(trimmedNickname));
+                });
+    }
+
+    /**
+     * Get the nickname for a user session, or null if not set.
+     */
+    public String getNickname(String username, String sessionId) {
+        String compositeKey = username + ":" + sessionId;
+        return activeUsersSignal.value().stream()
+                .filter(userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()))
+                .findFirst().map(userSignal -> userSignal.value().nickname())
+                .orElse(null);
+    }
+
+    /**
+     * Update the current view for a user session.
+     */
+    public void updateUserView(String username, String sessionId,
+            String viewRoute) {
+        String compositeKey = username + ":" + sessionId;
+
+        // Find the user and update their view
+        activeUsersSignal.value().stream()
+                .filter(userSignal -> compositeKey.equals(
+                        userSignal.value().getCompositeKey()))
+                .findFirst().ifPresent(userSignal -> {
+                    UserInfo oldInfo = userSignal.value();
+                    userSignal.value(oldInfo.withCurrentView(viewRoute));
+                });
+    }
+
+    /**
+     * Get a reactive signal of display names for users on a specific view.
+     */
+    public Signal<java.util.List<String>> getActiveUsersOnView(
+            String viewRoute) {
+        return Signal.computed(() -> {
+            var allUsers = activeUsersSignal.value();
+            var allDisplayNames = displayNamesSignal.value();
+
+            java.util.List<String> result = new java.util.ArrayList<>();
+            for (int i = 0; i < allUsers.size(); i++) {
+                UserInfo user = allUsers.get(i).value();
+                if (viewRoute.equals(user.currentView())) {
+                    result.add(allDisplayNames.get(i));
+                }
+            }
+            return result;
+        });
     }
 
 }

--- a/src/main/java/com/example/views/MUC01View.java
+++ b/src/main/java/com/example/views/MUC01View.java
@@ -145,13 +145,6 @@ public class MUC01View extends VerticalLayout {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         this.sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.registerUser(currentUser, sessionId);
-    }
-
-    @Override
-    protected void onDetach(DetachEvent detachEvent) {
-        super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser, sessionId);
     }
 
     private Div createMessageComponent(CollaborativeSignals.Message message) {

--- a/src/main/java/com/example/views/MUC02View.java
+++ b/src/main/java/com/example/views/MUC02View.java
@@ -191,7 +191,6 @@ public class MUC02View extends VerticalLayout {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         this.sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.registerUser(currentUser, sessionId);
         this.myCursorSignal = collaborativeSignals
                 .getCursorSignalForUser(currentUser, sessionId);
     }
@@ -199,7 +198,6 @@ public class MUC02View extends VerticalLayout {
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser, sessionId);
         collaborativeSignals.unregisterCursor(currentUser, sessionId);
     }
 

--- a/src/main/java/com/example/views/MUC03View.java
+++ b/src/main/java/com/example/views/MUC03View.java
@@ -259,14 +259,12 @@ public class MUC03View extends VerticalLayout {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         this.sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.registerUser(currentUser, sessionId);
         collaborativeSignals.initializePlayerScore(currentUser, sessionId);
     }
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser, sessionId);
         collaborativeSignals.unregisterScore(currentUser, sessionId);
     }
 }

--- a/src/main/java/com/example/views/MUC04View.java
+++ b/src/main/java/com/example/views/MUC04View.java
@@ -249,12 +249,5 @@ public class MUC04View extends VerticalLayout {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         this.sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.registerUser(currentUser, sessionId);
-    }
-
-    @Override
-    protected void onDetach(DetachEvent detachEvent) {
-        super.onDetach(detachEvent);
-        userSessionRegistry.unregisterUser(currentUser, sessionId);
     }
 }

--- a/src/main/java/com/example/views/MUC06View.java
+++ b/src/main/java/com/example/views/MUC06View.java
@@ -179,20 +179,6 @@ public class MUC06View extends VerticalLayout {
                 tasksContainer, addButton, infoBox);
     }
 
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        String sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.registerUser(currentUser, sessionId);
-    }
-
-    @Override
-    protected void onDetach(DetachEvent detachEvent) {
-        super.onDetach(detachEvent);
-        String sessionId = SessionIdHelper.getCurrentSessionId();
-        userSessionRegistry.unregisterUser(currentUser, sessionId);
-    }
-
     private HorizontalLayout createTaskRow(
             ValueSignal<CollaborativeSignals.Task> taskSignal,
             ListSignal<CollaborativeSignals.Task> tasksSignal) {


### PR DESCRIPTION
Move user session registration from individual views to MainLayout, and add support for custom nicknames and view-based filtering.

Key enhancements:

UserInfo changes:
- Add currentView field to track user's current route
- Add nickname field for custom display names
- Add withCurrentView() and withNickname() helper methods

UserSessionRegistry changes:
- Update displayNamesSignal to prioritize nicknames over auto-generated names
- Add setNickname/getNickname methods for nickname management
- Add updateUserView() to track navigation
- Add getActiveUsersOnView() for view-based filtering
- Store nickname in UserInfo instead of separate signal (cleaner design)

MainLayout changes:
- Implement BeforeEnterObserver for navigation tracking
- Add onAttach to register sessions automatically
- Add onDetach to unregister sessions on tab close
- Add beforeEnter to update user's current view
- Add nickname TextField in navbar for user customization

MUC views simplified:
- Remove duplicate registration code from all views
- MUC01/04: Only keep sessionId initialization
- MUC02/03: Keep view-specific registrations (cursors, scores)
- MUC06: Completely remove lifecycle methods

Benefits:
- Centralized session management eliminates code duplication
- Users can set custom nicknames replacing "username #1" format
- View tracking enables filtering users by current route
- Cleaner architecture with all session data in UserInfo
