### PR TITLE
UC05: Use Signal.computed() for multi-signal dependency

### DIFF
--- a/src/main/java/com/example/usecase05/UseCase05View.java
+++ b/src/main/java/com/example/usecase05/UseCase05View.java
@@ -44,8 +44,8 @@ public class UseCase05View extends VerticalLayout {
                 null);
 
         var states = countrySignal.map(country -> loadStates(country));
-        var cities = stateSignal
-                .map(state -> loadCities(countrySignal.get(), state));
+        var cities = Signal.computed(
+                () -> loadCities(countrySignal.get(), stateSignal.get()));
 
         // Country selector
         ComboBox<String> countrySelect = new ComboBox<>("Country");


### PR DESCRIPTION
The cities signal depended on both stateSignal and countrySignal but was using stateSignal.map() which is meant for single-signal transforms. Per best practices, use Signal.computed() when the derived value depends on multiple signals.
