### PR TITLE
geolocation/uc2: Lazy-init tracker and bindText the toggle label

### DIFF
--- a/geolocation/src/main/java/com/example/uc2/TrackingView.java
+++ b/geolocation/src/main/java/com/example/uc2/TrackingView.java
@@ -10,7 +10,6 @@ import java.util.List;
 import com.example.views.MainLayout;
 import org.jspecify.annotations.Nullable;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.geolocation.GeolocationError;
 import com.vaadin.flow.component.geolocation.GeolocationOptions;
@@ -33,16 +32,19 @@ import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
 
 /**
  * UC2 — Continuous tracking with reactive signal.
  * <p>
- * A Start/Stop toggle drives a single {@link GeolocationTracker} via
- * {@link GeolocationTracker#resume()} and {@link GeolocationTracker#stop()}.
- * Two effects subscribe to the tracker's signals: one appends new readings to
- * the grid and extends the path on the map, the other binds the toggle button's
- * label to {@link GeolocationTracker#activeSignal()}. Resuming does not clear
- * the history — the grid and the map line keep growing.
+ * A Start/Stop toggle drives a single {@link GeolocationTracker}. The tracker
+ * is created lazily on the first click so a fresh page load does not start —
+ * and immediately stop — a browser watch. Once created, two effects subscribe
+ * to the tracker's signals: one appends new readings to the grid and extends
+ * the path on the map, the other reports a "stopped after N updates" status.
+ * The toggle's label is bound via {@code bindText} to a computed signal of the
+ * tracker's active state combined with whether any readings have arrived yet.
+ * Resuming does not clear the history — the grid and the map line keep growing.
  */
 @Route(value = "uc2", layout = MainLayout.class)
 @PageTitle("UC2 — Continuous tracking with reactive signal")
@@ -63,7 +65,9 @@ public class TrackingView extends VerticalLayout {
     private @Nullable LineStringFeature pathLine;
     private @Nullable MarkerFeature startMarker;
 
-    private final GeolocationTracker tracker;
+    private @Nullable GeolocationTracker tracker;
+    private final ValueSignal<Boolean> hasUpdates = new ValueSignal<>(
+            Boolean.FALSE);
     private int updateCount;
 
     public TrackingView() {
@@ -73,11 +77,6 @@ public class TrackingView extends VerticalLayout {
                 + "reading is appended to the history and extends the "
                 + "path on the map. Resuming after Stop keeps the "
                 + "accumulated history."));
-
-        GeolocationOptions options = GeolocationOptions.builder()
-                .highAccuracy(true).maximumAge(Duration.ZERO).build();
-        tracker = UI.getCurrent().getGeolocation().track(this, options);
-        tracker.stop();
 
         toggle.addClickListener(e -> toggleTracking());
         add(toggle, status);
@@ -89,24 +88,6 @@ public class TrackingView extends VerticalLayout {
         add(new H2("Position history"));
         configureGrid();
         add(history);
-
-        Signal.effect(this, () -> {
-            switch (tracker.valueSignal().get()) {
-            case GeolocationPending p ->
-                status.setText("Waiting for first reading…");
-            case GeolocationPosition pos -> appendPosition(pos);
-            case GeolocationError err ->
-                status.setText("Error " + err.code() + ": " + err.message());
-            }
-        });
-        Signal.effect(this, () -> {
-            boolean active = tracker.activeSignal().get();
-            toggle.setText(active ? "Stop tracking"
-                    : (updateCount > 0 ? "Resume tracking" : "Start tracking"));
-            if (!active && updateCount > 0) {
-                status.setText("Stopped after " + updateCount + " updates");
-            }
-        });
     }
 
     private void configureGrid() {
@@ -124,6 +105,10 @@ public class TrackingView extends VerticalLayout {
     }
 
     private void toggleTracking() {
+        if (tracker == null) {
+            ensureTracker();
+            return;
+        }
         if (tracker.activeSignal().peek()) {
             tracker.stop();
         } else {
@@ -131,8 +116,41 @@ public class TrackingView extends VerticalLayout {
         }
     }
 
+    private void ensureTracker() {
+        GeolocationOptions options = GeolocationOptions.builder()
+                .highAccuracy(true).maximumAge(Duration.ZERO).build();
+        GeolocationTracker t = getUI().orElseThrow().getGeolocation()
+                .track(this, options);
+        tracker = t;
+
+        Signal.effect(this, () -> {
+            switch (t.valueSignal().get()) {
+            case GeolocationPending p ->
+                status.setText("Waiting for first reading…");
+            case GeolocationPosition pos -> appendPosition(pos);
+            case GeolocationError err ->
+                status.setText("Error " + err.code() + ": " + err.message());
+            }
+        });
+
+        toggle.bindText(Signal.computed(() -> {
+            boolean active = t.activeSignal().get();
+            if (active) {
+                return "Stop tracking";
+            }
+            return hasUpdates.get() ? "Resume tracking" : "Start tracking";
+        }));
+
+        Signal.effect(this, () -> {
+            if (!t.activeSignal().get() && hasUpdates.get()) {
+                status.setText("Stopped after " + updateCount + " updates");
+            }
+        });
+    }
+
     private void appendPosition(GeolocationPosition pos) {
         updateCount++;
+        hasUpdates.set(Boolean.TRUE);
         status.setText("Update #" + updateCount);
         points.add(new TrackPoint(updateCount, pos.timestamp(),
                 pos.coords().latitude(), pos.coords().longitude(),


### PR DESCRIPTION
The previous track(this, options) + tracker.stop() in the constructor fired a watch / clearWatch round-trip on every page load. Defer the tracker creation to the first toggle click instead.

Also replace the manual Signal.effect that set the toggle's text with toggle.bindText(Signal.computed(...)) over the tracker's active signal and a hasUpdates ValueSignal — closer to the documented "prefer binding methods over manual effects" guideline.
