### PR TITLE
UC21: Use bindPlaceholder() instead of Signal.effect for placeholders

### DIFF
--- a/src/main/java/com/example/usecase21/UseCase21View.java
+++ b/src/main/java/com/example/usecase21/UseCase21View.java
@@ -103,16 +103,16 @@ public class UseCase21View extends VerticalLayout {
         nameField.setWidthFull();
         Signal.effect(nameField, () -> nameField
                 .setLabel(translate("uc21.sampleForm.nameLabel").get()));
-        Signal.effect(nameField, () -> nameField.setPlaceholder(
-                translate("uc21.sampleForm.namePlaceholder").get()));
+        nameField.bindPlaceholder(
+                translate("uc21.sampleForm.namePlaceholder"));
 
         // Email field
         EmailField emailField = new EmailField();
         emailField.setWidthFull();
         Signal.effect(emailField, () -> emailField
                 .setLabel(translate("uc21.sampleForm.emailLabel").get()));
-        Signal.effect(emailField, () -> emailField.setPlaceholder(
-                translate("uc21.sampleForm.emailPlaceholder").get()));
+        emailField.bindPlaceholder(
+                translate("uc21.sampleForm.emailPlaceholder"));
 
         // Buttons
         Button submitButton = new Button();


### PR DESCRIPTION
Per best practices, prefer direct binding methods (bindPlaceholder()) over Signal.effect() for simple property bindings. Label still uses effect as there is no bindLabel() API.
