### PR TITLE
feat: Switch signals use-cases from Lumo to Aura

### DIFF
--- a/clipboard/src/main/java/com/example/Application.java
+++ b/clipboard/src/main/java/com/example/Application.java
@@ -8,7 +8,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.theme.aura.Aura;
 
 @SpringBootApplication
-@StyleSheet(Aura.STYLESHEET) // Use Lumo.STYLESHEET to use Lumo instead
+@StyleSheet(Aura.STYLESHEET)
 @StyleSheet("styles.css") // Your custom styles
 public class Application implements AppShellConfigurator {
 

--- a/common/src/main/java/com/example/common/BaseMainLayout.java
+++ b/common/src/main/java/com/example/common/BaseMainLayout.java
@@ -59,7 +59,7 @@ public abstract class BaseMainLayout extends AppLayout
 
         Icon codeIcon = VaadinIcon.CODE.create();
         codeIcon.setSize("16px");
-        codeIcon.getStyle().set("color", "var(--lumo-secondary-text-color)")
+        codeIcon.getStyle().set("color", "var(--vaadin-text-color-secondary)")
                 .set("margin-right", "0.5em");
 
         link.setTarget("_blank");
@@ -68,9 +68,9 @@ public abstract class BaseMainLayout extends AppLayout
                 .set("background-color", "rgba(255, 255, 255, 0.95)")
                 .set("padding", "0.5em 0.75em").set("border-radius", "4px")
                 .set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)")
-                .set("color", "var(--lumo-primary-text-color)")
+                .set("color", "var(--aura-accent-text-color)")
                 .set("text-decoration", "none")
-                .set("font-size", "var(--lumo-font-size-s)")
+                .set("font-size", "var(--aura-font-size-s)")
                 .set("transition", "box-shadow 0.2s");
 
         link.getElement()

--- a/geolocation/src/main/java/com/example/Application.java
+++ b/geolocation/src/main/java/com/example/Application.java
@@ -10,7 +10,7 @@ import com.vaadin.flow.theme.aura.Aura;
 
 @SpringBootApplication
 @EnableAsync
