### PR TITLE
Configure Fly.io to keep single machine always running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,9 @@ primary_region = 'iad'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   max_machines_running = 1
   processes = ['app']
 


### PR DESCRIPTION
- Set min_machines_running = 1 (was 0)
- Set auto_stop_machines = 'off' (was 'stop')

This ensures the application stays running continuously without stopping when idle, improving availability and response times for users.
