### PR TITLE
MainLayout: Add cross-app navigation selector to drawer

### DIFF
--- a/clipboard/src/main/java/com/example/views/AppCatalog.java
+++ b/clipboard/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/clipboard/src/main/java/com/example/views/MainLayout.java
+++ b/clipboard/src/main/java/com/example/views/MainLayout.java
@@ -71,6 +71,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("clipboard"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/fullscreen/src/main/java/com/example/views/AppCatalog.java
+++ b/fullscreen/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/fullscreen/src/main/java/com/example/views/MainLayout.java
+++ b/fullscreen/src/main/java/com/example/views/MainLayout.java
@@ -19,6 +19,8 @@ public class MainLayout extends AppLayout {
 
         addToNavbar(toggle, title);
 
+        addToDrawer(AppCatalog.createSelector("fullscreen"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/geolocation/src/main/java/com/example/views/AppCatalog.java
+++ b/geolocation/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/geolocation/src/main/java/com/example/views/MainLayout.java
+++ b/geolocation/src/main/java/com/example/views/MainLayout.java
@@ -71,6 +71,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("geolocation"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/page-visibility/src/main/java/com/example/views/AppCatalog.java
+++ b/page-visibility/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/page-visibility/src/main/java/com/example/views/MainLayout.java
+++ b/page-visibility/src/main/java/com/example/views/MainLayout.java
@@ -70,6 +70,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("page-visibility"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/screen-orientation/src/main/java/com/example/views/AppCatalog.java
+++ b/screen-orientation/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/screen-orientation/src/main/java/com/example/views/MainLayout.java
+++ b/screen-orientation/src/main/java/com/example/views/MainLayout.java
@@ -70,6 +70,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("screen-orientation"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/signals/src/main/java/com/example/views/AppCatalog.java
+++ b/signals/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/signals/src/main/java/com/example/views/MainLayout.java
+++ b/signals/src/main/java/com/example/views/MainLayout.java
@@ -222,6 +222,8 @@ public class MainLayout extends AppLayout {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("signals"));
+
         // Add auto-menu from @Menu annotations
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav

--- a/text-selection/src/main/java/com/example/views/AppCatalog.java
+++ b/text-selection/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/text-selection/src/main/java/com/example/views/MainLayout.java
+++ b/text-selection/src/main/java/com/example/views/MainLayout.java
@@ -70,6 +70,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("text-selection"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/wake-lock/src/main/java/com/example/views/AppCatalog.java
+++ b/wake-lock/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/wake-lock/src/main/java/com/example/views/MainLayout.java
+++ b/wake-lock/src/main/java/com/example/views/MainLayout.java
@@ -19,6 +19,8 @@ public class MainLayout extends AppLayout {
 
         addToNavbar(toggle, title);
 
+        addToDrawer(AppCatalog.createSelector("wake-lock"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));

--- a/web-share/src/main/java/com/example/views/AppCatalog.java
+++ b/web-share/src/main/java/com/example/views/AppCatalog.java
@@ -1,0 +1,57 @@
+package com.example.views;
+
+import java.util.List;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+
+public final class AppCatalog {
+
+    public record App(String id, String title, String url) {
+    }
+
+    public static final List<App> APPS = List.of(
+            new App("clipboard", "Clipboard API",
+                    "https://clipboard-cases.fly.dev/"),
+            new App("fullscreen", "Fullscreen API",
+                    "https://fullscreen-cases.fly.dev/"),
+            new App("geolocation", "Geolocation API",
+                    "https://geo-cases.fly.dev/"),
+            new App("page-visibility", "Page Visibility API",
+                    "https://page-visibility-cases.fly.dev/"),
+            new App("screen-orientation", "Screen Orientation API",
+                    "https://screen-orientation-cases.fly.dev/"),
+            new App("signals", "Signal API",
+                    "https://signals-cases.fly.dev/"),
+            new App("text-selection", "Text Selection API",
+                    "https://text-selection-cases.fly.dev/"),
+            new App("wake-lock", "Screen Wake Lock API",
+                    "https://wake-lock-cases.fly.dev/"),
+            new App("web-share", "Web Share API",
+                    "https://web-share-cases.fly.dev/"));
+
+    private AppCatalog() {
+    }
+
+    public static Div createSelector(String currentAppId) {
+        Select<App> select = new Select<>();
+        select.setLabel("Application");
+        select.setItems(APPS);
+        select.setItemLabelGenerator(App::title);
+        select.setWidthFull();
+        APPS.stream().filter(a -> a.id().equals(currentAppId)).findFirst()
+                .ifPresent(select::setValue);
+        select.addValueChangeListener(event -> {
+            App selected = event.getValue();
+            if (selected != null && !selected.id().equals(currentAppId)) {
+                UI.getCurrent().getPage().setLocation(selected.url());
+            }
+        });
+
+        Div wrapper = new Div(select);
+        wrapper.getStyle().set("padding",
+                "var(--vaadin-padding-s) var(--vaadin-padding-m) var(--vaadin-padding-m)");
+        return wrapper;
+    }
+}

--- a/web-share/src/main/java/com/example/views/MainLayout.java
+++ b/web-share/src/main/java/com/example/views/MainLayout.java
@@ -70,6 +70,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         sourceCodeContainer.add(sourceCodeLink);
         getElement().appendChild(sourceCodeContainer.getElement());
 
+        addToDrawer(AppCatalog.createSelector("web-share"));
+
         SideNav nav = new SideNav();
         MenuConfiguration.getMenuEntries().forEach(entry -> nav
                 .addItem(new SideNavItem(entry.title(), entry.path())));


### PR DESCRIPTION
Adds an AppCatalog helper listing all nine deployed use-case apps with their fly.dev URLs, and a Select at the top of each module's drawer that navigates between them.