-@StyleSheet(Aura.STYLESHEET) // Use Lumo.STYLESHEET to use Lumo instead
+@StyleSheet(Aura.STYLESHEET)
 @StyleSheet("styles.css") // Your custom styles
 public class Application implements AppShellConfigurator {
 

--- a/signals/src/main/java/com/example/Application.java
+++ b/signals/src/main/java/com/example/Application.java
@@ -7,12 +7,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
-import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.theme.aura.Aura;
 
 @SpringBootApplication
 @EnableAsync
-@StyleSheet(Lumo.STYLESHEET) // Use Aura.STYLESHEET to use Aura instead
-@StyleSheet(Lumo.UTILITY_STYLESHEET)
+@StyleSheet(Aura.STYLESHEET)
 @StyleSheet("styles.css") // Your custom styles
 @Push
 public class Application implements AppShellConfigurator {

--- a/signals/src/main/java/com/example/muc01/MUC01View.java
+++ b/signals/src/main/java/com/example/muc01/MUC01View.java
@@ -118,8 +118,9 @@ public class MUC01View extends VerticalLayout {
         Div messageCount = new Div();
         messageCount.bindText(muc01Signals.getMessagesSignal()
                 .map(messages -> "Total messages: " + messages.size()));
-        messageCount.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)");
+        messageCount.getStyle()
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)");
 
         add(title, description, activeUsersDisplay, new H3("Messages"),
                 messagesContainer, messageCount, messageInput, sendButton,
@@ -163,13 +164,13 @@ public class MUC01View extends VerticalLayout {
         Div timestamp = new Div();
         timestamp.setText(message.getFormattedTimestamp());
         timestamp.getStyle().set("font-size", "0.85em").set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
 
         header.add(author, timestamp);
 
         Div text = new Div();
         text.setText(message.text());
-        text.getStyle().set("color", "var(--lumo-body-text-color)");
+        text.getStyle().set("color", "var(--vaadin-text-color)");
 
         contentArea.add(header, text);
         messageDiv.add(avatar, contentArea);

--- a/signals/src/main/java/com/example/muc02/MUC02View.java
+++ b/signals/src/main/java/com/example/muc02/MUC02View.java
@@ -206,7 +206,7 @@ public class MUC02View extends VerticalLayout {
         Div positionLabel = new Div(
                 positionSignal.map(MUC02Signals.CursorPosition::toString));
         positionLabel.getStyle().set("font-family", "monospace")
-                .set("color", "var(--lumo-secondary-text-color)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("margin-left", "auto");
 
         userItem.add(colorDot, avatar, userLabel, positionLabel);

--- a/signals/src/main/java/com/example/muc03/MUC03View.java
+++ b/signals/src/main/java/com/example/muc03/MUC03View.java
@@ -83,7 +83,7 @@ public class MUC03View extends VerticalLayout {
 
         Div clicksStatus = new Div();
         clicksStatus.getStyle().set("font-size", "1em").set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
         clicksStatus.bindText(muc03Signals.getClicksRemainingSignal().map(
                 clicks -> clicks > 0 ? "Targets remaining: " + clicks : ""));
 

--- a/signals/src/main/java/com/example/muc06/MUC06View.java
+++ b/signals/src/main/java/com/example/muc06/MUC06View.java
@@ -109,12 +109,12 @@ public class MUC06View extends VerticalLayout {
 
         Span completedLabel = new Span();
         completedLabel.bindText(completedSignal.map(n -> "Completed: " + n));
-        completedLabel.getStyle().set("color", "var(--lumo-success-color)")
+        completedLabel.getStyle().set("color", "var(--aura-green)")
                 .set("font-weight", "500");
 
         Span pendingLabel = new Span();
         pendingLabel.bindText(pendingSignal.map(n -> "Pending: " + n));
-        pendingLabel.getStyle().set("color", "var(--lumo-primary-color)")
+        pendingLabel.getStyle().set("color", "var(--aura-accent-color)")
                 .set("font-weight", "500");
 
         statsBox.add(totalLabel, completedLabel, pendingLabel);
@@ -203,8 +203,8 @@ public class MUC06View extends VerticalLayout {
         row.setDefaultVerticalComponentAlignment(Alignment.CENTER);
         row.setWidthFull();
         row.setPadding(true);
-        row.getStyle().set("background-color", "#ffffff")
-                .set("border", "1px solid var(--lumo-contrast-20pct)")
+        row.getStyle().set("background-color", "#ffffff").set("border",
+                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("border-radius", "4px");
 
         return row;

--- a/signals/src/main/java/com/example/preferences/UserPreferences.java
+++ b/signals/src/main/java/com/example/preferences/UserPreferences.java
@@ -15,9 +15,9 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @SessionScope
 public class UserPreferences {
 
-    public static final String DEFAULT_COLOR = "var(--lumo-base-color)"; // uses
-                                                                         // theme
-                                                                         // default
+    public static final String DEFAULT_COLOR = "var(--aura-background-color)"; // uses
+    // theme
+    // default
 
     private final ValueSignal<String> backgroundColorSignal;
 

--- a/signals/src/main/java/com/example/usecase03/UseCase03View.java
+++ b/signals/src/main/java/com/example/usecase03/UseCase03View.java
@@ -136,8 +136,8 @@ public class UseCase03View extends VerticalLayout {
 
     private Div createSvgCanvas() {
         Div container = new Div();
-        container.getStyle()
-                .set("border", "2px solid var(--lumo-contrast-10pct)")
+        container.getStyle().set("border",
+                "2px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)")
                 .set("padding", "20px").set("background", "white")
                 .set("border-radius", "8px")
                 .set("box-shadow", "0 2px 8px rgba(0,0,0,0.1)");
@@ -288,8 +288,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Position section
         Span positionLabel = new Span("Position");
-        positionLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        positionLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500");
 
         IntegerSlider xSlider = new IntegerSlider("X", 0, 500);
@@ -302,8 +302,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Size section
         Span sizeLabel = new Span("Size");
-        sizeLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        sizeLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         IntegerSlider widthSlider = new IntegerSlider("Width", 50, 250);
@@ -321,8 +321,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Appearance section
         Span appearanceLabel = new Span("Appearance");
-        appearanceLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        appearanceLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         ComboBox<String> fillColorField = createColorPicker("Fill");
@@ -340,8 +340,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Transform section
         Span transformLabel = new Span("Transform");
-        transformLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        transformLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         IntegerSlider rotationSlider = new IntegerSlider("Rotation", 0, 360);
@@ -368,8 +368,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Position section
         Span positionLabel = new Span("Position");
-        positionLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        positionLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500");
 
         IntegerSlider cxSlider = new IntegerSlider("Center X", 0, 500);
@@ -382,8 +382,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Shape section
         Span shapeLabel = new Span("Shape");
-        shapeLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        shapeLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         IntegerSlider pointsSlider = new IntegerSlider("Points", 3, 10);
@@ -396,8 +396,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Appearance section
         Span appearanceLabel = new Span("Appearance");
-        appearanceLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        appearanceLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         ComboBox<String> fillColorField = createColorPicker("Fill");
@@ -415,8 +415,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Transform section
         Span transformLabel = new Span("Transform");
-        transformLabel.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        transformLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500").set("margin-top", "8px");
 
         IntegerSlider rotationSlider = new IntegerSlider("Rotation", 0, 360);
@@ -457,11 +457,12 @@ public class UseCase03View extends VerticalLayout {
             Div swatch = new Div();
             swatch.getStyle().set("width", "20px").set("height", "20px")
                     .set("background-color", color)
-                    .set("border", "1px solid var(--lumo-contrast-20pct)")
+                    .set("border",
+                            "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                     .set("border-radius", "4px");
 
             Span text = new Span(color);
-            text.getStyle().set("font-size", "var(--lumo-font-size-s)");
+            text.getStyle().set("font-size", "var(--aura-font-size-s)");
 
             layout.add(swatch, text);
             return layout;

--- a/signals/src/main/java/com/example/usecase06/UseCase06View.java
+++ b/signals/src/main/java/com/example/usecase06/UseCase06View.java
@@ -116,7 +116,7 @@ public class UseCase06View extends VerticalLayout {
 
         var emptyCart = new Paragraph("Empty cart");
         emptyCart.getStyle().set("margin", "0").set("font-style", "italic")
-                .set("color", "var(--lumo-secondary-text-color)");
+                .set("color", "var(--vaadin-text-color-secondary)");
         emptyCart.bindVisible(cartItemsSignal.map(List::isEmpty));
         cartItemsContainer.add(emptyCart, cartItemsList);
 
@@ -157,7 +157,7 @@ public class UseCase06View extends VerticalLayout {
                 () -> discountSignal.get().compareTo(BigDecimal.ZERO) > 0);
         discountLabel.getStyle().set("display", "block")
                 .set("margin-bottom", "0.5em")
-                .set("color", "var(--lumo-success-color)");
+                .set("color", "var(--aura-green)");
 
         var shippingLabel = new Span(formatter("Shipping: $", shippingSignal));
         shippingLabel.getStyle().set("display", "block").set("margin-bottom",
@@ -168,14 +168,14 @@ public class UseCase06View extends VerticalLayout {
                 "0.5em");
 
         var divider = new Div();
-        divider.getStyle()
-                .set("border-top", "2px solid var(--lumo-contrast-20pct)")
+        divider.getStyle().set("border-top",
+                "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("margin", "0.75em 0");
 
         var totalLabel = new Span(formatter("Total: $", totalSignal));
         totalLabel.getStyle().set("display", "block").set("font-weight", "bold")
                 .set("font-size", "1.5em")
-                .set("color", "var(--lumo-primary-color)");
+                .set("color", "var(--aura-accent-color)");
 
         totalsBox.add(summaryTitle, subtotalLabel, discountLabel, shippingLabel,
                 taxLabel, divider, totalLabel);
@@ -257,7 +257,7 @@ public class UseCase06View extends VerticalLayout {
         itemTotalLabel.setWidth("100px");
         itemTotalLabel.getStyle().set("text-align", "right")
                 .set("font-weight", "bold")
-                .set("color", "var(--lumo-primary-color)");
+                .set("color", "var(--aura-accent-color)");
 
         var removeButton = new Button("Remove", e -> {
             cartItemsSignal.remove(itemSignal);

--- a/signals/src/main/java/com/example/usecase10/UseCase10View.java
+++ b/signals/src/main/java/com/example/usecase10/UseCase10View.java
@@ -164,7 +164,7 @@ public class UseCase10View extends VerticalLayout {
         Paragraph hint = new Paragraph(
                 "Try pressing Ctrl+K, Ctrl+B, or Ctrl+J");
         hint.getStyle().set("font-size", "0.85em")
-                .set("color", "var(--lumo-secondary-text-color)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-style", "italic");
 
         card.add(shortcutLabel, hint);
@@ -182,7 +182,7 @@ public class UseCase10View extends VerticalLayout {
         Paragraph hint = new Paragraph(
                 "Try toggling OS dark mode or browser theme");
         hint.getStyle().set("font-size", "0.85em")
-                .set("color", "var(--lumo-secondary-text-color)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-style", "italic");
 
         card.add(indicator, hint);
@@ -195,7 +195,8 @@ public class UseCase10View extends VerticalLayout {
     private Div buildCompositionSection() {
         Div section = new Div();
         section.getStyle().set("margin-top", "1.5em").set("padding", "1.5em")
-                .set("background-color", "var(--lumo-contrast-5pct)")
+                .set("background-color",
+                        "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
                 .set("border-radius", "8px");
 
         H3 heading = new H3("Composed System Summary");
@@ -230,9 +231,9 @@ public class UseCase10View extends VerticalLayout {
         summaryText.getStyle().set("font-family", "monospace")
                 .set("font-size", "1.1em").set("font-weight", "bold")
                 .set("padding", "0.75em")
-                .set("background-color", "var(--lumo-base-color)")
-                .set("border-radius", "4px")
-                .set("border", "1px solid var(--lumo-contrast-20pct)");
+                .set("background-color", "var(--aura-background-color)")
+                .set("border-radius", "4px").set("border",
+                        "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)");
 
         section.add(heading, intro, summaryText);
         return section;
@@ -292,10 +293,11 @@ public class UseCase10View extends VerticalLayout {
 
     private Div createCard(String title, String subtitle) {
         Div card = new Div();
-        card.getStyle().set("border", "1px solid var(--lumo-contrast-20pct)")
+        card.getStyle().set("border",
+                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("border-radius", "8px").set("padding", "1.5em")
                 .set("flex", "1 1 250px").set("min-width", "250px")
-                .set("background-color", "var(--lumo-base-color)");
+                .set("background-color", "var(--aura-background-color)");
 
         H3 cardTitle = new H3(title);
         cardTitle.getStyle().set("margin-top", "0").set("margin-bottom",
@@ -304,7 +306,7 @@ public class UseCase10View extends VerticalLayout {
         Paragraph cardSubtitle = new Paragraph(subtitle);
         cardSubtitle.getStyle().set("font-family", "monospace")
                 .set("font-size", "0.8em")
-                .set("color", "var(--lumo-secondary-text-color)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("margin-top", "0").set("margin-bottom", "1em");
 
         card.add(cardTitle, cardSubtitle);
@@ -320,9 +322,9 @@ public class UseCase10View extends VerticalLayout {
         Span dot = new Span();
         dot.getStyle().set("width", "12px").set("height", "12px")
                 .set("border-radius", "50%").set("display", "inline-block");
-        dot.getStyle().bind("background-color",
-                () -> activeSignal.get() ? "var(--lumo-contrast-80pct)"
-                        : "var(--lumo-contrast-30pct)");
+        dot.getStyle().bind("background-color", () -> activeSignal.get()
+                ? "color-mix(in srgb, var(--vaadin-text-color) 80%, transparent)"
+                : "color-mix(in srgb, var(--vaadin-text-color) 30%, transparent)");
 
         Span label = new Span(labelSignal);
         label.getStyle().set("font-weight", "bold").set("font-size", "1.1em");

--- a/signals/src/main/java/com/example/usecase13/UseCase13View.java
+++ b/signals/src/main/java/com/example/usecase13/UseCase13View.java
@@ -65,10 +65,10 @@ public class UseCase13View extends VerticalLayout {
                         + "Try opening multiple browser tabs with different users to see live synchronization!");
 
         Div counterBox = new Div();
-        counterBox.getStyle()
-                .set("background", "var(--lumo-primary-color-10pct)")
+        counterBox.getStyle().set("background",
+                "color-mix(in srgb, var(--aura-accent-color) 10%, transparent)")
                 .set("padding", "1em").set("border-radius", "8px")
-                .set("border-left", "4px solid var(--lumo-primary-color)")
+                .set("border-left", "4px solid var(--aura-accent-color)")
                 .set("margin", "1em 0");
 
         H3 counterTitle = new H3(() -> "👥 Currently Online: "
@@ -138,8 +138,9 @@ public class UseCase13View extends VerticalLayout {
 
         // Highlight current user's session
         if (isCurrentSession) {
-            card.getStyle().set("border", "2px solid var(--lumo-primary-color)")
-                    .set("background", "var(--lumo-primary-color-10pct)");
+            card.getStyle().set("border", "2px solid var(--aura-accent-color)")
+                    .set("background",
+                            "color-mix(in srgb, var(--aura-accent-color) 10%, transparent)");
         }
 
         // Dim inactive tabs
@@ -226,7 +227,7 @@ public class UseCase13View extends VerticalLayout {
         Span viewText = new Span(() -> "Viewing: "
                 + (currentView.get() != null ? formatViewName(currentView.get())
                         : "Unknown"));
-        viewText.getStyle().set("font-size", "var(--lumo-font-size-s)");
+        viewText.getStyle().set("font-size", "var(--aura-font-size-s)");
 
         viewRow.add(viewIcon, viewText);
 
@@ -240,8 +241,8 @@ public class UseCase13View extends VerticalLayout {
         Span durationTextSpan = new Span(
                 () -> "Online for " + formatDuration(System.currentTimeMillis()
                         - userSignal.get().sessionStartTime()));
-        durationTextSpan.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)");
+        durationTextSpan.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)");
 
         durationRow.add(durationIcon, durationTextSpan);
 
@@ -261,8 +262,8 @@ public class UseCase13View extends VerticalLayout {
             return interactionText;
         });
         interactionTextSpan.getStyle()
-                .set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)");
+                .set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)");
 
         interactionRow.add(interactionIcon, interactionTextSpan);
 
@@ -294,7 +295,7 @@ public class UseCase13View extends VerticalLayout {
         Span badge = new Span("[" + badgeLabel + "]");
         badge.getStyle().set("padding", "2px 6px").set("border-radius", "4px")
                 .set("background", badgeColor).set("color", "white")
-                .set("font-size", "var(--lumo-font-size-xs)")
+                .set("font-size", "var(--aura-font-size-xs)")
                 .set("font-weight", "bold").set("flex-shrink", "0");
 
         return badge;

--- a/signals/src/main/java/com/example/usecase14/UseCase14View.java
+++ b/signals/src/main/java/com/example/usecase14/UseCase14View.java
@@ -107,8 +107,8 @@ public class UseCase14View extends VerticalLayout {
 
         // State display box
         Div stateBox = new Div();
-        stateBox.getStyle()
-                .set("border", "2px solid var(--lumo-contrast-20pct)")
+        stateBox.getStyle().set("border",
+                "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("border-radius", "8px").set("padding", "1.5em")
                 .set("margin", "1em 0").set("min-height", "300px");
 
@@ -116,7 +116,8 @@ public class UseCase14View extends VerticalLayout {
         Div idleContent = new Div();
         Paragraph idleMessage = new Paragraph(
                 "👆 Click 'Generate Analytics Report' to start the two-step process: fetch data, then generate comprehensive report with sales metrics and performance data");
-        idleMessage.getStyle().set("color", "var(--lumo-secondary-text-color)")
+        idleMessage.getStyle()
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-style", "italic");
         idleContent.add(idleMessage);
         idleContent.bindVisible(() -> stateSignal.get() == LoadingState.IDLE);
@@ -137,7 +138,7 @@ public class UseCase14View extends VerticalLayout {
                 case GENERATING -> "Generating report... (2/2)";
                 default -> "";
                 });
-        loadingMessage.getStyle().set("color", "var(--lumo-primary-color)");
+        loadingMessage.getStyle().set("color", "var(--aura-accent-color)");
 
         loadingContent.add(progressBar, loadingMessage);
         loadingContent.bindVisible(isLoadingSignal);
@@ -149,7 +150,7 @@ public class UseCase14View extends VerticalLayout {
                         ? "Analytics Report - " + report.getPeriod()
                         : "Analytics Report"));
         successTitle.getStyle().set("margin-top", "0").set("color",
-                "var(--lumo-success-color)");
+                "var(--aura-green)");
 
         // Metrics grid
         Div metricsGrid = new Div();
@@ -205,11 +206,11 @@ public class UseCase14View extends VerticalLayout {
         Div errorContent = new Div();
         errorContent.getStyle().set("background-color", "#ffebee")
                 .set("padding", "1em").set("border-radius", "4px")
-                .set("border-left", "4px solid var(--lumo-error-color)");
+                .set("border-left", "4px solid var(--aura-red)");
 
         H3 errorTitle = new H3("❌ Report Generation Failed");
         errorTitle.getStyle().set("margin-top", "0").set("color",
-                "var(--lumo-error-color)");
+                "var(--aura-red)");
 
         Paragraph errorMessage = new Paragraph(
                 "Analytics report generation failed. Please contact the administrator.");
@@ -256,19 +257,19 @@ public class UseCase14View extends VerticalLayout {
         // Use headerPrefix slot for icon
         Icon icon = new Icon(iconType);
         icon.setColor(color);
-        icon.setSize("var(--lumo-icon-size-m)");
+        icon.setSize("24px");
         card.setHeaderPrefix(icon);
 
         // Use title slot for label
         Span labelSpan = new Span(label);
-        labelSpan.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
+        labelSpan.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-weight", "500");
         card.setTitle(labelSpan);
 
         // Main content slot for value display
         Span valueSpan = new Span(valueSignal);
-        valueSpan.getStyle().set("font-size", "var(--lumo-font-size-xxxl)")
+        valueSpan.getStyle().set("font-size", "2.5em")
                 .set("font-weight", "bold").set("color", color)
                 .set("line-height", "1");
         card.add(valueSpan);

--- a/signals/src/main/java/com/example/usecase15/UseCase15View.java
+++ b/signals/src/main/java/com/example/usecase15/UseCase15View.java
@@ -148,7 +148,7 @@ public class UseCase15View extends VerticalLayout {
         Div instantQueryDiv = new Div();
         Span instantLabel = new Span("Instant value: ");
         instantLabel.getStyle().set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
         Span instantValue = new Span(instantQuerySignal
                 .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         instantValue.getStyle().set("font-family", "monospace")
@@ -158,18 +158,18 @@ public class UseCase15View extends VerticalLayout {
         Div debouncedQueryDiv = new Div();
         Span debouncedLabel = new Span("Debounced value (1000ms): ");
         debouncedLabel.getStyle().set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
         Span debouncedValue = new Span(searchQuerySignal
                 .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
         debouncedValue.getStyle().set("font-family", "monospace")
                 .set("font-weight", "bold")
-                .set("color", "var(--lumo-primary-color)");
+                .set("color", "var(--aura-accent-color)");
         debouncedQueryDiv.add(debouncedLabel, debouncedValue);
 
         Div keystrokeCountDiv = new Div();
         Span keystrokeLabel = new Span("Keystrokes: ");
         keystrokeLabel.getStyle().set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
         Span keystrokeValue = new Span(
                 keystrokeCountSignal.map(String::valueOf));
         keystrokeValue.getStyle().set("font-weight", "bold");
@@ -177,10 +177,11 @@ public class UseCase15View extends VerticalLayout {
 
         Div searchCountDiv = new Div();
         Span countLabel = new Span("Searches performed: ");
-        countLabel.getStyle().set("color", "var(--lumo-secondary-text-color)");
+        countLabel.getStyle().set("color",
+                "var(--vaadin-text-color-secondary)");
         Span countValue = new Span(searchCountSignal.map(String::valueOf));
         countValue.getStyle().set("font-weight", "bold").set("color",
-                "var(--lumo-success-color)");
+                "var(--aura-green)");
         searchCountDiv.add(countLabel, countValue);
 
         statsBox.add(instantQueryDiv, debouncedQueryDiv, keystrokeCountDiv,
@@ -197,7 +198,7 @@ public class UseCase15View extends VerticalLayout {
 
         Span statusText = new Span(isSearchingSignal
                 .map(searching -> searching ? "Searching..." : ""));
-        statusText.getStyle().set("color", "var(--lumo-primary-color)");
+        statusText.getStyle().set("color", "var(--aura-accent-color)");
 
         statusBox.add(searchingIcon, statusText);
 
@@ -317,8 +318,8 @@ public class UseCase15View extends VerticalLayout {
 
     private Div createProductCard(Product product) {
         Div card = new Div();
-        card.getStyle().set("background-color", "#ffffff")
-                .set("border", "1px solid var(--lumo-contrast-20pct)")
+        card.getStyle().set("background-color", "#ffffff").set("border",
+                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("border-radius", "4px").set("padding", "1em")
                 .set("display", "flex").set("justify-content", "space-between")
                 .set("align-items", "center");
@@ -334,14 +335,14 @@ public class UseCase15View extends VerticalLayout {
 
         Div categoryDiv = new Div(product.category());
         categoryDiv.getStyle().set("font-size", "0.9em").set("color",
-                "var(--lumo-secondary-text-color)");
+                "var(--vaadin-text-color-secondary)");
 
         leftSide.add(nameDiv, categoryDiv);
 
         Div priceDiv = new Div(
                 "$" + product.price().setScale(2, RoundingMode.HALF_UP));
         priceDiv.getStyle().set("font-weight", "bold").set("color",
-                "var(--lumo-primary-color)");
+                "var(--aura-accent-color)");
 
         card.add(leftSide, priceDiv);
         return card;

--- a/signals/src/main/java/com/example/usecase16/UseCase16View.java
+++ b/signals/src/main/java/com/example/usecase16/UseCase16View.java
@@ -202,8 +202,8 @@ public class UseCase16View extends VerticalLayout
         // Articles are read-only so no need to create bindings
         var article = articleSignal.peek();
         Div card = new Div();
-        card.getStyle().set("background-color", "#ffffff")
-                .set("border", "1px solid var(--lumo-contrast-20pct)")
+        card.getStyle().set("background-color", "#ffffff").set("border",
+                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("border-radius", "4px").set("padding", "1em");
 
         Div headerDiv = new Div();
@@ -223,7 +223,7 @@ public class UseCase16View extends VerticalLayout
         headerDiv.add(titleDiv, categoryBadge);
 
         Div contentDiv = new Div(article.content());
-        contentDiv.getStyle().set("color", "var(--lumo-secondary-text-color)")
+        contentDiv.getStyle().set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-size", "0.9em");
 
         card.add(headerDiv, contentDiv);

--- a/signals/src/main/java/com/example/usecase17/UseCase17View.java
+++ b/signals/src/main/java/com/example/usecase17/UseCase17View.java
@@ -668,7 +668,7 @@ public class UseCase17View extends VerticalLayout {
 
         Span perfRating = new Span(performanceRatingSignal);
         perfRating.getStyle().set("display", "block").set("font-size", "1.2em")
-                .set("color", "var(--lumo-primary-color)");
+                .set("color", "var(--aura-accent-color)");
 
         Span perfGaming = new Span(
                 gamingScoreSignal.map(s -> "Gaming: " + s + "/100"));
@@ -785,7 +785,7 @@ public class UseCase17View extends VerticalLayout {
         Span price = new Span(() -> "$" + compSignal.get().getPrice()
                 .setScale(0, RoundingMode.HALF_UP));
         price.getStyle().set("font-weight", "bold").set("color",
-                "var(--lumo-primary-color)");
+                "var(--aura-accent-color)");
 
         item.add(name, price);
         return item;
@@ -801,8 +801,7 @@ public class UseCase17View extends VerticalLayout {
 
     private String formatCheck(String label, boolean passes) {
         String icon = passes ? "✓" : "✗";
-        String color = passes ? "var(--lumo-success-color)"
-                : "var(--lumo-error-color)";
+        String color = passes ? "var(--aura-green)" : "var(--aura-red)";
         return "<span style='color: " + color + "; font-weight: bold;'>" + icon
                 + "</span> " + label;
     }

--- a/signals/src/main/java/com/example/usecase18/AbstractTaskChatView.java
+++ b/signals/src/main/java/com/example/usecase18/AbstractTaskChatView.java
@@ -205,11 +205,11 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         statsLayout.setSpacing(true);
 
         Div totalCard = createStatCard("Total", totalTasksSignal,
-                "var(--lumo-primary-color)");
+                "var(--aura-accent-color)");
         Div completedCard = createStatCard("Completed", completedTasksSignal,
-                "var(--lumo-success-color)");
+                "var(--aura-green)");
         Div pendingCard = createStatCard("Pending", pendingTasksSignal,
-                "var(--lumo-contrast-60pct)");
+                "color-mix(in srgb, var(--vaadin-text-color) 60%, transparent)");
 
         statsLayout.add(totalCard, completedCard, pendingCard);
         return statsLayout;
@@ -228,7 +228,7 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
                 .set("color", color).set("display", "block");
 
         Span titleLabel = new Span(label);
-        titleLabel.getStyle().set("color", "var(--lumo-secondary-text-color)")
+        titleLabel.getStyle().set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-size", "0.875em");
 
         card.add(valueLabel, titleLabel);

--- a/signals/src/main/java/com/example/usecase19/UseCase19View.java
+++ b/signals/src/main/java/com/example/usecase19/UseCase19View.java
@@ -206,10 +206,11 @@ public class UseCase19View extends VerticalLayout {
         idleContent.getStyle().set("display", "flex")
                 .set("flex-direction", "column").set("align-items", "center")
                 .set("gap", "0.5em").set("padding", "2em")
-                .set("color", "var(--lumo-secondary-text-color)");
+                .set("color", "var(--vaadin-text-color-secondary)");
 
         Icon idleIcon = new Icon(VaadinIcon.CIRCLE);
-        idleIcon.setColor("var(--lumo-contrast-30pct)");
+        idleIcon.setColor(
+                "color-mix(in srgb, var(--vaadin-text-color) 30%, transparent)");
         idleIcon.setSize("2em");
 
         Span idleText = new Span("Ready to load");
@@ -231,7 +232,7 @@ public class UseCase19View extends VerticalLayout {
         progressBar.setWidth("80%");
 
         Span loadingText = new Span("Loading...");
-        loadingText.getStyle().set("color", "var(--lumo-primary-color)");
+        loadingText.getStyle().set("color", "var(--aura-accent-color)");
 
         loadingContent.add(progressBar, loadingText);
         Signal<Boolean> isLoadingSignal = itemSignal
@@ -248,17 +249,17 @@ public class UseCase19View extends VerticalLayout {
                 .set("margin-bottom", "1em");
 
         Icon successIcon = new Icon(VaadinIcon.CHECK_CIRCLE);
-        successIcon.setColor("var(--lumo-success-color)");
+        successIcon.setColor("var(--aura-green)");
 
         Span successLabel = new Span("Loaded successfully");
-        successLabel.getStyle().set("color", "var(--lumo-success-color)")
+        successLabel.getStyle().set("color", "var(--aura-green)")
                 .set("font-weight", "500");
 
         successHeader.add(successIcon, successLabel);
 
         Div dataContent = new Div();
-        dataContent.getStyle()
-                .set("background-color", "var(--lumo-contrast-5pct)")
+        dataContent.getStyle().set("background-color",
+                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
                 .set("padding", "1em").set("border-radius", "4px")
                 .set("white-space", "pre-line").set("font-family", "monospace")
                 .set("font-size", "0.875em");
@@ -283,11 +284,11 @@ public class UseCase19View extends VerticalLayout {
                 .set("margin-bottom", "1em");
 
         Icon errorIcon = new Icon(VaadinIcon.CLOSE_CIRCLE);
-        errorIcon.setColor("var(--lumo-error-color)");
+        errorIcon.setColor("var(--aura-red)");
 
         Span errorLabel = new Span("Failed to load");
-        errorLabel.getStyle().set("color", "var(--lumo-error-color)")
-                .set("font-weight", "500");
+        errorLabel.getStyle().set("color", "var(--aura-red)").set("font-weight",
+                "500");
 
         errorHeader.add(errorIcon, errorLabel);
 
@@ -295,7 +296,7 @@ public class UseCase19View extends VerticalLayout {
         errorMessage.getStyle().set("background-color", "#ffebee")
                 .set("padding", "1em").set("border-radius", "4px")
                 .set("margin-bottom", "1em")
-                .set("color", "var(--lumo-error-text-color)");
+                .set("color", "var(--aura-red-text)");
 
         Span errorText = new Span();
         errorText.bindText(itemSignal.map(
@@ -317,10 +318,11 @@ public class UseCase19View extends VerticalLayout {
         // Card styling based on state - use direct style binding
         card.getStyle().bind("border-left", itemSignal.map(item -> {
             String color = switch (item.state()) {
-            case IDLE -> "var(--lumo-contrast-20pct)";
-            case LOADING, GENERATING -> "var(--lumo-primary-color)";
-            case SUCCESS -> "var(--lumo-success-color)";
-            case ERROR -> "var(--lumo-error-color)";
+            case IDLE ->
+                "color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)";
+            case LOADING, GENERATING -> "var(--aura-accent-color)";
+            case SUCCESS -> "var(--aura-green)";
+            case ERROR -> "var(--aura-red)";
             };
             return "4px solid " + color;
         }));

--- a/signals/src/main/java/com/example/usecase20/UseCase20View.java
+++ b/signals/src/main/java/com/example/usecase20/UseCase20View.java
@@ -65,7 +65,8 @@ public class UseCase20View extends VerticalLayout {
             tile.getStyle().set("background-color", item)
                     .set("padding", "0.5rem 0.75rem")
                     .set("border-radius", "8px")
-                    .set("border", "1px solid var(--lumo-contrast-20pct)")
+                    .set("border",
+                            "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                     .set("min-width", "180px").set("min-height", "40px")
                     .set("display", "flex").set("align-items", "center")
                     .set("justify-content", "center")
@@ -84,12 +85,12 @@ public class UseCase20View extends VerticalLayout {
 
     private static String chooseTextColor(String background) {
         if (background == null) {
-            return "var(--lumo-body-text-color)";
+            return "var(--vaadin-text-color)";
         }
         String bg = background.trim().toLowerCase();
         // If CSS var, use default text color
         if (bg.startsWith("var(")) {
-            return "var(--lumo-body-text-color)";
+            return "var(--vaadin-text-color)";
         }
         // Expect #rrggbb
         if (bg.startsWith("#") && (bg.length() == 7)) {
@@ -108,6 +109,6 @@ public class UseCase20View extends VerticalLayout {
                 // fall through
             }
         }
-        return "var(--lumo-body-text-color)";
+        return "var(--vaadin-text-color)";
     }
 }

--- a/signals/src/main/java/com/example/usecase21/UseCase21View.java
+++ b/signals/src/main/java/com/example/usecase21/UseCase21View.java
@@ -172,8 +172,9 @@ public class UseCase21View extends VerticalLayout {
         Span localeValue = new Span();
         localeValue.bindText(
                 UI.getCurrent().localeSignal().map(Locale::toLanguageTag));
-        localeValue.getStyle().set("font-family", "monospace")
-                .set("background-color", "var(--lumo-contrast-10pct)")
+        localeValue.getStyle().set("font-family", "monospace").set(
+                "background-color",
+                "color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)")
                 .set("padding", "0.25em 0.5em").set("border-radius", "4px");
 
         localeRow.add(localeLabel, localeValue);
@@ -184,7 +185,8 @@ public class UseCase21View extends VerticalLayout {
 
     private Div createCard() {
         Div card = new Div();
-        card.getStyle().set("background-color", "var(--lumo-contrast-5pct)")
+        card.getStyle().set("background-color",
+                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
                 .set("border-radius", "8px").set("padding", "1.5em")
                 .set("margin-bottom", "1em");
         return card;

--- a/signals/src/main/java/com/example/usecase22/UseCase22View.java
+++ b/signals/src/main/java/com/example/usecase22/UseCase22View.java
@@ -110,7 +110,7 @@ public class UseCase22View extends VerticalLayout {
             return "Full name: " + p.firstName() + " " + p.lastName();
         }));
         fullNameLabel.getStyle().set("font-weight", "bold").set("color",
-                "var(--lumo-primary-color)");
+                "var(--aura-accent-color)");
 
         section.add(sectionTitle, firstNameField, lastNameField, emailField,
                 ageField, fullNameLabel);
@@ -164,7 +164,7 @@ public class UseCase22View extends VerticalLayout {
                     + addr.zipCode() + ", " + addr.country();
         }));
         formattedAddressLabel.getStyle().set("font-weight", "bold")
-                .set("color", "var(--lumo-primary-color)")
+                .set("color", "var(--aura-accent-color)")
                 .set("word-break", "break-word");
 
         section.add(sectionTitle, streetField, cityField, zipCodeField,

--- a/signals/src/main/java/com/example/usecase23/UseCase23View.java
+++ b/signals/src/main/java/com/example/usecase23/UseCase23View.java
@@ -42,10 +42,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ListSignal;
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.flow.theme.lumo.LumoUtility.FontSize;
-import com.vaadin.flow.theme.lumo.LumoUtility.FontWeight;
-import com.vaadin.flow.theme.lumo.LumoUtility.Margin;
-import com.vaadin.flow.theme.lumo.LumoUtility.TextColor;
 
 @PageTitle("Use Case 23: Real-time Dashboard")
 @Route(value = "use-case-23", layout = MainLayout.class)
@@ -272,10 +268,12 @@ public class UseCase23View extends Main {
 
     private HorizontalLayout createHeader(String title, String subtitle) {
         H2 h2 = new H2(title);
-        h2.addClassNames(FontSize.XLARGE, Margin.NONE);
+        h2.getStyle().set("font-size", "var(--aura-font-size-xl)").set("margin",
+                "0");
 
         Span span = new Span(subtitle);
-        span.addClassNames(TextColor.SECONDARY, FontSize.XSMALL);
+        span.getStyle().set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-xs)");
 
         VerticalLayout column = new VerticalLayout(h2, span);
         column.setPadding(false);
@@ -403,11 +401,13 @@ public class UseCase23View extends Main {
                     .map(percentage -> percentage > 0);
 
             H2 h2 = new H2(title);
-            h2.addClassNames(FontWeight.NORMAL, Margin.NONE,
-                    TextColor.SECONDARY, FontSize.XSMALL);
+            h2.getStyle().set("font-weight", "400").set("margin", "0")
+                    .set("color", "var(--vaadin-text-color-secondary)")
+                    .set("font-size", "var(--aura-font-size-xs)");
 
             Span valueSpan = new Span();
-            valueSpan.addClassNames(FontWeight.SEMIBOLD, FontSize.XXXLARGE);
+            valueSpan.getStyle().set("font-weight", "600").set("font-size",
+                    "2.5em");
             valueSpan.bindText(signal.map(format::apply));
 
             Span percentageSpan = new Span();

--- a/signals/src/main/java/com/example/usecase24/UseCase24View.java
+++ b/signals/src/main/java/com/example/usecase24/UseCase24View.java
@@ -153,15 +153,16 @@ public class UseCase24View extends VerticalLayout {
         // Header row with count and unread badge
         var countLabel = new Span();
         countLabel.bindText(countLabelSignal);
-        countLabel.getStyle().set("color", "var(--lumo-secondary-text-color)");
+        countLabel.getStyle().set("color",
+                "var(--vaadin-text-color-secondary)");
 
         var unreadBadge = new Span();
         unreadBadge.bindText(unreadCountSignal.map(c -> c + " unread"));
         unreadBadge.getStyle()
-                .set("background-color", "var(--lumo-primary-color)")
+                .set("background-color", "var(--aura-accent-color)")
                 .set("color", "white").set("padding", "0.25em 0.75em")
                 .set("border-radius", "1em")
-                .set("font-size", "var(--lumo-font-size-s)")
+                .set("font-size", "var(--aura-font-size-s)")
                 .set("font-weight", "bold");
         unreadBadge.bindVisible(unreadCountSignal.map(c -> c > 0));
 
@@ -184,7 +185,7 @@ public class UseCase24View extends VerticalLayout {
         var emptyState = new Paragraph(
                 "No notifications to display. Try adjusting your filters or adding new notifications.");
         emptyState.getStyle().set("text-align", "center").set("padding", "2em")
-                .set("color", "var(--lumo-secondary-text-color)")
+                .set("color", "var(--vaadin-text-color-secondary)")
                 .set("font-style", "italic");
         emptyState.bindVisible(filteredSignal.map(List::isEmpty));
 
@@ -239,7 +240,7 @@ public class UseCase24View extends VerticalLayout {
                 .set("background-color", getTypeColor(notification.type()))
                 .set("color", "white").set("padding", "0.1em 0.5em")
                 .set("border-radius", "0.75em")
-                .set("font-size", "var(--lumo-font-size-xs)")
+                .set("font-size", "var(--aura-font-size-xs)")
                 .set("margin-left", "0.5em");
 
         var titleRow = new Div(titleSpan, typeBadge);
@@ -248,15 +249,17 @@ public class UseCase24View extends VerticalLayout {
 
         // Message
         var messageSpan = new Span(notification.message());
-        messageSpan.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)")
+        messageSpan.getStyle()
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)")
                 .set("display", "block").set("margin-bottom", "0.5em");
 
         // Timestamp
         var timestampSpan = new Span(
                 notification.timestamp().format(TIME_FORMAT));
-        timestampSpan.getStyle().set("color", "var(--lumo-tertiary-text-color)")
-                .set("font-size", "var(--lumo-font-size-xs)")
+        timestampSpan.getStyle()
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-xs)")
                 .set("display", "block");
 
         content.add(titleRow, messageSpan, timestampSpan);

--- a/signals/src/main/java/com/example/usecase25/UseCase25View.java
+++ b/signals/src/main/java/com/example/usecase25/UseCase25View.java
@@ -36,7 +36,7 @@ public class UseCase25View extends Main {
     public UseCase25View(SchedulerService schedulerService) {
         addClassName("stock-ticker-view");
         getStyle().set("display", "block").set("padding",
-                "var(--lumo-space-l)");
+                "var(--vaadin-gap-l)");
 
         var title = new H2("Use Case 25: Stock Ticker");
         var description = new Paragraph(
@@ -77,12 +77,13 @@ public class UseCase25View extends Main {
         Div row = new Div();
         row.getStyle().set("display", "grid")
                 .set("grid-template-columns", "80px 1fr 120px 100px 100px")
-                .set("gap", "var(--lumo-space-s)")
-                .set("padding", "var(--lumo-space-s) var(--lumo-space-m)")
-                .set("border-bottom", "2px solid var(--lumo-contrast-20pct)")
+                .set("gap", "var(--vaadin-gap-s)")
+                .set("padding", "var(--vaadin-gap-s) var(--vaadin-gap-m)")
+                .set("border-bottom",
+                        "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
                 .set("font-weight", "bold")
-                .set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)");
+                .set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)");
 
         row.add(headerCell("Symbol"), headerCell("Company"),
                 headerCell("Price", true), headerCell("Change", true),
@@ -106,10 +107,10 @@ public class UseCase25View extends Main {
         Div row = new Div();
         row.getStyle().set("display", "grid")
                 .set("grid-template-columns", "80px 1fr 120px 100px 100px")
-                .set("gap", "var(--lumo-space-s)")
-                .set("padding", "var(--lumo-space-s) var(--lumo-space-m)")
-                .set("align-items", "center")
-                .set("border-bottom", "1px solid var(--lumo-contrast-10pct)");
+                .set("gap", "var(--vaadin-gap-s)")
+                .set("padding", "var(--vaadin-gap-s) var(--vaadin-gap-m)")
+                .set("align-items", "center").set("border-bottom",
+                        "1px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)");
 
         // Symbol
         Span symbol = new Span();
@@ -120,8 +121,8 @@ public class UseCase25View extends Main {
         // Company name
         Span name = new Span();
         name.bindText(stockSignal.map(StockQuote::name));
-        name.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)");
+        name.getStyle().set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)");
 
         // Price
         Span price = new Span();

--- a/signals/src/main/java/com/example/usecase27/UseCase27Layout.java
+++ b/signals/src/main/java/com/example/usecase27/UseCase27Layout.java
@@ -37,14 +37,16 @@ public class UseCase27Layout extends Div implements RouterLayout {
 
     public UseCase27Layout() {
         breadcrumb.setId(BREADCRUMB_ID);
-        breadcrumb.getStyle().set("padding", "0.5em 0.75em")
-                .set("background-color", "var(--lumo-contrast-5pct)")
+        breadcrumb.getStyle().set("padding", "0.5em 0.75em").set(
+                "background-color",
+                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
                 .set("border-radius", "4px")
-                .set("font-family", "var(--lumo-font-family)");
+                .set("font-family", "var(--aura-font-family)");
 
         updateBadge.setId(UPDATE_COUNT_ID);
-        updateBadge.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)")
+        updateBadge.getStyle()
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)")
                 .set("margin-left", "0.75em");
 
         Div header = new Div(breadcrumb, updateBadge);
@@ -72,8 +74,8 @@ public class UseCase27Layout extends Div implements RouterLayout {
 
         if (target == UseCase27DetailsView.class) {
             String id = state.routeParameters().get("id").orElse("?");
-            return new Component[] { overview, separator(),
-                    new Span("Details"), separator(), new Span("#" + id) };
+            return new Component[] { overview, separator(), new Span("Details"),
+                    separator(), new Span("#" + id) };
         }
         if (target == UseCase27SettingsView.class) {
             return new Component[] { overview, separator(),
@@ -86,7 +88,7 @@ public class UseCase27Layout extends Div implements RouterLayout {
 
     private static Span separator() {
         Span s = new Span(" › ");
-        s.getStyle().set("color", "var(--lumo-tertiary-text-color)")
+        s.getStyle().set("color", "var(--vaadin-text-color-secondary)")
                 .set("margin", "0 0.4em");
         return s;
     }

--- a/signals/src/main/java/com/example/views/ActiveUsersDisplay.java
+++ b/signals/src/main/java/com/example/views/ActiveUsersDisplay.java
@@ -81,8 +81,7 @@ public class ActiveUsersDisplay extends Div {
                 .set("gap", "0.5em");
 
         if (showAccentBorder) {
-            getStyle().set("border-left",
-                    "4px solid var(--lumo-warning-color)");
+            getStyle().set("border-left", "4px solid var(--aura-orange)");
         }
 
         // Users container with avatars
@@ -134,7 +133,7 @@ public class ActiveUsersDisplay extends Div {
 
         Span nameLabel = new Span();
         nameLabel.bindText(displayNameSignal);
-        nameLabel.getStyle().set("font-size", "var(--lumo-font-size-s)");
+        nameLabel.getStyle().set("font-size", "var(--aura-font-size-s)");
 
         userItem.add(avatar, nameLabel);
         return userItem;

--- a/signals/src/main/java/com/example/views/HomeView.java
+++ b/signals/src/main/java/com/example/views/HomeView.java
@@ -112,12 +112,11 @@ public class HomeView extends VerticalLayout {
     private Span createStat(String number, String description) {
         Span stat = new Span();
         Span num = new Span(number);
-        num.getStyle().set("font-size", "var(--lumo-font-size-xxl)")
-                .set("font-weight", "bold")
-                .set("color", "var(--lumo-primary-color)")
-                .set("margin-right", "var(--lumo-space-s)");
+        num.getStyle().set("font-size", "2em").set("font-weight", "bold")
+                .set("color", "var(--aura-accent-color)")
+                .set("margin-right", "var(--vaadin-gap-s)");
         Span desc = new Span(description);
-        desc.getStyle().set("color", "var(--lumo-secondary-text-color)");
+        desc.getStyle().set("color", "var(--vaadin-text-color-secondary)");
         stat.add(num, desc);
         stat.getStyle().set("display", "flex").set("align-items", "center");
         return stat;
@@ -128,20 +127,20 @@ public class HomeView extends VerticalLayout {
         VerticalLayout category = new VerticalLayout();
         category.setSpacing(false);
         category.setPadding(false);
-        category.getStyle().set("margin-bottom", "var(--lumo-space-m)");
+        category.getStyle().set("margin-bottom", "var(--vaadin-gap-m)");
 
         Span titleSpan = new Span(title);
         titleSpan.getStyle().set("font-weight", "600");
 
         Span rangeSpan = new Span(range);
-        rangeSpan.getStyle().set("font-size", "var(--lumo-font-size-s)")
-                .set("color", "var(--lumo-secondary-text-color)")
-                .set("margin-left", "var(--lumo-space-s)");
+        rangeSpan.getStyle().set("font-size", "var(--aura-font-size-s)")
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("margin-left", "var(--vaadin-gap-s)");
 
         Paragraph descPara = new Paragraph(description);
-        descPara.getStyle().set("margin-top", "var(--lumo-space-xs)")
+        descPara.getStyle().set("margin-top", "var(--vaadin-gap-xs)")
                 .set("margin-bottom", "0")
-                .set("color", "var(--lumo-secondary-text-color)");
+                .set("color", "var(--vaadin-text-color-secondary)");
 
         category.add(new Span(titleSpan, rangeSpan), descPara);
 

--- a/signals/src/main/java/com/example/views/MainLayout.java
+++ b/signals/src/main/java/com/example/views/MainLayout.java
@@ -67,7 +67,7 @@ public class MainLayout extends AppLayout {
         DrawerToggle toggle = new DrawerToggle();
 
         H1 title = new H1("Signal API Use Cases");
-        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+        title.getStyle().set("font-size", "var(--aura-font-size-l)")
                 .set("margin", "0");
 
         // Active users display with avatars
@@ -83,8 +83,8 @@ public class MainLayout extends AppLayout {
                         .map(displayNames -> displayNames.isEmpty() ? ""
                                 : "👥 " + displayNames.size() + " online:"));
         activeUsersLabel.getStyle()
-                .set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)");
+                .set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)");
 
         com.vaadin.flow.component.html.Div avatarsContainer = new com.vaadin.flow.component.html.Div();
         avatarsContainer.getStyle().set("display", "flex").set("gap", "0.25em");
@@ -162,8 +162,8 @@ public class MainLayout extends AppLayout {
 
         Span userName = new Span(currentUserSignal.getUserSignal()
                 .map(user -> user.isAuthenticated() ? user.getUsername() : ""));
-        userName.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("font-size", "var(--lumo-font-size-s)");
+        userName.getStyle().set("color", "var(--vaadin-text-color-secondary)")
+                .set("font-size", "var(--aura-font-size-s)");
 
         userDisplay.add(userAvatar, userName);
 
@@ -190,7 +190,7 @@ public class MainLayout extends AppLayout {
 
         Icon codeIcon = VaadinIcon.CODE.create();
         codeIcon.setSize("16px");
-        codeIcon.getStyle().set("color", "var(--lumo-secondary-text-color)")
+        codeIcon.getStyle().set("color", "var(--vaadin-text-color-secondary)")
                 .set("margin-right", "0.5em");
 
         sourceCodeLink = new Anchor("", "View source");
@@ -200,9 +200,9 @@ public class MainLayout extends AppLayout {
                 .set("background-color", "rgba(255, 255, 255, 0.95)")
                 .set("padding", "0.5em 0.75em").set("border-radius", "4px")
                 .set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)")
-                .set("color", "var(--lumo-primary-text-color)")
+                .set("color", "var(--aura-accent-text-color)")
                 .set("text-decoration", "none")
-                .set("font-size", "var(--lumo-font-size-s)")
+                .set("font-size", "var(--aura-font-size-s)")
                 .set("transition", "box-shadow 0.2s");
 
         sourceCodeLink.getElement().addEventListener("mouseenter", e -> {

--- a/signals/src/main/resources/META-INF/resources/styles.css
+++ b/signals/src/main/resources/META-INF/resources/styles.css
@@ -34,11 +34,11 @@ html {
 }
 
 .price-up {
-    color: var(--lumo-success-color);
+    color: var(--aura-green);
     animation: flash-green 0.6s ease-out;
 }
 .price-down {
-    color: var(--lumo-error-color);
+    color: var(--aura-red);
     animation: flash-red 0.6s ease-out;
 }
 @keyframes flash-green {

--- a/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
+++ b/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
@@ -70,9 +70,8 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         Card card = $view(Card.class).all().getFirst();
 
         // IDLE state should have contrast border
-        assertTrue(
-                card.getStyle().get("border-left")
-                        .contains("var(--lumo-contrast-20pct)"),
+        assertTrue(card.getStyle().get("border-left").contains(
+                "color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)"),
                 "IDLE card should have contrast border but was: "
                         + card.getStyle().get("border-left"));
     }
@@ -93,7 +92,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         Card card = $view(Card.class).all().getFirst();
         assertTrue(
                 card.getStyle().get("border-left")
-                        .contains("var(--lumo-primary-color)"),
+                        .contains("var(--aura-accent-color)"),
                 "LOADING card should have primary border but was: "
                         + card.getStyle().get("border-left"));
     }

--- a/signals/src/test/java/com/example/usecase20/UseCase20ViewTest.java
+++ b/signals/src/test/java/com/example/usecase20/UseCase20ViewTest.java
@@ -30,7 +30,7 @@ class UseCase20ViewTest extends SpringBrowserlessTest {
 
         RadioButtonGroup<String> colorPicker = $view(RadioButtonGroup.class)
                 .single();
-        assertEquals("var(--lumo-base-color)", colorPicker.getValue());
+        assertEquals("var(--aura-background-color)", colorPicker.getValue());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Signals was the last module still declaring `@StyleSheet(Lumo.STYLESHEET)` and `@StyleSheet(Lumo.UTILITY_STYLESHEET)`; it now declares only `@StyleSheet(Aura.STYLESHEET)` like the rest of the apps. To make that real and not just a label, every Lumo CSS-variable reference and Lumo utility-class usage in the codebase has been ported:

- All `var(--lumo-*)` references in signals/* and `BaseMainLayout` rewritten to their Aura equivalents:
  - colors → `--aura-accent-color`, `--aura-red`/`-text`, `--aura-green`, `--aura-orange`, `--aura-background-color`, `--vaadin-text-color`, `--vaadin-text-color-secondary`;
  - typography → `--aura-font-family`, `--aura-font-size-{xs,s,l}`; `--lumo-font-size-xxl`/`xxxl` mapped to `2em`/`2.5em` since Aura's scale tops out at `xl`;
  - spacing → `--vaadin-gap-{xs,s,m,l}`;
  - contrast levels → `color-mix(in srgb, var(--vaadin-text-color) N%, transparent)` (Lumo's transparent-black overlays; Aura computes these dynamically per contrast-level so there's no 1:1 token).
- `LumoUtility.FontSize`/`FontWeight`/`Margin`/`TextColor` constants in UseCase23View replaced with inline `getStyle()` calls, since dropping the Lumo utility stylesheet would silently break those class names.
- Test assertions in UseCase19ViewTest and UseCase20ViewTest updated to match the new strings.
- Two stale "Use Lumo.STYLESHEET to use Lumo instead" comments in clipboard's and geolocation's Application.java removed.

Visual drift is expected and intentional: Aura's palette and density system are not pixel-identical to Lumo's, and some translations (the contrast overlays and the very-large font sizes) approximate rather than match the Lumo values.
