### PR TITLE
Fix out-of-sync routes for UseCase views

### DIFF
--- a/src/main/java/com/example/views/UseCase01View.java
+++ b/src/main/java/com/example/views/UseCase01View.java
@@ -17,7 +17,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-03", layout = MainLayout.class)
+@Route(value = "use-case-01", layout = MainLayout.class)
 @PageTitle("Use Case 1: Dynamic Button State")
 @Menu(order = 1, title = "UC 1: Dynamic Button State")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase02View.java
+++ b/src/main/java/com/example/views/UseCase02View.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.signals.ReferenceSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-07", layout = MainLayout.class)
+@Route(value = "use-case-02", layout = MainLayout.class)
 @PageTitle("Use Case 2: Progressive Disclosure with Nested Conditions")
 @Menu(order = 2, title = "UC 2: Nested Conditions")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase03View.java
+++ b/src/main/java/com/example/views/UseCase03View.java
@@ -22,7 +22,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-08", layout = MainLayout.class)
+@Route(value = "use-case-03", layout = MainLayout.class)
 @PageTitle("Use Case 3: Permission-Based Component Visibility")
 @Menu(order = 3, title = "UC 3: Permission-Based UI")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase04View.java
+++ b/src/main/java/com/example/views/UseCase04View.java
@@ -20,7 +20,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-09", layout = MainLayout.class)
+@Route(value = "use-case-04", layout = MainLayout.class)
 @PageTitle("Use Case 4: Filtered and Sorted Data Grid")
 @Menu(order = 4, title = "UC 4: Filtered Data Grid")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase05View.java
+++ b/src/main/java/com/example/views/UseCase05View.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-5", layout = MainLayout.class)
+@Route(value = "use-case-05", layout = MainLayout.class)
 @PageTitle("Use Case 5: Cascading Location Selector")
 @Menu(order = 5, title = "UC 5: Cascading Selector")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase06View.java
+++ b/src/main/java/com/example/views/UseCase06View.java
@@ -26,7 +26,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-6", layout = MainLayout.class)
+@Route(value = "use-case-06", layout = MainLayout.class)
 @PageTitle("Use Case 6: Shopping Cart with Real-time Totals")
 @Menu(order = 6, title = "UC 6: Shopping Cart")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase07View.java
+++ b/src/main/java/com/example/views/UseCase07View.java
@@ -23,7 +23,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-7", layout = MainLayout.class)
+@Route(value = "use-case-07", layout = MainLayout.class)
 @PageTitle("Use Case 7: Master-Detail Invoice View")
 @Menu(order = 7, title = "UC 7: Master-Detail Invoice")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase08View.java
+++ b/src/main/java/com/example/views/UseCase08View.java
@@ -22,7 +22,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-8", layout = MainLayout.class)
+@Route(value = "use-case-08", layout = MainLayout.class)
 @PageTitle("Use Case 8: Multi-Step Wizard with Validation")
 @Menu(order = 8, title = "UC 8: Multi-Step Wizard")
 @PermitAll

--- a/src/main/java/com/example/views/UseCase09View.java
+++ b/src/main/java/com/example/views/UseCase09View.java
@@ -21,7 +21,7 @@ import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
-@Route(value = "use-case-9", layout = MainLayout.class)
+@Route(value = "use-case-09", layout = MainLayout.class)
 @PageTitle("Use Case 9: Form with Binder Integration and Signal Validation")
 @Menu(order = 9, title = "UC 9: Binder Integration")
 @PermitAll


### PR DESCRIPTION
The routes were completely mismatched with class names and menu titles:
- UseCase01View had route "use-case-03" (now "use-case-01")
- UseCase02View had route "use-case-07" (now "use-case-02")
- UseCase03View had route "use-case-08" (now "use-case-03")
- UseCase04View had route "use-case-09" (now "use-case-04")
- UseCase05-09 had routes without leading zeros (now with zeros)

All routes now correctly match their class names with consistent two-digit formatting (use-case-01 through use-case-17).
