### PR TITLE
Fix reactivity timing issue in active users display

### DIFF
--- a/src/main/java/com/example/signals/UserSessionRegistry.java
+++ b/src/main/java/com/example/signals/UserSessionRegistry.java
@@ -76,6 +76,13 @@ public class UserSessionRegistry {
      * Register a user as active with a specific session ID.
      */
     public void registerUser(String username, String sessionId) {
+        registerUser(username, sessionId, null);
+    }
+
+    /**
+     * Register a user as active with a specific session ID and initial route.
+     */
+    public void registerUser(String username, String sessionId, String initialRoute) {
         if (username == null || sessionId == null) {
             throw new IllegalArgumentException(
                     "Username and sessionId cannot be null");
@@ -88,7 +95,10 @@ public class UserSessionRegistry {
                         userSignal.value().getCompositeKey()));
 
         if (!exists) {
-            activeUsersSignal.insertLast(new UserInfo(username, sessionId));
+            activeUsersSignal.insertLast(new UserInfo(username, sessionId, initialRoute, null));
+        } else if (initialRoute != null) {
+            // User already registered, just update the route
+            updateUserView(username, sessionId, initialRoute);
         }
     }
 

--- a/src/main/java/com/example/views/MainLayout.java
+++ b/src/main/java/com/example/views/MainLayout.java
@@ -104,9 +104,7 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         super.onAttach(attachEvent);
         this.sessionId = SessionIdHelper.getCurrentSessionId();
 
-        if (currentUser != null) {
-            userSessionRegistry.registerUser(currentUser, sessionId);
-
+        if (currentUser != null && sessionId != null) {
             // Load current nickname if exists
             String currentNickname = userSessionRegistry.getNickname(currentUser,
                     sessionId);
@@ -127,11 +125,15 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        // Update user's current view
+        // Get sessionId if not already set (beforeEnter fires before onAttach)
+        if (sessionId == null) {
+            sessionId = SessionIdHelper.getCurrentSessionId();
+        }
+
+        // Register user with current route (or update route if already registered)
         if (currentUser != null && sessionId != null) {
             String viewRoute = event.getLocation().getPath();
-            userSessionRegistry.updateUserView(currentUser, sessionId,
-                    viewRoute);
+            userSessionRegistry.registerUser(currentUser, sessionId, viewRoute);
         }
     }
 }


### PR DESCRIPTION
Register user with initial route in beforeEnter() instead of onAttach() to ensure currentView is set before child components render. This fixes the issue where ActiveUsersDisplay showed no users when first navigating to a view.

The problem was that beforeEnter() fires before onAttach() in Vaadin's lifecycle, so calling updateUserView() in beforeEnter() tried to update a user that wasn't registered yet.
