### PR TITLE
geolocation: Add @PageTitle to every route

### DIFF
--- a/geolocation/src/main/java/com/example/home/HomeView.java
+++ b/geolocation/src/main/java/com/example/home/HomeView.java
@@ -16,10 +16,12 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.UnorderedList;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 
 @Route(value = "", layout = MainLayout.class)
+@PageTitle("Geolocation API Use Cases")
 @Menu(order = 0, title = "Home")
 public class HomeView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc1/OneShotOnClickView.java
+++ b/geolocation/src/main/java/com/example/uc1/OneShotOnClickView.java
@@ -14,6 +14,7 @@ import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -25,6 +26,7 @@ import com.vaadin.flow.router.Route;
  * below is centered on the result and a marker is dropped.
  */
 @Route(value = "uc1", layout = MainLayout.class)
+@PageTitle("UC1 — One-shot request on user click")
 @Menu(order = 1, title = "UC1 — One-shot request")
 public class OneShotOnClickView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc2/TrackingView.java
+++ b/geolocation/src/main/java/com/example/uc2/TrackingView.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.map.configuration.style.Stroke;
 import com.vaadin.flow.component.map.configuration.style.Style;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.signals.Signal;
 
@@ -44,6 +45,7 @@ import com.vaadin.flow.signals.Signal;
  * the history — the grid and the map line keep growing.
  */
 @Route(value = "uc2", layout = MainLayout.class)
+@PageTitle("UC2 — Continuous tracking with reactive signal")
 @Menu(order = 2, title = "UC2 — Tracking")
 public class TrackingView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
+++ b/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -28,6 +29,7 @@ import com.vaadin.flow.router.Route;
  * prompt — they trigger the request by clicking the explicit button.
  */
 @Route(value = "uc3", layout = MainLayout.class)
+@PageTitle("UC3 — Auto-fetch on view load, gated on permission")
 @Menu(order = 3, title = "UC3 — Auto-fetch on attach")
 public class AutoFetchView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc4/DenialView.java
+++ b/geolocation/src/main/java/com/example/uc4/DenialView.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -30,6 +31,7 @@ import com.vaadin.flow.router.Route;
  * the actual API.
  */
 @Route(value = "uc4", layout = MainLayout.class)
+@PageTitle("UC4 — Denial, failure and unavailability")
 @Menu(order = 4, title = "UC4 — Denial & unavailability")
 public class DenialView extends VerticalLayout {
 
@@ -52,7 +54,8 @@ public class DenialView extends VerticalLayout {
 
     private static VerticalLayout card() {
         VerticalLayout card = new VerticalLayout();
-        card.getStyle().set("border", "1px solid var(--vaadin-border-color-secondary)");
+        card.getStyle().set("border",
+                "1px solid var(--vaadin-border-color-secondary)");
         card.getStyle().set("border-radius", "var(--vaadin-radius-l)");
         card.getStyle().set("padding", "var(--vaadin-padding-m)");
         card.getStyle().set("margin-bottom", "var(--vaadin-gap-m)");

--- a/geolocation/src/main/java/com/example/uc5/DetailedDataView.java
+++ b/geolocation/src/main/java/com/example/uc5/DetailedDataView.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -26,6 +27,7 @@ import com.vaadin.flow.router.Route;
  * {@code null} and are shown as "—".
  */
 @Route(value = "uc5", layout = MainLayout.class)
+@PageTitle("UC5 — Reading detailed position data")
 @Menu(order = 5, title = "UC5 — Detailed data")
 public class DetailedDataView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc6/OptionsView.java
+++ b/geolocation/src/main/java/com/example/uc6/OptionsView.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -27,6 +28,7 @@ import com.vaadin.flow.router.Route;
  * accuracy will differ between profiles.
  */
 @Route(value = "uc6", layout = MainLayout.class)
+@PageTitle("UC6 — Tuning precision, freshness and battery")
 @Menu(order = 6, title = "UC6 — Tuning options")
 public class OptionsView extends VerticalLayout {
 

--- a/geolocation/src/main/java/com/example/uc7/FormFieldView.java
+++ b/geolocation/src/main/java/com/example/uc7/FormFieldView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -32,6 +33,7 @@ import com.vaadin.flow.router.Route;
  * the grid below.
  */
 @Route(value = "uc7", layout = MainLayout.class)
+@PageTitle("UC7 — Capturing a location as part of a form")
 @Menu(order = 7, title = "UC7 — Form field")
 public class FormFieldView extends VerticalLayout {
 


### PR DESCRIPTION
Each view now declares its own browser tab title instead of falling back to the layout's @PageTitle, which previously left every UC showing "Geolocation API Use Cases" as the tab title.
