### PR TITLE
text-selection: Move UC6-only rules into per-use-case CSS file

### DIFF
--- a/text-selection/src/main/java/com/example/uc6/LiveSelectionInfoView.java
+++ b/text-selection/src/main/java/com/example/uc6/LiveSelectionInfoView.java
@@ -2,6 +2,7 @@ package com.example.uc6;
 
 import com.example.views.MainLayout;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
@@ -27,6 +28,7 @@ import com.vaadin.flow.signals.Signal;
 @Route(value = "uc6", layout = MainLayout.class)
 @PageTitle("UC6 — Live selection info")
 @Menu(order = 6, title = "UC6 — Live selection info")
+@StyleSheet("uc6.css")
 public class LiveSelectionInfoView extends VerticalLayout {
 
     private static final String SAMPLE = """
@@ -36,6 +38,7 @@ public class LiveSelectionInfoView extends VerticalLayout {
             zebras jump!""";
 
     public LiveSelectionInfoView() {
+        addClassName("uc6-view");
         add(new H1("UC6 — Live selection info"));
         add(new Paragraph(
                 "Drag to select text in the textarea below. The right panel "

--- a/text-selection/src/main/resources/META-INF/resources/styles.css
+++ b/text-selection/src/main/resources/META-INF/resources/styles.css
@@ -12,35 +12,6 @@
     align-items: center;
 }
 
-.uc-info-grid {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.25rem 1rem;
-    align-items: baseline;
-    font-size: 0.95rem;
-}
-
-.uc-info-grid > .label {
-    color: var(--vaadin-text-color-secondary);
-}
-
-.uc-info-grid > .value {
-    font-weight: 600;
-    font-family: monospace;
-}
-
-.uc-mono {
-    font-family: monospace;
-    font-size: 0.9rem;
-    background: var(--vaadin-background-container);
-    border: 1px solid var(--vaadin-border-color);
-    border-radius: var(--vaadin-radius-m);
-    padding: 0.4rem 0.6rem;
-    white-space: pre-wrap;
-    word-break: break-word;
-    min-height: 1.2em;
-}
-
 .uc-status {
     color: var(--vaadin-text-color-secondary);
     font-size: 0.9rem;

--- a/text-selection/src/main/resources/META-INF/resources/uc6.css
+++ b/text-selection/src/main/resources/META-INF/resources/uc6.css
@@ -1,0 +1,30 @@
+.uc6-view {
+    .uc-info-grid {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        gap: 0.25rem 1rem;
+        align-items: baseline;
+        font-size: 0.95rem;
+    }
+
+    .uc-info-grid > .label {
+        color: var(--vaadin-text-color-secondary);
+    }
+
+    .uc-info-grid > .value {
+        font-weight: 600;
+        font-family: monospace;
+    }
+
+    .uc-mono {
+        font-family: monospace;
+        font-size: 0.9rem;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        padding: 0.4rem 0.6rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+        min-height: 1.2em;
+    }
+}


### PR DESCRIPTION
UC6 is the only view that uses .uc-info-grid and .uc-mono, so those
rules move into uc6.css scoped under .uc6-view, loaded via @StyleSheet.
styles.css keeps the utility classes shared across the other UCs.
