### PR TITLE
Fix UC11 simulate screen sizes layout for mobile

### DIFF
--- a/src/main/java/com/example/views/UseCase11View.java
+++ b/src/main/java/com/example/views/UseCase11View.java
@@ -158,8 +158,10 @@ public class UseCase11View extends VerticalLayout {
         Paragraph controlsLabel = new Paragraph("Simulate Screen Sizes:");
         controlsLabel.getStyle().set("font-weight", "bold");
 
-        HorizontalLayout testButtons = new HorizontalLayout();
-        testButtons.setSpacing(true);
+        Div testButtons = new Div();
+        testButtons.getStyle().set("display", "flex")
+                .set("gap", "0.5em")
+                .set("flex-wrap", "wrap");
 
         Button mobileBtn = new Button("📱 Mobile (375×667)",
                 event -> windowSizeSignal.value(new WindowSize(375, 667)));


### PR DESCRIPTION
Replace HorizontalLayout with flex div that wraps buttons on small screens. The test buttons now wrap to multiple lines instead of overflowing on mobile devices.

Changes:
- Use Div with display:flex and flex-wrap:wrap
- Add gap:0.5em for consistent spacing
- Buttons wrap automatically when space is limited
