### PR TITLE
geolocation/uc3: Bind permission hint reactively to availability

### DIFF
--- a/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
+++ b/geolocation/src/main/java/com/example/uc3/AutoFetchView.java
@@ -51,9 +51,9 @@ public class AutoFetchView extends VerticalLayout {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         Geolocation geo = attachEvent.getUI().getGeolocation();
-        GeolocationAvailability availability = geo.availabilitySignal().peek();
-        permissionHint.setText(hintFor(availability));
-        if (availability == GeolocationAvailability.GRANTED) {
+        permissionHint
+                .bindText(geo.availabilitySignal().map(AutoFetchView::hintFor));
+        if (geo.availabilitySignal().peek() == GeolocationAvailability.GRANTED) {
             fetchAndPopulate();
         }
         // PROMPT / DENIED / UNKNOWN / UNSUPPORTED: do nothing automatic.


### PR DESCRIPTION
The hint was set once with a peeked snapshot on attach, so it went stale when the user changed the site's location permission while the view was open. Bind it to availabilitySignal.map(...) instead — same pattern UC4's RealBrowserCard uses. The GRANTED gate keeps using peek() since auto-fetch should be one-shot, not retriggered on every permission flip.
