### PR TITLE
fullscreen/UC7: add "View app fullscreen" use case

### DIFF
--- a/fullscreen/src/main/java/com/example/home/HomeView.java
+++ b/fullscreen/src/main/java/com/example/home/HomeView.java
@@ -7,6 +7,7 @@ import com.example.uc3.DistractionFreeEditorView;
 import com.example.uc4.ReactiveLayoutView;
 import com.example.uc5.KioskExitDetectionView;
 import com.example.uc6.ChartExpandView;
+import com.example.uc7.AppFullscreenView;
 import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.html.Div;
@@ -52,6 +53,10 @@ public class HomeView extends BaseHomeView {
         cards.add(homeCard("UC6", "Chart expand",
                 "Per-card expand buttons fullscreen a single Vaadin Chart.",
                 ChartExpandView.class));
+        cards.add(homeCard("UC7", "View app fullscreen",
+                "Page#requestFullscreen() hides browser chrome and shows "
+                        + "the whole app — kiosk-style.",
+                AppFullscreenView.class));
         add(cards);
     }
 }

--- a/fullscreen/src/main/java/com/example/uc7/AppFullscreenView.java
+++ b/fullscreen/src/main/java/com/example/uc7/AppFullscreenView.java
@@ -1,0 +1,81 @@
+package com.example.uc7;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.page.FullscreenState;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.Signal;
+
+/**
+ * UC7 — View the whole app fullscreen via {@link
+ * com.vaadin.flow.component.page.Page#requestFullscreen() Page#requestFullscreen()}.
+ * <p>
+ * With a MainLayout in place, page-level fullscreen really just means "hide
+ * the browser's chrome." Nothing interesting reflows: the navigation drawer
+ * toggle, the app title, the side nav and this view all stay exactly where
+ * they were. The use case is kiosk-style installations and demoing the app
+ * itself with no browser UI in the way — there's nothing more elaborate to
+ * stage.
+ */
+@Route(value = "uc7", layout = MainLayout.class)
+@Menu(order = 7, title = "UC7 — View app fullscreen")
+public class AppFullscreenView extends VerticalLayout {
+
+    private final Span stateBadge = new Span();
+
+    public AppFullscreenView() {
+        add(new H1("UC7 — View this app fullscreen"));
+        add(new Paragraph(
+                "Page#requestFullscreen() asks the browser to fullscreen the "
+                        + "whole document. With this app's MainLayout in "
+                        + "place, that just means: browser chrome (URL bar, "
+                        + "tabs, bookmarks) goes away, but everything inside "
+                        + "the document — the drawer toggle, the app title, "
+                        + "the side nav, this view — stays exactly where it "
+                        + "is. No reflow, no special staging; the use case "
+                        + "is kiosk installations and demoing the app itself "
+                        + "without browser UI in the way."));
+
+        stateBadge.addClassName("status-badge");
+
+        Button enter = new Button("Enter fullscreen",
+                e -> getUI().ifPresent(ui -> ui.getPage().requestFullscreen()));
+        enter.addThemeVariants(ButtonVariant.PRIMARY);
+        Button exit = new Button("Exit fullscreen",
+                e -> getUI().ifPresent(ui -> ui.getPage().exitFullscreen()));
+
+        add(new HorizontalLayout(enter, exit, stateBadge));
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        Signal<FullscreenState> fs = attachEvent.getUI().getPage()
+                .fullscreenSignal();
+        stateBadge.bindText(fs.map(AppFullscreenView::badgeText));
+        stateBadge.bindClassName("fullscreen",
+                fs.map(s -> s == FullscreenState.FULLSCREEN));
+        stateBadge.bindClassName("unsupported",
+                fs.map(s -> s == FullscreenState.UNSUPPORTED));
+    }
+
+    private static String badgeText(FullscreenState state) {
+        // The whole document is fullscreen, so the badge stays on screen —
+        // a FULLSCREEN-specific message is actually visible here.
+        return switch (state) {
+        case FULLSCREEN -> "App is fullscreen — Escape to exit";
+        case NOT_FULLSCREEN -> "Click Enter fullscreen to hide browser chrome";
+        case UNSUPPORTED -> "Fullscreen not supported in this browser";
+        case UNKNOWN -> "Detecting fullscreen support…";
+        };
+    }
+}

--- a/fullscreen/src/test/java/com/example/uc7/AppFullscreenViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc7/AppFullscreenViewTest.java
@@ -1,0 +1,57 @@
+package com.example.uc7;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.FullscreenTestSupport;
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.page.FullscreenState;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = AppFullscreenView.class)
+class AppFullscreenViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithEnterExitAndBadge() {
+        navigate(AppFullscreenView.class);
+
+        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+                .equals("UC7 — View this app fullscreen")));
+        assertTrue($view(Button.class).all().stream()
+                .anyMatch(b -> "Enter fullscreen".equals(b.getText())));
+        assertTrue($view(Button.class).all().stream()
+                .anyMatch(b -> "Exit fullscreen".equals(b.getText())));
+    }
+
+    @Test
+    void badgeReflectsFullscreenSignal() {
+        navigate(AppFullscreenView.class);
+        runPendingSignalsTasks();
+
+        FullscreenTestSupport.setFullscreenState(FullscreenState.NOT_FULLSCREEN);
+        runPendingSignalsTasks();
+        assertBadgeContains("Enter fullscreen");
+
+        FullscreenTestSupport.setFullscreenState(FullscreenState.FULLSCREEN);
+        runPendingSignalsTasks();
+        assertBadgeContains("App is fullscreen");
+
+        FullscreenTestSupport.setFullscreenState(FullscreenState.UNSUPPORTED);
+        runPendingSignalsTasks();
+        assertBadgeContains("not supported");
+    }
+
+    private void assertBadgeContains(String fragment) {
+        assertTrue($view(Span.class).all().stream()
+                .anyMatch(s -> s.getClassNames().contains("status-badge")
+                        && s.getText() != null
+                        && s.getText().contains(fragment)),
+                "expected status badge to contain \"" + fragment + "\"");
+    }
+}


### PR DESCRIPTION
Page#requestFullscreen() in an app with a MainLayout really just means "hide browser chrome." Nothing reflows: the drawer toggle, app title, side nav and the routed view all stay in place. The use case is kiosk-style installations and demoing the app itself without browser UI in the way — there's nothing more elaborate to stage, so the demo is just an Enter / Exit pair plus a status badge.

Unlike UC1/UC2/UC3/UC5/UC6 where the badge sits outside the fullscreened element, here the whole document is fullscreen — so the badge stays visible and its FULLSCREEN-specific text is meaningful.
