### PR TITLE
geolocation: Drop unused @Push annotation

### DIFF
--- a/geolocation/src/main/java/com/example/Application.java
+++ b/geolocation/src/main/java/com/example/Application.java
@@ -6,14 +6,12 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.theme.aura.Aura;
 
 @SpringBootApplication
 @EnableAsync
 @StyleSheet(Aura.STYLESHEET) // Use Lumo.STYLESHEET to use Lumo instead
 @StyleSheet("styles.css") // Your custom styles
-@Push
 public class Application implements AppShellConfigurator {
 
     public static void main(String[] args) {


### PR DESCRIPTION
The Geolocation API delivers all results via DOM events from the client (executeJs callbacks and DomListenerRegistration), so no view needs server-initiated push. Remove the annotation and the WebSocket connection it implies.
