### PR TITLE
ci: Exclude common module from PR build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           modules=$(find . -mindepth 2 -maxdepth 2 -name pom.xml -printf '%h\n' \
             | sed 's|^\./||' \
+            | grep -v '^common$' \
             | sort \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "modules=$modules" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The common module is built transitively via -am whenever a dependent module is built, so a dedicated matrix job is redundant.
