### PR TITLE
Use display names instead of usernames in chat

### DIFF
--- a/src/main/java/com/example/views/MUC07View.java
+++ b/src/main/java/com/example/views/MUC07View.java
@@ -29,7 +29,8 @@ public class MUC07View extends AbstractTaskChatView {
             collaborativeSignals.getLlmChatMessagesSignal(),    // Shared chat signal
             taskLLMService,
             getUserConversationId(currentUserSignal),           // Per-user conversation ID
-            currentUserSignal                                   // Current user for avatar/name
+            currentUserSignal,                                  // Current user for avatar/name
+            userSessionRegistry                                 // For display name lookup
         );
 
         // Add active users display

--- a/src/main/java/com/example/views/UseCase18View.java
+++ b/src/main/java/com/example/views/UseCase18View.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import com.example.model.Task;
 import com.example.security.CurrentUserSignal;
 import com.example.service.TaskLLMService;
+import com.example.signals.UserSessionRegistry;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -19,13 +20,16 @@ import com.vaadin.signals.ListSignal;
 @PermitAll
 public class UseCase18View extends AbstractTaskChatView {
 
-    public UseCase18View(TaskLLMService taskLLMService, CurrentUserSignal currentUserSignal) {
+    public UseCase18View(TaskLLMService taskLLMService,
+                          CurrentUserSignal currentUserSignal,
+                          UserSessionRegistry userSessionRegistry) {
         super(
             new ListSignal<>(Task.class),                    // View-local task signal
             new ListSignal<>(ChatMessageData.class),         // View-local chat signal
             taskLLMService,
             UUID.randomUUID().toString(),                    // Per-instance conversation ID
-            currentUserSignal                                 // Current user for avatar/name
+            currentUserSignal,                                // Current user for avatar/name
+            userSessionRegistry                               // For display name lookup
         );
 
         // Initialize sample tasks for single-user view


### PR DESCRIPTION
- Add UserSessionRegistry to AbstractTaskChatView constructor
- Add getCurrentDisplayName() method to look up display names from UserSessionRegistry
- Display names support nicknames and session numbers (e.g., 'alice #2')
- Update message rendering to use display names for 'You' messages
- Inject UserSessionRegistry in both UseCase18View and MUC07View
- Add onAttach to capture sessionId for display name lookup

Chat now shows the same display names as used in ActiveUsersDisplay and other multi-user views.
