### PR TITLE
Extract ActiveUsersDisplay as reusable component

### DIFF
--- a/src/main/java/com/example/views/ActiveUsersDisplay.java
+++ b/src/main/java/com/example/views/ActiveUsersDisplay.java
@@ -1,0 +1,68 @@
+package com.example.views;
+
+import com.example.signals.UserSessionRegistry;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+
+/**
+ * Reusable component for displaying active users/sessions.
+ * Shows a count and comma-separated list of display names.
+ */
+public class ActiveUsersDisplay extends Div {
+
+    /**
+     * Creates an active users display with default styling and "Active sessions"
+     * label.
+     *
+     * @param userSessionRegistry the registry to get user data from
+     */
+    public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry) {
+        this(userSessionRegistry, "Active sessions");
+    }
+
+    /**
+     * Creates an active users display with custom label text.
+     *
+     * @param userSessionRegistry the registry to get user data from
+     * @param labelText the text to show before the count (e.g., "Active users",
+     *            "Active sessions")
+     */
+    public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry,
+            String labelText) {
+        this(userSessionRegistry, labelText, false);
+    }
+
+    /**
+     * Creates an active users display with custom label text and optional accent
+     * border.
+     *
+     * @param userSessionRegistry the registry to get user data from
+     * @param labelText the text to show before the count (e.g., "Active users",
+     *            "Active sessions")
+     * @param showAccentBorder if true, shows a colored left border
+     */
+    public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry,
+            String labelText, boolean showAccentBorder) {
+        // Container styling
+        getStyle().set("background-color", "#fff3e0").set("padding", "0.75em")
+                .set("border-radius", "4px").set("margin-bottom", "1em");
+
+        if (showAccentBorder) {
+            getStyle().set("border-left",
+                    "4px solid var(--lumo-warning-color)");
+        }
+
+        // Label with reactive binding
+        Span label = new Span();
+        label.bindText(userSessionRegistry.getDisplayNamesSignal()
+                .map(displayNames -> {
+                    String usernames = String.join(", ", displayNames);
+                    return "👥 " + labelText + ": " + displayNames.size() + " ("
+                            + usernames + ")";
+                }));
+        label.getStyle().set("font-weight", "500");
+
+        add(label);
+    }
+}

--- a/src/main/java/com/example/views/MUC02View.java
+++ b/src/main/java/com/example/views/MUC02View.java
@@ -105,21 +105,8 @@ public class MUC02View extends VerticalLayout {
         }).addEventData("event.offsetX").addEventData("event.offsetY");
 
         // Active sessions display
-        Div activeSessionsBox = new Div();
-        activeSessionsBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "1em");
-
-        Span sessionCountLabel = new Span();
-        sessionCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> {
-                    String usernames = String.join(", ", displayNames);
-                    return "👥 Active sessions: " + displayNames.size() + " ("
-                            + usernames + ")";
-                }));
-        sessionCountLabel.getStyle().set("font-weight", "500");
-
-        activeSessionsBox.add(sessionCountLabel);
+        ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
+                userSessionRegistry);
 
         // Current users list (cursor tracking)
         H3 usersTitle = new H3("Cursor Tracking");

--- a/src/main/java/com/example/views/MUC03View.java
+++ b/src/main/java/com/example/views/MUC03View.java
@@ -132,21 +132,8 @@ public class MUC03View extends VerticalLayout {
         controls.add(startButton, resetButton);
 
         // Active sessions display
-        Div activeSessionsBox = new Div();
-        activeSessionsBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "1em");
-
-        Span sessionCountLabel = new Span();
-        sessionCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> {
-                    String usernames = String.join(", ", displayNames);
-                    return "👥 Active sessions: " + displayNames.size() + " ("
-                            + usernames + ")";
-                }));
-        sessionCountLabel.getStyle().set("font-weight", "500");
-
-        activeSessionsBox.add(sessionCountLabel);
+        ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
+                userSessionRegistry);
 
         // Leaderboard
         H3 leaderboardTitle = new H3("Leaderboard");

--- a/src/main/java/com/example/views/MUC04View.java
+++ b/src/main/java/com/example/views/MUC04View.java
@@ -82,21 +82,8 @@ public class MUC04View extends VerticalLayout {
                 collaborativeSignals.getPhoneSignal());
 
         // Active sessions display
-        Div activeSessionsBox = new Div();
-        activeSessionsBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "1em");
-
-        Span sessionCountLabel = new Span();
-        sessionCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> {
-                    String usernames = String.join(", ", displayNames);
-                    return "👥 Active sessions: " + displayNames.size() + " ("
-                            + usernames + ")";
-                }));
-        sessionCountLabel.getStyle().set("font-weight", "500");
-
-        activeSessionsBox.add(sessionCountLabel);
+        ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
+                userSessionRegistry);
 
         // Active editors display
         H3 editorsTitle = new H3("Active Editors");

--- a/src/main/java/com/example/views/MUC06View.java
+++ b/src/main/java/com/example/views/MUC06View.java
@@ -96,22 +96,8 @@ public class MUC06View extends VerticalLayout {
                 .computed(() -> totalSignal.value() - completedSignal.value());
 
         // User count display
-        Div userCountBox = new Div();
-        userCountBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "1em").set("border-left",
-                        "4px solid var(--lumo-warning-color)");
-
-        Span userCountLabel = new Span();
-        userCountLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> {
-                    String usernames = String.join(", ", displayNames);
-                    return "👥 Active users: " + displayNames.size() + " ("
-                            + usernames + ")";
-                }));
-        userCountLabel.getStyle().set("font-weight", "500");
-
-        userCountBox.add(userCountLabel);
+        ActiveUsersDisplay userCountBox = new ActiveUsersDisplay(
+                userSessionRegistry, "Active users", true);
 
         // Statistics panel
         Div statsBox = new Div();


### PR DESCRIPTION
Create a reusable component to display active users/sessions, eliminating code duplication across MUC views.

Changes:
- Add ActiveUsersDisplay.java with configurable label and styling
- Support custom label text ("Active users" vs "Active sessions")
- Support optional accent border for visual emphasis
- Update MUC02, MUC03, MUC04 to use default "Active sessions" style
- Update MUC06 to use "Active users" with accent border

Benefits:
- Eliminates ~15 lines of duplicate code per view
- Consistent styling and behavior across all views
- Easier to maintain and update active users display
- Configurable via constructor parameters
