### PR TITLE
geolocation/uc4: Bind RealBrowserCard availability label reactively

### DIFF
--- a/geolocation/src/main/java/com/example/uc4/DenialView.java
+++ b/geolocation/src/main/java/com/example/uc4/DenialView.java
@@ -241,8 +241,12 @@ public class DenialView extends VerticalLayout {
         @Override
         protected void onAttach(com.vaadin.flow.component.AttachEvent e) {
             super.onAttach(e);
-            availabilityLabel.setText("Current availability: "
-                    + e.getUI().getGeolocation().availabilitySignal().peek());
+            // Bind to the availability signal so the label tracks browser
+            // permission flips (granted → denied, prompt → granted) instead
+            // of showing a snapshot taken on attach.
+            availabilityLabel
+                    .bindText(e.getUI().getGeolocation().availabilitySignal()
+                            .map(a -> "Current availability: " + a));
         }
 
         private void runReal() {


### PR DESCRIPTION
Bind the label via availabilityLabel.bindText(availabilitySignal() .map(...)) so it tracks browser permission flips while the view is open. Previously the label was set once on attach via peek() and went stale if the user changed the site permission afterwards.
