### PR TITLE
feat: Use display names for field highlighting in MUC04

### DIFF
--- a/src/main/java/com/example/muc04/MUC04Signals.java
+++ b/src/main/java/com/example/muc04/MUC04Signals.java
@@ -56,4 +56,18 @@ public class MUC04Signals {
             return u != null && u.id() == user.id();
         }).findFirst().ifPresent(getFieldEditors(fieldName)::remove);
     }
+
+    /**
+     * Update the display name for a user across all field editor lists.
+     */
+    public void updateUserName(int userId, String newName) {
+        for (var editors : fieldEditors.values()) {
+            for (var entry : editors.peek()) {
+                var user = entry.peek();
+                if (user != null && user.id() == userId) {
+                    entry.set(new User(user.id(), newName, user.colorIndex()));
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/muc04/MUC04View.java
+++ b/src/main/java/com/example/muc04/MUC04View.java
@@ -55,13 +55,22 @@ public class MUC04View extends VerticalLayout {
         String sessionId = SessionIdHelper.getCurrentSessionId();
         int colorIndex = userSessionRegistry.getUserColorIndex(username,
                 sessionId);
-        this.currentUser = new User((username + ":" + sessionId).hashCode(),
-                username, colorIndex);
+        String compositeKey = username + ":" + sessionId;
+        int userId = compositeKey.hashCode();
+        Signal<String> displayNameSignal = userSessionRegistry
+                .getDisplayNameSignal(compositeKey);
+        this.currentUser = new User(userId,
+                displayNameSignal.peek(), colorIndex);
         this.muc04Signals = muc04Signals;
         this.lockingEnabledSignal = muc04Signals.getLockingEnabledSignal();
 
         setSpacing(true);
         setPadding(true);
+
+        // Update field editor entries when display name changes
+        Signal.effect(this,
+                () -> muc04Signals.updateUserName(userId,
+                        displayNameSignal.get()));
 
         var lockingCheckbox = new Checkbox("Enable field locking");
         lockingCheckbox.bindValue(lockingEnabledSignal,


### PR DESCRIPTION
Use the reactive display name from UserSessionRegistry instead of the raw username, so field highlighter tags show nicknames and session numbers. A Signal.effect watches for display name changes and updates all field editor entries accordingly.
