### PR TITLE
geolocation: Use component-anchored Geolocation lookup

### DIFF
--- a/geolocation/src/main/java/com/example/uc1/OneShotOnClickView.java
+++ b/geolocation/src/main/java/com/example/uc1/OneShotOnClickView.java
@@ -2,7 +2,6 @@ package com.example.uc1;
 
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationError;
 import com.vaadin.flow.component.geolocation.GeolocationPosition;
@@ -40,7 +39,7 @@ public class OneShotOnClickView extends VerticalLayout {
         map.setWidthFull();
 
         Button locate = new Button("Use my location", e -> {
-            UI.getCurrent().getGeolocation().get(value -> {
+            getUI().orElseThrow().getGeolocation().get(value -> {
                 switch (value) {
                 case GeolocationPosition pos -> {
                     result.setText("lat=%.5f, lon=%.5f (±%.0f m)".formatted(

--- a/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
+++ b/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.Geolocation;
 import com.vaadin.flow.component.geolocation.GeolocationAvailability;
@@ -62,7 +61,7 @@ public class AutoFetchView extends VerticalLayout {
         GeolocationOptions opts = GeolocationOptions.builder()
                 .timeout(Duration.ofSeconds(5))
                 .maximumAge(Duration.ofMinutes(5)).build();
-        UI.getCurrent().getGeolocation().get(opts, result -> {
+        getUI().orElseThrow().getGeolocation().get(opts, result -> {
             switch (result) {
             case GeolocationPosition pos -> localContent
                     .setText("Local content for lat=%.4f, lon=%.4f".formatted(

--- a/geolocation/src/main/java/com/example/uc4/DenialView.java
+++ b/geolocation/src/main/java/com/example/uc4/DenialView.java
@@ -2,7 +2,6 @@ package com.example.uc4;
 
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationAvailability;
 import com.vaadin.flow.component.geolocation.GeolocationError;
@@ -263,7 +262,7 @@ public class DenialView extends VerticalLayout {
         }
 
         private void runReal() {
-            UI.getCurrent().getGeolocation().get(value -> {
+            getUI().orElseThrow().getGeolocation().get(value -> {
                 switch (value) {
                 case GeolocationPosition pos ->
                     output.setText("Position: lat=%.5f, lon=%.5f (±%.0f m)"

--- a/geolocation/src/main/java/com/example/uc5/DetailedDataView.java
+++ b/geolocation/src/main/java/com/example/uc5/DetailedDataView.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationCoordinates;
 import com.vaadin.flow.component.geolocation.GeolocationError;
@@ -39,7 +38,7 @@ public class DetailedDataView extends VerticalLayout {
             output.removeAll();
             GeolocationOptions opts = GeolocationOptions.builder()
                     .highAccuracy(true).timeout(Duration.ofSeconds(10)).build();
-            UI.getCurrent().getGeolocation().get(opts, value -> {
+            getUI().orElseThrow().getGeolocation().get(opts, value -> {
                 switch (value) {
                 case GeolocationPosition pos -> renderPosition(output, pos);
                 case GeolocationError err ->

--- a/geolocation/src/main/java/com/example/uc6/OptionsView.java
+++ b/geolocation/src/main/java/com/example/uc6/OptionsView.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationError;
 import com.vaadin.flow.component.geolocation.GeolocationOptions;
@@ -58,7 +57,7 @@ public class OptionsView extends VerticalLayout {
         Span result = new Span("(not fetched yet)");
         Button run = new Button("Run", e -> {
             long started = System.currentTimeMillis();
-            UI.getCurrent().getGeolocation().get(options, value -> {
+            getUI().orElseThrow().getGeolocation().get(options, value -> {
                 long elapsed = System.currentTimeMillis() - started;
                 switch (value) {
                 case GeolocationPosition pos ->

--- a/geolocation/src/main/java/com/example/uc7/FormFieldView.java
+++ b/geolocation/src/main/java/com/example/uc7/FormFieldView.java
@@ -7,7 +7,6 @@ import java.util.List;
 import com.example.views.MainLayout;
 import org.jspecify.annotations.Nullable;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationError;
 import com.vaadin.flow.component.geolocation.GeolocationOptions;
@@ -92,7 +91,7 @@ public class FormFieldView extends VerticalLayout {
         GeolocationOptions opts = GeolocationOptions.builder()
                 .highAccuracy(true).timeout(Duration.ofSeconds(10))
                 .maximumAge(Duration.ZERO).build();
-        UI.getCurrent().getGeolocation().get(opts, value -> {
+        getUI().orElseThrow().getGeolocation().get(opts, value -> {
             switch (value) {
             case GeolocationPosition pos -> {
                 if (pos.coords().accuracy() > MAX_ACCURACY_METRES) {


### PR DESCRIPTION
Replace UI.getCurrent().getGeolocation() with getUI().orElseThrow() .getGeolocation() in click handlers across UC1, UC3, UC4, UC5, UC6 and UC7. The new form binds to the UI the view is currently attached to instead of the thread-local current UI, so the call keeps working if the callback ever runs from a non-UI thread.
