### PR TITLE
clipboard: Move inline styles into per-use-case CSS files

### DIFF
--- a/clipboard/src/main/java/com/example/uc4/PasteSpreadsheetView.java
+++ b/clipboard/src/main/java/com/example/uc4/PasteSpreadsheetView.java
@@ -9,6 +9,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import com.vaadin.flow.component.clipboard.Clipboard;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
@@ -32,9 +33,11 @@ import com.vaadin.flow.router.Route;
 @Route(value = "uc4", layout = MainLayout.class)
 @PageTitle("UC4 — Paste a table from a spreadsheet")
 @Menu(order = 4, title = "UC4 — Paste a table")
+@StyleSheet("uc4.css")
 public class PasteSpreadsheetView extends VerticalLayout {
 
     public PasteSpreadsheetView() {
+        addClassName("uc4-view");
         add(new H1("UC4 — Paste a table from a spreadsheet"));
         add(new Paragraph(
                 "Select cells in the spreadsheet below and copy with Ctrl/Cmd-C, "
@@ -46,14 +49,10 @@ public class PasteSpreadsheetView extends VerticalLayout {
         add(spreadsheet);
 
         Div dropZone = new Div();
+        dropZone.addClassName("drop-zone");
         dropZone.setText("Paste here (Ctrl+V / Cmd+V)");
         dropZone.setWidthFull();
         dropZone.getElement().setAttribute("tabindex", "0");
-        dropZone.getStyle().set("border", "2px dashed #b0b8c0")
-                .set("padding", "24px").set("text-align", "center")
-                .set("border-radius", "8px").set("min-height", "80px")
-                .set("display", "flex").set("align-items", "center")
-                .set("justify-content", "center");
 
         Grid<List<String>> grid = new Grid<>();
         grid.setVisible(false);

--- a/clipboard/src/main/java/com/example/uc5/PasteFilesView.java
+++ b/clipboard/src/main/java/com/example/uc5/PasteFilesView.java
@@ -6,6 +6,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.clipboard.Clipboard;
 import com.vaadin.flow.component.clipboard.ClipboardFile;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Image;
@@ -34,9 +35,11 @@ import com.vaadin.flow.router.Route;
 @Route(value = "uc5", layout = MainLayout.class)
 @PageTitle("UC5 — Paste files")
 @Menu(order = 5, title = "UC5 — Paste files")
+@StyleSheet("uc5.css")
 public class PasteFilesView extends VerticalLayout {
 
     public PasteFilesView() {
+        addClassName("uc5-view");
         add(new H1("UC5 — Paste images and files"));
         add(new Paragraph(
                 "Click into the drop zone, then paste a screenshot or any "
@@ -44,24 +47,13 @@ public class PasteFilesView extends VerticalLayout {
                         + "bytes via the upload mechanism."));
 
         Div dropZone = new Div();
+        dropZone.addClassName("drop-zone");
         dropZone.setText("Paste a file here (Ctrl+V / Cmd+V)");
         dropZone.setWidthFull();
         dropZone.getElement().setAttribute("tabindex", "0");
-        dropZone.getStyle()
-                .set("border", "2px dashed var(--aura-contrast-30pct)")
-                .set("padding", "var(--aura-space-xl)")
-                .set("text-align", "center")
-                .set("border-radius", "var(--aura-border-radius-l)")
-                .set("min-height", "150px").set("display", "flex")
-                .set("align-items", "center").set("justify-content", "center");
 
         Span log = new Span("File log will appear here…");
-        log.getStyle().set("font-family", "monospace")
-                .set("white-space", "pre-wrap")
-                .set("padding", "var(--aura-space-s)")
-                .set("background", "var(--aura-contrast-5pct)")
-                .set("display", "block")
-                .set("border-radius", "var(--aura-border-radius-m)");
+        log.addClassName("file-log");
 
         ProgressBar uploadProgress = new ProgressBar();
         uploadProgress.setIndeterminate(true);

--- a/clipboard/src/main/java/com/example/uc6/CopyFromContextMenuView.java
+++ b/clipboard/src/main/java/com/example/uc6/CopyFromContextMenuView.java
@@ -5,6 +5,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.clipboard.Clipboard;
 import com.vaadin.flow.component.contextmenu.ContextMenu;
 import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Pre;
@@ -26,9 +27,11 @@ import com.vaadin.flow.router.Route;
 @Route(value = "uc6", layout = MainLayout.class)
 @PageTitle("UC6 — Copy via context menu")
 @Menu(order = 6, title = "UC6 — Context menu")
+@StyleSheet("uc6.css")
 public class CopyFromContextMenuView extends VerticalLayout {
 
     public CopyFromContextMenuView() {
+        addClassName("uc6-view");
         add(new H1("UC6 — Copy via a context-menu item"));
         add(new Paragraph(
                 "Right-click (or long-press) the box below and pick \"Copy "
@@ -38,10 +41,7 @@ public class CopyFromContextMenuView extends VerticalLayout {
         String value = "secret-token-9f8e7a6b";
 
         Pre target = new Pre(value);
-        target.getStyle().set("padding", "var(--aura-space-m)")
-                .set("background", "var(--aura-contrast-5pct)")
-                .set("border-radius", "var(--aura-border-radius-m)")
-                .set("cursor", "context-menu");
+        target.addClassName("copy-target");
 
         ContextMenu menu = new ContextMenu(target);
         MenuItem copyItem = menu.addItem("Copy value");

--- a/clipboard/src/main/java/com/example/uc7/AvailabilityView.java
+++ b/clipboard/src/main/java/com/example/uc7/AvailabilityView.java
@@ -5,6 +5,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.clipboard.Clipboard;
 import com.vaadin.flow.component.clipboard.ClipboardAvailability;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
@@ -32,9 +33,11 @@ import com.vaadin.flow.signals.Signal;
 @Route(value = "uc7", layout = MainLayout.class)
 @PageTitle("UC7 — Detect availability")
 @Menu(order = 7, title = "UC7 — Availability")
+@StyleSheet("uc7.css")
 public class AvailabilityView extends VerticalLayout {
 
     public AvailabilityView() {
+        addClassName("uc7-view");
         add(new H1("UC7 — Detect availability and degrade gracefully"));
         add(new Paragraph(
                 "Clipboard access is unavailable on plain HTTP, in restrictive "
@@ -43,9 +46,7 @@ public class AvailabilityView extends VerticalLayout {
                         + "instead of letting a copy fail silently."));
 
         Span status = new Span();
-        status.getStyle().set("padding", "var(--aura-space-s)")
-                .set("border-radius", "var(--aura-border-radius-m)")
-                .set("display", "block");
+        status.addClassName("availability-status");
 
         Button copyButton = new Button("Copy");
         Clipboard.copyOnClick(copyButton, "https://example.com/share/abc123",
@@ -55,24 +56,21 @@ public class AvailabilityView extends VerticalLayout {
         Signal<ClipboardAvailability> availability = Clipboard
                 .availabilityHintSignal();
         Signal.effect(this, () -> {
+            status.removeClassNames("available", "unsupported");
             switch (availability.get()) {
             case AVAILABLE -> {
                 status.setText("Clipboard is available.");
-                status.getStyle().set("background",
-                        "var(--aura-success-color-10pct)");
+                status.addClassName("available");
                 copyButton.setEnabled(true);
             }
             case UNSUPPORTED -> {
                 status.setText("Clipboard is unavailable in this context "
                         + "— the copy button is disabled.");
-                status.getStyle().set("background",
-                        "var(--aura-error-color-10pct)");
+                status.addClassName("unsupported");
                 copyButton.setEnabled(false);
             }
             case UNKNOWN -> {
                 status.setText("Checking clipboard availability…");
-                status.getStyle().set("background",
-                        "var(--aura-contrast-5pct)");
                 copyButton.setEnabled(false);
             }
             }

--- a/clipboard/src/main/resources/META-INF/resources/uc4.css
+++ b/clipboard/src/main/resources/META-INF/resources/uc4.css
@@ -1,0 +1,12 @@
+.uc4-view {
+    .drop-zone {
+        border: 2px dashed #b0b8c0;
+        padding: 24px;
+        text-align: center;
+        border-radius: 8px;
+        min-height: 80px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+}

--- a/clipboard/src/main/resources/META-INF/resources/uc5.css
+++ b/clipboard/src/main/resources/META-INF/resources/uc5.css
@@ -1,0 +1,21 @@
+.uc5-view {
+    .drop-zone {
+        border: 2px dashed var(--aura-contrast-30pct);
+        padding: var(--aura-space-xl);
+        text-align: center;
+        border-radius: var(--aura-border-radius-l);
+        min-height: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .file-log {
+        font-family: monospace;
+        white-space: pre-wrap;
+        padding: var(--aura-space-s);
+        background: var(--aura-contrast-5pct);
+        display: block;
+        border-radius: var(--aura-border-radius-m);
+    }
+}

--- a/clipboard/src/main/resources/META-INF/resources/uc6.css
+++ b/clipboard/src/main/resources/META-INF/resources/uc6.css
@@ -1,0 +1,8 @@
+.uc6-view {
+    .copy-target {
+        padding: var(--aura-space-m);
+        background: var(--aura-contrast-5pct);
+        border-radius: var(--aura-border-radius-m);
+        cursor: context-menu;
+    }
+}

--- a/clipboard/src/main/resources/META-INF/resources/uc7.css
+++ b/clipboard/src/main/resources/META-INF/resources/uc7.css
@@ -1,0 +1,16 @@
+.uc7-view {
+    .availability-status {
+        padding: var(--aura-space-s);
+        border-radius: var(--aura-border-radius-m);
+        display: block;
+        background: var(--aura-contrast-5pct);
+    }
+
+    .availability-status.available {
+        background: var(--aura-success-color-10pct);
+    }
+
+    .availability-status.unsupported {
+        background: var(--aura-error-color-10pct);
+    }
+}


### PR DESCRIPTION
Each use-case view that had inline styles now adds a uc<N>-view root class, loads a uc<N>.css file via @StyleSheet, and the CSS rules are nested under that root selector.
