### PR TITLE
web-share: Split styles.css into per-use-case CSS files

### DIFF
--- a/web-share/src/main/java/com/example/uc2/CopyLinkFallbackView.java
+++ b/web-share/src/main/java/com/example/uc2/CopyLinkFallbackView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
@@ -30,6 +31,7 @@ import com.vaadin.flow.signals.Signal;
  */
 @Route(value = "uc2", layout = MainLayout.class)
 @Menu(order = 2, title = "UC2 — Copy-link fallback")
+@StyleSheet("uc2.css")
 public class CopyLinkFallbackView extends VerticalLayout {
 
     private static final String DOC_TITLE = "Web Share API use cases";
@@ -39,6 +41,7 @@ public class CopyLinkFallbackView extends VerticalLayout {
     private final Paragraph hint = new Paragraph();
 
     public CopyLinkFallbackView() {
+        addClassName("uc2-view");
         add(new H1("UC2 — Share with copy-link fallback"));
         add(new Paragraph("Mobile and modern Safari/Edge users get the "
                 + "native share sheet. Desktop Firefox and older browsers "
@@ -46,9 +49,8 @@ public class CopyLinkFallbackView extends VerticalLayout {
                 + "URL either way. The swap is driven entirely by the "
                 + "shareSupportSignal()."));
 
-        actionSlot.getStyle().set("margin-top", "0.5rem");
-        hint.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("margin-top", "0.5rem");
+        actionSlot.addClassName("action-slot");
+        hint.addClassName("hint");
 
         add(actionSlot, hint);
     }

--- a/web-share/src/main/java/com/example/uc3/CustomMessageView.java
+++ b/web-share/src/main/java/com/example/uc3/CustomMessageView.java
@@ -10,6 +10,7 @@ import tools.jackson.databind.node.ObjectNode;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
@@ -37,6 +38,7 @@ import com.vaadin.flow.signals.Signal;
  */
 @Route(value = "uc3", layout = MainLayout.class)
 @Menu(order = 3, title = "UC3 — Share a custom message")
+@StyleSheet("uc3.css")
 public class CustomMessageView extends VerticalLayout {
 
     private static final ObjectMapper JSON = JsonMapper.builder()
@@ -50,6 +52,7 @@ public class CustomMessageView extends VerticalLayout {
             VaadinIcon.SHARE.create());
 
     public CustomMessageView() {
+        addClassName("uc3-view");
         add(new H1("UC3 — Share a custom message"));
         add(new Paragraph("Fill any combination of the three fields. The "
                 + "preview shows exactly what gets passed to "

--- a/web-share/src/main/java/com/example/uc4/ShareListItemsView.java
+++ b/web-share/src/main/java/com/example/uc4/ShareListItemsView.java
@@ -7,6 +7,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
@@ -32,6 +33,7 @@ import com.vaadin.flow.signals.Signal;
  */
 @Route(value = "uc4", layout = MainLayout.class)
 @Menu(order = 4, title = "UC4 — Per-item share")
+@StyleSheet("uc4.css")
 public class ShareListItemsView extends VerticalLayout {
 
     private record Article(String title, String summary, String url) {
@@ -53,6 +55,7 @@ public class ShareListItemsView extends VerticalLayout {
     private final Div list = new Div();
 
     public ShareListItemsView() {
+        addClassName("uc4-view");
         add(new H1("UC4 — Share each item in a list"));
         add(new Paragraph("Each row has its own Share button bound to its "
                 + "own payload. On a phone, tapping a row's icon opens the "

--- a/web-share/src/main/java/com/example/uc5/ShareFeedbackView.java
+++ b/web-share/src/main/java/com/example/uc5/ShareFeedbackView.java
@@ -8,6 +8,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
@@ -35,6 +36,7 @@ import com.vaadin.flow.signals.Signal;
  */
 @Route(value = "uc5", layout = MainLayout.class)
 @Menu(order = 5, title = "UC5 — Completion feedback")
+@StyleSheet("uc5.css")
 public class ShareFeedbackView extends VerticalLayout {
 
     private static final DateTimeFormatter TIME = DateTimeFormatter
@@ -45,6 +47,7 @@ public class ShareFeedbackView extends VerticalLayout {
     private final Div log = new Div();
 
     public ShareFeedbackView() {
+        addClassName("uc5-view");
         add(new H1("UC5 — Share with completion feedback"));
         add(new Paragraph("Hooks .then(ok, err) on the PendingJavaScriptResult "
                 + "returned by Page.share(...). The browser resolves the "

--- a/web-share/src/main/java/com/example/uc6/ShareInviteLinkView.java
+++ b/web-share/src/main/java/com/example/uc6/ShareInviteLinkView.java
@@ -8,6 +8,7 @@ import org.jspecify.annotations.Nullable;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
@@ -36,6 +37,7 @@ import com.vaadin.flow.signals.Signal;
  */
 @Route(value = "uc6", layout = MainLayout.class)
 @Menu(order = 6, title = "UC6 — Share invite link")
+@StyleSheet("uc6.css")
 public class ShareInviteLinkView extends VerticalLayout {
 
     private static final SecureRandom RNG = new SecureRandom();
@@ -52,6 +54,7 @@ public class ShareInviteLinkView extends VerticalLayout {
     private boolean shareSupported;
 
     public ShareInviteLinkView() {
+        addClassName("uc6-view");
         add(new H1("UC6 — Share an invite link"));
         add(new Paragraph("Generates a fresh join code (server-side) and "
                 + "hands a https://example.com/join/<code> URL to the "

--- a/web-share/src/main/resources/META-INF/resources/styles.css
+++ b/web-share/src/main/resources/META-INF/resources/styles.css
@@ -19,36 +19,6 @@
     letter-spacing: 0.05em;
 }
 
-.share-preview {
-    font-family: monospace;
-    font-size: 0.85rem;
-    background: var(--vaadin-background-container);
-    border: 1px solid var(--vaadin-border-color);
-    border-radius: var(--vaadin-radius-m);
-    padding: 0.5rem 0.75rem;
-    white-space: pre-wrap;
-}
-
-.share-feedback-log {
-    font-family: monospace;
-    font-size: 0.85rem;
-    background: var(--vaadin-background-container);
-    border: 1px solid var(--vaadin-border-color);
-    border-radius: var(--vaadin-radius-m);
-    padding: 0.5rem 0.75rem;
-    max-height: 220px;
-    overflow-y: auto;
-}
-
-.share-feedback-log > div {
-    padding: 0.1rem 0;
-    border-bottom: 1px dashed var(--vaadin-border-color);
-}
-
-.share-feedback-log > div:last-child {
-    border-bottom: none;
-}
-
 .status-badge {
     display: inline-block;
     padding: 0.15rem 0.6rem;
@@ -69,40 +39,4 @@
     background: color-mix(in srgb, var(--aura-neutral) 18%, transparent);
     color: var(--vaadin-text-color-secondary);
     border-color: color-mix(in srgb, var(--aura-neutral) 35%, transparent);
-}
-
-.share-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-width: 640px;
-}
-
-.share-list-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    border: 1px solid var(--vaadin-border-color);
-    border-radius: var(--vaadin-radius-m);
-    background: var(--vaadin-background-container);
-}
-
-.share-list-item-title {
-    font-weight: 600;
-}
-
-.share-list-item-summary {
-    font-size: 0.85rem;
-    color: var(--vaadin-text-color-secondary);
-}
-
-.invite-code {
-    font-family: monospace;
-    font-size: 1.1rem;
-    padding: 0.25rem 0.6rem;
-    background: var(--vaadin-background-container);
-    border-radius: var(--vaadin-radius-s);
-    border: 1px solid var(--vaadin-border-color);
 }

--- a/web-share/src/main/resources/META-INF/resources/uc2.css
+++ b/web-share/src/main/resources/META-INF/resources/uc2.css
@@ -1,0 +1,10 @@
+.uc2-view {
+    .action-slot {
+        margin-top: 0.5rem;
+    }
+
+    .hint {
+        color: var(--vaadin-text-color-secondary);
+        margin-top: 0.5rem;
+    }
+}

--- a/web-share/src/main/resources/META-INF/resources/uc3.css
+++ b/web-share/src/main/resources/META-INF/resources/uc3.css
@@ -1,0 +1,11 @@
+.uc3-view {
+    .share-preview {
+        font-family: monospace;
+        font-size: 0.85rem;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        padding: 0.5rem 0.75rem;
+        white-space: pre-wrap;
+    }
+}

--- a/web-share/src/main/resources/META-INF/resources/uc4.css
+++ b/web-share/src/main/resources/META-INF/resources/uc4.css
@@ -1,0 +1,28 @@
+.uc4-view {
+    .share-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        max-width: 640px;
+    }
+
+    .share-list-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        background: var(--vaadin-background-container);
+    }
+
+    .share-list-item-title {
+        font-weight: 600;
+    }
+
+    .share-list-item-summary {
+        font-size: 0.85rem;
+        color: var(--vaadin-text-color-secondary);
+    }
+}

--- a/web-share/src/main/resources/META-INF/resources/uc5.css
+++ b/web-share/src/main/resources/META-INF/resources/uc5.css
@@ -1,0 +1,21 @@
+.uc5-view {
+    .share-feedback-log {
+        font-family: monospace;
+        font-size: 0.85rem;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        padding: 0.5rem 0.75rem;
+        max-height: 220px;
+        overflow-y: auto;
+
+        > div {
+            padding: 0.1rem 0;
+            border-bottom: 1px dashed var(--vaadin-border-color);
+        }
+
+        > div:last-child {
+            border-bottom: none;
+        }
+    }
+}

--- a/web-share/src/main/resources/META-INF/resources/uc6.css
+++ b/web-share/src/main/resources/META-INF/resources/uc6.css
@@ -1,0 +1,10 @@
+.uc6-view {
+    .invite-code {
+        font-family: monospace;
+        font-size: 1.1rem;
+        padding: 0.25rem 0.6rem;
+        background: var(--vaadin-background-container);
+        border-radius: var(--vaadin-radius-s);
+        border: 1px solid var(--vaadin-border-color);
+    }
+}


### PR DESCRIPTION
UC2..UC6 each get their own uc<N>.css scoped under .uc<N>-view, loaded
via @StyleSheet on the view class. styles.css keeps only the shared
home-page and status-badge utilities. UC1 only uses shared utilities,
so it doesn't need a per-UC file.

UC2's two inline getStyle().set(...) calls in CopyLinkFallbackView are
replaced with .action-slot and .hint class names.
