### PR TITLE
Add updateDueDate tool for LLM to update task dates

### DIFF
--- a/src/main/java/com/example/service/TaskContext.java
+++ b/src/main/java/com/example/service/TaskContext.java
@@ -1,5 +1,6 @@
 package com.example.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.example.model.Task;
@@ -19,4 +20,6 @@ public interface TaskContext {
     void updateTask(String taskId, String title, String description);
 
     void changeStatus(String taskId, Task.TaskStatus status);
+
+    void updateDueDate(String taskId, LocalDate dueDate);
 }

--- a/src/main/java/com/example/service/TaskToolsService.java
+++ b/src/main/java/com/example/service/TaskToolsService.java
@@ -89,6 +89,25 @@ public class TaskToolsService {
         }
     }
 
+    @Tool(description = "Update a task's due date by its ID. Date format: YYYY-MM-DD")
+    public String updateDueDate(String taskId, String dueDate, ToolContext toolContext) {
+        logger.info("🔧 Tool called: updateDueDate(taskId={}, dueDate={})", taskId, dueDate);
+
+        TaskContext context = (TaskContext) toolContext.getContext().get("taskContext");
+        if (context == null) {
+            return "Error: Task context not available";
+        }
+
+        try {
+            LocalDate date = LocalDate.parse(dueDate);
+            context.updateDueDate(taskId, date);
+            logger.info("✅ Task due date updated to {}", date);
+            return "Task due date updated to " + date;
+        } catch (Exception e) {
+            return "Error parsing due date. Please use YYYY-MM-DD format.";
+        }
+    }
+
     @Tool(description = "List all current tasks with their details")
     public String listTasks(ToolContext toolContext) {
         logger.info("🔧 Tool called: listTasks()");

--- a/src/main/java/com/example/views/AbstractTaskChatView.java
+++ b/src/main/java/com/example/views/AbstractTaskChatView.java
@@ -506,6 +506,11 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
             public void changeStatus(String taskId, Task.TaskStatus status) {
                 updateTaskField(taskId, task -> task.withStatus(status));
             }
+
+            @Override
+            public void updateDueDate(String taskId, java.time.LocalDate dueDate) {
+                updateTaskField(taskId, task -> task.withDueDate(dueDate));
+            }
         };
     }
 }


### PR DESCRIPTION
The LLM can now update a task's due date when asked.

Changes:
- Add updateDueDate(taskId, dueDate) method to TaskContext interface
- Add updateDueDate @Tool to TaskToolsService with date parsing
- Implement updateDueDate in AbstractTaskChatView's TaskContext
- Tool accepts date in YYYY-MM-DD format

Fixes: LLM can now handle requests like 'change the due date of task X to 2026-02-15'
