### PR TITLE
refactor: adopt signal-based constructor API for HTML components

### DIFF
--- a/src/main/java/com/example/views/ActiveUsersDisplay.java
+++ b/src/main/java/com/example/views/ActiveUsersDisplay.java
@@ -72,10 +72,6 @@ public class ActiveUsersDisplay extends Div {
                     "4px solid var(--lumo-warning-color)");
         }
 
-        // Title with count
-        Span title = new Span();
-        title.getStyle().set("font-weight", "500");
-
         // Users container with avatars
         Div usersContainer = new Div();
         usersContainer.getStyle().set("display", "flex")
@@ -86,10 +82,11 @@ public class ActiveUsersDisplay extends Div {
                 ? userSessionRegistry.getActiveUsersOnView(viewRoute)
                 : userSessionRegistry.getDisplayNamesSignal();
 
-        // Bind title with count
-        title.bindText(displayNamesSignal
+        // Title with count
+        Span title = new Span(displayNamesSignal
                 .map(displayNames -> "👥 " + labelText + ": "
                         + displayNames.size()));
+        title.getStyle().set("font-weight", "500");
 
         // Bind user avatars and names
         MissingAPI.bindChildren(usersContainer, Signal.computed(() -> {

--- a/src/main/java/com/example/views/MUC02View.java
+++ b/src/main/java/com/example/views/MUC02View.java
@@ -163,8 +163,7 @@ public class MUC02View extends VerticalLayout {
                 userLabel.getStyle().set("font-weight", "500");
 
                 // Position label
-                Div positionLabel = new Div();
-                positionLabel.bindText(positionSignal
+                Div positionLabel = new Div(positionSignal
                         .map(CollaborativeSignals.CursorPosition::toString));
                 positionLabel.getStyle().set("font-family", "monospace")
                         .set("color", "var(--lumo-secondary-text-color)")

--- a/src/main/java/com/example/views/MainLayout.java
+++ b/src/main/java/com/example/views/MainLayout.java
@@ -70,13 +70,12 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         activeUsersDisplay.getStyle().set("margin-left", "auto")
                 .set("margin-right", "1em");
 
-        Span activeUsersLabel = new Span();
+        Span activeUsersLabel = new Span(userSessionRegistry.getDisplayNamesSignal()
+                .map(displayNames -> displayNames.isEmpty() ? ""
+                        : "👥 " + displayNames.size() + " online:"));
         activeUsersLabel.getStyle().set("color",
                 "var(--lumo-secondary-text-color)")
                 .set("font-size", "var(--lumo-font-size-s)");
-        activeUsersLabel.bindText(userSessionRegistry.getDisplayNamesSignal()
-                .map(displayNames -> displayNames.isEmpty() ? ""
-                        : "👥 " + displayNames.size() + " online:"));
 
         com.vaadin.flow.component.html.Div avatarsContainer = new com.vaadin.flow.component.html.Div();
         avatarsContainer.getStyle().set("display", "flex").set("gap", "0.25em");
@@ -137,11 +136,10 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         userAvatar.bindVisible(currentUserSignal.getUserSignal()
                 .map(user -> user.isAuthenticated()));
 
-        Span userName = new Span();
+        Span userName = new Span(currentUserSignal.getUserSignal()
+                .map(user -> user.isAuthenticated() ? user.getUsername() : ""));
         userName.getStyle().set("color", "var(--lumo-secondary-text-color)")
                 .set("font-size", "var(--lumo-font-size-s)");
-        userName.bindText(currentUserSignal.getUserSignal()
-                .map(user -> user.isAuthenticated() ? user.getUsername() : ""));
 
         userDisplay.add(userAvatar, userName);
 

--- a/src/main/java/com/example/views/UseCase12View.java
+++ b/src/main/java/com/example/views/UseCase12View.java
@@ -71,24 +71,21 @@ public class UseCase12View extends VerticalLayout {
         titleLabel.getStyle().set("margin", "0 0 0.5em 0").set("font-weight",
                 "bold");
 
-        Paragraph titleDisplay = new Paragraph();
+        Paragraph titleDisplay = new Paragraph(viewTitleSignal);
         titleDisplay.getStyle().set("margin", "0")
                 .set("font-family", "monospace").set("font-size", "1.1em");
-        titleDisplay.bindText(viewTitleSignal);
 
         Paragraph browserTitleLabel = new Paragraph("Browser Tab Title:");
         browserTitleLabel.getStyle().set("margin", "1em 0 0.5em 0")
                 .set("font-weight", "bold");
 
-        Paragraph browserTitleDisplay = new Paragraph();
-        browserTitleDisplay.getStyle().set("margin", "0")
-                .set("font-family", "monospace").set("font-size", "1.1em")
-                .set("color", "var(--lumo-primary-color)");
-
         // Compose app name + view title
         Signal<String> fullTitleSignal = viewTitleSignal
                 .map(viewTitle -> APP_NAME + " - " + viewTitle);
-        browserTitleDisplay.bindText(fullTitleSignal);
+        Paragraph browserTitleDisplay = new Paragraph(fullTitleSignal);
+        browserTitleDisplay.getStyle().set("margin", "0")
+                .set("font-family", "monospace").set("font-size", "1.1em")
+                .set("color", "var(--lumo-primary-color)");
 
         currentTitleBox.add(titleLabel, titleDisplay, browserTitleLabel,
                 browserTitleDisplay);

--- a/src/main/java/com/example/views/UseCase15View.java
+++ b/src/main/java/com/example/views/UseCase15View.java
@@ -120,32 +120,29 @@ public class UseCase15View extends VerticalLayout {
         Span instantLabel = new Span("Instant value: ");
         instantLabel.getStyle().set("color",
                 "var(--lumo-secondary-text-color)");
-        Span instantValue = new Span();
+        Span instantValue = new Span(searchQuerySignal
+                .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         instantValue.getStyle().set("font-family", "monospace")
                 .set("font-weight", "bold");
-        instantValue.bindText(searchQuerySignal
-                .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         instantQueryDiv.add(instantLabel, instantValue);
 
         Div debouncedQueryDiv = new Div();
         Span debouncedLabel = new Span("Debounced value (300ms): ");
         debouncedLabel.getStyle().set("color",
                 "var(--lumo-secondary-text-color)");
-        Span debouncedValue = new Span();
+        Span debouncedValue = new Span(debouncedQuerySignal
+                .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         debouncedValue.getStyle().set("font-family", "monospace")
                 .set("font-weight", "bold")
                 .set("color", "var(--lumo-primary-color)");
-        debouncedValue.bindText(debouncedQuerySignal
-                .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         debouncedQueryDiv.add(debouncedLabel, debouncedValue);
 
         Div searchCountDiv = new Div();
         Span countLabel = new Span("Searches performed: ");
         countLabel.getStyle().set("color", "var(--lumo-secondary-text-color)");
-        Span countValue = new Span();
+        Span countValue = new Span(searchCountSignal.map(String::valueOf));
         countValue.getStyle().set("font-weight", "bold").set("color",
                 "var(--lumo-success-color)");
-        countValue.bindText(searchCountSignal.map(String::valueOf));
         searchCountDiv.add(countLabel, countValue);
 
         statsBox.add(instantQueryDiv, debouncedQueryDiv, searchCountDiv);
@@ -159,15 +156,13 @@ public class UseCase15View extends VerticalLayout {
         searchingIcon.getStyle().set("animation", "spin 1s linear infinite");
         searchingIcon.bindVisible(isSearchingSignal);
 
-        Span statusText = new Span();
-        statusText.bindText(isSearchingSignal
+        Span statusText = new Span(isSearchingSignal
                 .map(searching -> searching ? "Searching..." : ""));
         statusText.getStyle().set("color", "var(--lumo-primary-color)");
 
         statusBox.add(searchingIcon, statusText);
 
         // Results
-        H3 resultsTitle = new H3();
         Signal<String> resultsTitleSignal = searchResultsSignal.map(results -> {
             if (results.isEmpty() && !debouncedQuerySignal.value().isEmpty()) {
                 return "No results found";
@@ -177,7 +172,7 @@ public class UseCase15View extends VerticalLayout {
             }
             return "Type to search";
         });
-        resultsTitle.bindText(resultsTitleSignal);
+        H3 resultsTitle = new H3(resultsTitleSignal);
 
         Div resultsContainer = new Div();
         resultsContainer.getStyle().set("display", "flex")
@@ -266,10 +261,8 @@ public class UseCase15View extends VerticalLayout {
             debounceTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    getUI().ifPresent(ui -> ui.access(() -> {
-                        debouncedQuerySignal.value(query);
-                        performSearch(query);
-                    }));
+                    debouncedQuerySignal.value(query);
+                    performSearch(query);
                 }
             }, 300); // 300ms debounce delay
         });

--- a/src/main/java/com/example/views/UseCase16View.java
+++ b/src/main/java/com/example/views/UseCase16View.java
@@ -161,12 +161,6 @@ public class UseCase16View extends VerticalLayout
         H3 urlTitle = new H3("Current URL");
         urlTitle.getStyle().set("margin-top", "0");
 
-        Paragraph urlDisplay = new Paragraph();
-        urlDisplay.getStyle().set("font-family", "monospace")
-                .set("word-break", "break-all")
-                .set("background-color", "#ffffff").set("padding", "0.5em")
-                .set("border-radius", "4px");
-
         // Update URL display based on signals
         Signal<String> currentUrlSignal = Signal.computed(() -> {
             String baseUrl = getBaseUrl();
@@ -188,7 +182,11 @@ public class UseCase16View extends VerticalLayout
             return url.toString();
         });
 
-        urlDisplay.bindText(currentUrlSignal);
+        Paragraph urlDisplay = new Paragraph(currentUrlSignal);
+        urlDisplay.getStyle().set("font-family", "monospace")
+                .set("word-break", "break-all")
+                .set("background-color", "#ffffff").set("padding", "0.5em")
+                .set("border-radius", "4px");
 
         urlBox.add(urlTitle, urlDisplay);
 
@@ -212,11 +210,10 @@ public class UseCase16View extends VerticalLayout
         shareLinks.add(link1, link2, link3);
 
         // Results
-        H3 resultsTitle = new H3();
         Signal<String> resultsTitleSignal = filteredArticlesSignal
                 .map(articles -> articles.size() + " article"
                         + (articles.size() == 1 ? "" : "s") + " found");
-        resultsTitle.bindText(resultsTitleSignal);
+        H3 resultsTitle = new H3(resultsTitleSignal);
 
         Div resultsContainer = new Div();
         resultsContainer.getStyle().set("display", "flex")

--- a/src/main/java/com/example/views/UseCase17View.java
+++ b/src/main/java/com/example/views/UseCase17View.java
@@ -1018,11 +1018,9 @@ public class UseCase17View extends VerticalLayout {
         powerLabel.getStyle().set("display", "block").set("font-weight", "bold")
                 .set("margin-bottom", "0.5em");
 
-        Span powerValue = new Span();
-        powerValue.bindText(totalPowerSignal.map(p -> p + "W total"));
+        Span powerValue = new Span(totalPowerSignal.map(p -> p + "W total"));
         powerValue.getStyle().set("display", "block");
 
-        Span psuStatus = new Span();
         Signal<String> psuStatusText = Signal.computed(() -> {
             PSU psu = psuSignal.value();
             if (psu == null)
@@ -1033,7 +1031,7 @@ public class UseCase17View extends VerticalLayout {
                     + (sufficient ? "✓ OK (+" + margin + "W)"
                             : "⚠ Insufficient");
         });
-        psuStatus.bindText(psuStatusText);
+        Span psuStatus = new Span(psuStatusText);
         psuStatus.getStyle().set("display", "block");
 
         powerBox.add(powerLabel, powerValue, psuStatus);
@@ -1053,18 +1051,14 @@ public class UseCase17View extends VerticalLayout {
         perfLabel.getStyle().set("display", "block").set("font-weight", "bold")
                 .set("margin-bottom", "0.5em");
 
-        Span perfRating = new Span();
-        perfRating.bindText(performanceRatingSignal);
+        Span perfRating = new Span(performanceRatingSignal);
         perfRating.getStyle().set("display", "block").set("font-size", "1.2em")
                 .set("color", "var(--lumo-primary-color)");
 
-        Span perfGaming = new Span();
-        perfGaming
-                .bindText(gamingScoreSignal.map(s -> "Gaming: " + s + "/100"));
+        Span perfGaming = new Span(gamingScoreSignal.map(s -> "Gaming: " + s + "/100"));
         perfGaming.getStyle().set("display", "block").set("font-size", "0.9em");
 
-        Span perfBottleneck = new Span();
-        perfBottleneck.bindText(bottleneckSignal.map(b -> "Bottleneck: " + b));
+        Span perfBottleneck = new Span(bottleneckSignal.map(b -> "Bottleneck: " + b));
         perfBottleneck.getStyle().set("display", "block").set("font-size",
                 "0.9em");
 
@@ -1084,8 +1078,7 @@ public class UseCase17View extends VerticalLayout {
         labelSpan.getStyle().set("display", "block").set("font-weight", "bold")
                 .set("margin-bottom", "0.5em");
 
-        Span valueSpan = new Span();
-        valueSpan.bindText(valueSignal);
+        Span valueSpan = new Span(valueSignal);
         valueSpan.getStyle().set("display", "block").set("font-size", "1.2em");
 
         box.add(labelSpan, valueSpan);
@@ -1103,8 +1096,7 @@ public class UseCase17View extends VerticalLayout {
         labelSpan.getStyle().set("display", "block").set("font-weight", "bold")
                 .set("margin-bottom", "0.5em");
 
-        Span valueSpan = new Span();
-        valueSpan.bindText(valueSignal);
+        Span valueSpan = new Span(valueSignal);
         valueSpan.getStyle().set("display", "block").set("font-size", "1.2em");
 
         box.add(labelSpan, valueSpan);


### PR DESCRIPTION
- Use new Paragraph(signal) instead of new Paragraph() + bindText()
- Apply to Span, H3, Div components across 7 view files
- Remove unnecessary UI.access() in UseCase15View debounce logic
- Based on Vaadin Flow API update from Jan 15, 2026

Updated files:
- UseCase12View: 2 Paragraph components
- UseCase15View: 4 Span + 1 H3 + removed UI.access wrapper
- UseCase16View: 1 Paragraph + 1 H3
- UseCase17View: 7 Span components
- MainLayout: 2 Span components
- MUC02View: 1 Div component
- ActiveUsersDisplay: 1 Span component
