### PR TITLE
fix: Set unitless line-height on UC2 slideshow so text doesn't overlap

### DIFF
--- a/fullscreen/src/main/resources/META-INF/resources/styles.css
+++ b/fullscreen/src/main/resources/META-INF/resources/styles.css
@@ -105,6 +105,10 @@
     align-items: center;
     justify-content: center;
     font-size: 2.25rem;
+    /* Unitless so the line-height scales with font-size; the body's
+       length-valued line-height would otherwise stay ~20px and the
+       wrapped slide text would overlap at 2.25rem / 4rem. */
+    line-height: 1.2;
     text-align: center;
     padding: 2rem;
     box-sizing: border-box;


### PR DESCRIPTION
Aura's body line-height is a fixed length (~20px from the 14px base), which inherits literally. At the slideshow's 2.25rem / 4rem font sizes the inherited length kept the lines ~20px apart and wrapped text overlapped.
