### PR TITLE
Filter active users display to show only users on current view

### DIFF
--- a/src/main/java/com/example/views/ActiveUsersDisplay.java
+++ b/src/main/java/com/example/views/ActiveUsersDisplay.java
@@ -12,25 +12,24 @@ import com.vaadin.flow.component.html.Span;
 public class ActiveUsersDisplay extends Div {
 
     /**
-     * Creates an active users display with default styling and "Active sessions"
-     * label.
+     * Creates an active users display showing all users with default styling and
+     * "Active sessions" label.
      *
      * @param userSessionRegistry the registry to get user data from
      */
     public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry) {
-        this(userSessionRegistry, "Active sessions");
+        this(userSessionRegistry, "Active sessions", null, false);
     }
 
     /**
-     * Creates an active users display with custom label text.
+     * Creates an active users display filtered to a specific view route.
      *
      * @param userSessionRegistry the registry to get user data from
-     * @param labelText the text to show before the count (e.g., "Active users",
-     *            "Active sessions")
+     * @param viewRoute the view route to filter by (e.g., "muc-01")
      */
     public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry,
-            String labelText) {
-        this(userSessionRegistry, labelText, false);
+            String viewRoute) {
+        this(userSessionRegistry, "Active on this view", viewRoute, false);
     }
 
     /**
@@ -44,6 +43,20 @@ public class ActiveUsersDisplay extends Div {
      */
     public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry,
             String labelText, boolean showAccentBorder) {
+        this(userSessionRegistry, labelText, null, showAccentBorder);
+    }
+
+    /**
+     * Creates an active users display with all customization options.
+     *
+     * @param userSessionRegistry the registry to get user data from
+     * @param labelText the text to show before the count (e.g., "Active users",
+     *            "Active sessions")
+     * @param viewRoute the view route to filter by, or null for all users
+     * @param showAccentBorder if true, shows a colored left border
+     */
+    public ActiveUsersDisplay(UserSessionRegistry userSessionRegistry,
+            String labelText, String viewRoute, boolean showAccentBorder) {
         // Container styling
         getStyle().set("background-color", "#fff3e0").set("padding", "0.75em")
                 .set("border-radius", "4px").set("margin-bottom", "1em");
@@ -53,14 +66,28 @@ public class ActiveUsersDisplay extends Div {
                     "4px solid var(--lumo-warning-color)");
         }
 
-        // Label with reactive binding
+        // Label with reactive binding - filter by view if specified
         Span label = new Span();
-        label.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> {
-                    String usernames = String.join(", ", displayNames);
-                    return "👥 " + labelText + ": " + displayNames.size() + " ("
-                            + usernames + ")";
-                }));
+        if (viewRoute != null) {
+            // Show only users on this specific view
+            label.bindText(
+                    userSessionRegistry.getActiveUsersOnView(viewRoute)
+                            .map(displayNames -> {
+                                String usernames = String.join(", ",
+                                        displayNames);
+                                return "👥 " + labelText + ": "
+                                        + displayNames.size() + " (" + usernames
+                                        + ")";
+                            }));
+        } else {
+            // Show all users across all views
+            label.bindText(userSessionRegistry.getDisplayNamesSignal()
+                    .map(displayNames -> {
+                        String usernames = String.join(", ", displayNames);
+                        return "👥 " + labelText + ": " + displayNames.size()
+                                + " (" + usernames + ")";
+                    }));
+        }
         label.getStyle().set("font-weight", "500");
 
         add(label);

--- a/src/main/java/com/example/views/MUC01View.java
+++ b/src/main/java/com/example/views/MUC01View.java
@@ -73,6 +73,10 @@ public class MUC01View extends VerticalLayout {
                         + "In production, this would use server-side signals with Push to broadcast messages to all users. "
                         + "Try opening this page in multiple browser windows (different users) to see simulated collaboration.");
 
+        // Active users display
+        ActiveUsersDisplay activeUsersDisplay = new ActiveUsersDisplay(
+                userSessionRegistry, "muc-01");
+
         // Message display area
         Div messagesContainer = new Div();
         messagesContainer.setWidthFull();
@@ -137,8 +141,8 @@ public class MUC01View extends VerticalLayout {
                 + "• Signal API handles all synchronization automatically"),
                 messageCount);
 
-        add(title, description, new H3("Messages"), messagesContainer,
-                inputTitle, messageInput, sendLayout, infoBox);
+        add(title, description, activeUsersDisplay, new H3("Messages"),
+                messagesContainer, inputTitle, messageInput, sendLayout, infoBox);
     }
 
     @Override

--- a/src/main/java/com/example/views/MUC02View.java
+++ b/src/main/java/com/example/views/MUC02View.java
@@ -106,7 +106,7 @@ public class MUC02View extends VerticalLayout {
 
         // Active sessions display
         ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
-                userSessionRegistry);
+                userSessionRegistry, "muc-02");
 
         // Current users list (cursor tracking)
         H3 usersTitle = new H3("Cursor Tracking");

--- a/src/main/java/com/example/views/MUC03View.java
+++ b/src/main/java/com/example/views/MUC03View.java
@@ -133,7 +133,7 @@ public class MUC03View extends VerticalLayout {
 
         // Active sessions display
         ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
-                userSessionRegistry);
+                userSessionRegistry, "muc-03");
 
         // Leaderboard
         H3 leaderboardTitle = new H3("Leaderboard");

--- a/src/main/java/com/example/views/MUC04View.java
+++ b/src/main/java/com/example/views/MUC04View.java
@@ -83,7 +83,7 @@ public class MUC04View extends VerticalLayout {
 
         // Active sessions display
         ActiveUsersDisplay activeSessionsBox = new ActiveUsersDisplay(
-                userSessionRegistry);
+                userSessionRegistry, "muc-04");
 
         // Active editors display
         H3 editorsTitle = new H3("Active Editors");

--- a/src/main/java/com/example/views/MUC06View.java
+++ b/src/main/java/com/example/views/MUC06View.java
@@ -97,7 +97,7 @@ public class MUC06View extends VerticalLayout {
 
         // User count display
         ActiveUsersDisplay userCountBox = new ActiveUsersDisplay(
-                userSessionRegistry, "Active users", true);
+                userSessionRegistry, "Active on this view", "muc-06", true);
 
         // Statistics panel
         Div statsBox = new Div();


### PR DESCRIPTION
Update ActiveUsersDisplay to support view-based filtering and apply it to all MUC views. Each view now shows only users currently viewing that specific view, not all users across the entire application.

ActiveUsersDisplay changes:
- Add viewRoute parameter to filter users by current view
- Add constructor overloads for different use cases
- Use getActiveUsersOnView(route) when viewRoute is specified
- Default label changes to "Active on this view" for filtered display

MUC view updates:
- MUC01: Add ActiveUsersDisplay component, filter by "muc-01"
- MUC02: Filter by "muc-02" route
- MUC03: Filter by "muc-03" route
- MUC04: Filter by "muc-04" route
- MUC06: Filter by "muc-06" route with accent border

Benefits:
- Users see relevant collaboration context (who's on the same view)
- More accurate representation of real-time collaboration
- Cleaner UX - no confusion about users on other views
