### PR TITLE
signals: Split inline styles and styles.css into per-use-case CSS files

### DIFF
--- a/signals/src/main/java/com/example/muc01/MUC01View.java
+++ b/signals/src/main/java/com/example/muc01/MUC01View.java
@@ -13,6 +13,7 @@ import org.jspecify.annotations.Nullable;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -38,6 +39,7 @@ import com.vaadin.flow.router.Route;
 @Route(value = "muc-01", layout = MainLayout.class)
 @PageTitle("MUC 1: Shared Chat")
 @Menu(order = 50, title = "MUC 1: Shared Chat")
+@StyleSheet("muc01.css")
 @PermitAll
 public class MUC01View extends VerticalLayout {
 
@@ -59,6 +61,7 @@ public class MUC01View extends VerticalLayout {
         this.muc01Signals = muc01Signals;
         this.userSessionRegistry = userSessionRegistry;
 
+        addClassName("muc01-view");
         setSpacing(true);
         setPadding(true);
         setHeight("100%");
@@ -77,10 +80,7 @@ public class MUC01View extends VerticalLayout {
         // Message display area
         Div messagesContainer = new Div();
         messagesContainer.setWidthFull();
-        messagesContainer.getStyle().set("background-color", "#f5f5f5")
-                .set("border", "1px solid #e0e0e0").set("border-radius", "4px")
-                .set("padding", "1em").set("min-height", "200px")
-                .set("overflow-y", "auto").set("max-height", "400px");
+        messagesContainer.addClassName("messages-container");
 
         // Bind message list to UI
         messagesContainer.bindChildren(muc01Signals.getMessagesSignal(),
@@ -118,9 +118,7 @@ public class MUC01View extends VerticalLayout {
         Div messageCount = new Div();
         messageCount.bindText(muc01Signals.getMessagesSignal()
                 .map(messages -> "Total messages: " + messages.size()));
-        messageCount.getStyle()
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-s)");
+        messageCount.addClassName("message-count");
 
         add(title, description, activeUsersDisplay, new H3("Messages"),
                 messagesContainer, messageCount, messageInput, sendButton,
@@ -138,11 +136,9 @@ public class MUC01View extends VerticalLayout {
                 .getUserColorByUsername(message.username());
 
         Div messageDiv = new Div();
-        messageDiv.getStyle().set("background-color", "#ffffff")
-                .set("border-left", "3px solid " + senderColor)
-                .set("padding", "0.75em").set("margin-bottom", "0.5em")
-                .set("border-radius", "4px").set("display", "flex")
-                .set("gap", "0.75em");
+        messageDiv.addClassName("message-row");
+        // Per-user color is dynamic — keep inline
+        messageDiv.getStyle().set("border-left", "3px solid " + senderColor);
 
         // Avatar
         ColoredAvatar avatar = new ColoredAvatar(message.username(),
@@ -150,27 +146,26 @@ public class MUC01View extends VerticalLayout {
 
         // Content area (header + text)
         Div contentArea = new Div();
-        contentArea.getStyle().set("flex", "1");
+        contentArea.addClassName("message-content");
 
         Div header = new Div();
-        header.getStyle().set("display", "flex")
-                .set("justify-content", "space-between")
-                .set("margin-bottom", "0.5em");
+        header.addClassName("message-header");
 
         Div author = new Div();
         author.setText(message.author());
-        author.getStyle().set("font-weight", "bold").set("color", senderColor);
+        author.addClassName("message-author");
+        // Per-user color is dynamic — keep inline
+        author.getStyle().set("color", senderColor);
 
         Div timestamp = new Div();
         timestamp.setText(message.getFormattedTimestamp());
-        timestamp.getStyle().set("font-size", "0.85em").set("color",
-                "var(--vaadin-text-color-secondary)");
+        timestamp.addClassName("message-timestamp");
 
         header.add(author, timestamp);
 
         Div text = new Div();
         text.setText(message.text());
-        text.getStyle().set("color", "var(--vaadin-text-color)");
+        text.addClassName("message-text");
 
         contentArea.add(header, text);
         messageDiv.add(avatar, contentArea);

--- a/signals/src/main/java/com/example/muc02/MUC02View.java
+++ b/signals/src/main/java/com/example/muc02/MUC02View.java
@@ -12,6 +12,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -38,6 +39,7 @@ import com.vaadin.flow.signals.shared.SharedValueSignal;
 @Route(value = "muc-02", layout = MainLayout.class)
 @PageTitle("Multi-User Case 2: Collaborative Cursors")
 @Menu(order = 51, title = "MUC 2: Collaborative Cursors")
+@StyleSheet("muc02.css")
 @PermitAll
 public class MUC02View extends VerticalLayout {
 
@@ -61,6 +63,7 @@ public class MUC02View extends VerticalLayout {
         this.muc02Signals = muc02Signals;
         this.userSessionRegistry = userSessionRegistry;
 
+        addClassName("muc02-view");
         setSpacing(true);
         setPadding(true);
 
@@ -75,15 +78,11 @@ public class MUC02View extends VerticalLayout {
         Div canvas = new Div();
         canvas.setId("cursor-canvas");
         canvas.setWidthFull();
-        canvas.getStyle().set("position", "relative")
-                .set("background-color", "#f5f5f5")
-                .set("outline", "2px solid #e0e0e0").set("border-radius", "4px")
-                .set("height", "400px").set("margin", "1em 0")
-                .set("cursor", "crosshair");
+        canvas.addClassName("cursor-canvas");
 
         // Add cursor indicators for all users
         Div cursorsContainer = new Div();
-        cursorsContainer.getStyle().set("position", "relative");
+        cursorsContainer.addClassName("cursors-container");
         canvas.add(cursorsContainer);
 
         // Render cursor indicators for all users
@@ -110,8 +109,7 @@ public class MUC02View extends VerticalLayout {
         // Current users list (cursor tracking)
         H3 usersTitle = new H3("Cursor Tracking");
         Div usersList = new Div();
-        usersList.getStyle().set("background-color", "#e3f2fd")
-                .set("padding", "1em").set("border-radius", "4px");
+        usersList.addClassName("users-list");
 
         // Display cursor positions per session - reactive
         usersList.bindChildren(
@@ -124,9 +122,7 @@ public class MUC02View extends VerticalLayout {
 
         // Info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "💡 Each user's cursor position is stored in a SharedValueSignal in a shared Map. "
                         + "All users read all signals to display cursor indicators. This pattern enables "
@@ -189,25 +185,23 @@ public class MUC02View extends VerticalLayout {
         userItem.setAlignItems(
                 com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment.CENTER);
         userItem.setWidthFull();
-        userItem.getStyle().set("margin-bottom", "0.5em");
+        userItem.addClassName("cursor-list-item");
 
         Div colorDot = new Div();
-        colorDot.getStyle().set("width", "12px").set("height", "12px")
-                .set("border-radius", "50%").set("background-color", userColor)
-                .set("flex-shrink", "0");
+        colorDot.addClassName("color-dot");
+        // Per-user color is dynamic — keep inline
+        colorDot.getStyle().set("background-color", userColor);
 
         ColoredAvatar avatar = new ColoredAvatar(username, userColor, 32);
 
         Div userLabel = new Div();
         userLabel
                 .bindText(userSessionRegistry.getDisplayNameSignal(sessionKey));
-        userLabel.getStyle().set("font-weight", "500");
+        userLabel.addClassName("user-label");
 
         Div positionLabel = new Div(
                 positionSignal.map(MUC02Signals.CursorPosition::toString));
-        positionLabel.getStyle().set("font-family", "monospace")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("margin-left", "auto");
+        positionLabel.addClassName("position-label");
 
         userItem.add(colorDot, avatar, userLabel, positionLabel);
         return userItem;
@@ -219,12 +213,9 @@ public class MUC02View extends VerticalLayout {
         String userColor = buildColorMap().getOrDefault(sessionKey, "#9E9E9E");
 
         Div cursorIndicator = new Div();
-        cursorIndicator.getStyle().set("position", "absolute")
-                .set("width", "20px").set("height", "20px")
-                .set("background-color", userColor).set("border-radius", "50%")
-                .set("border", "2px solid white").set("pointer-events", "none")
-                .set("transform", "translate(-50%, -50%)")
-                .set("z-index", "1000");
+        cursorIndicator.addClassName("cursor-indicator");
+        // Per-user color is dynamic — keep inline
+        cursorIndicator.getStyle().set("background-color", userColor);
 
         cursorIndicator.getStyle().bind("left", positionSignal
                 .map(pos -> pos != null ? pos.x() + "px" : "0px"));
@@ -233,11 +224,9 @@ public class MUC02View extends VerticalLayout {
 
         Div label = new Div();
         label.bindText(userSessionRegistry.getDisplayNameSignal(sessionKey));
-        label.getStyle().set("position", "absolute").set("top", "25px")
-                .set("left", "0").set("white-space", "nowrap")
-                .set("background-color", userColor).set("color", "white")
-                .set("padding", "2px 6px").set("border-radius", "3px")
-                .set("font-size", "0.75em");
+        label.addClassName("cursor-indicator-label");
+        // Per-user color is dynamic — keep inline
+        label.getStyle().set("background-color", userColor);
 
         cursorIndicator.add(label);
         return cursorIndicator;

--- a/signals/src/main/java/com/example/muc03/MUC03View.java
+++ b/signals/src/main/java/com/example/muc03/MUC03View.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.Nullable;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -40,6 +41,7 @@ import com.vaadin.flow.signals.Signal;
 @Route(value = "muc-03", layout = MainLayout.class)
 @PageTitle("Multi-User Case 3: Click Game")
 @Menu(order = 52, title = "MUC 3: Click Race Game")
+@StyleSheet("muc03.css")
 @PermitAll
 public class MUC03View extends VerticalLayout {
 
@@ -63,6 +65,7 @@ public class MUC03View extends VerticalLayout {
         this.muc03Signals = muc03Signals;
         this.userSessionRegistry = userSessionRegistry;
 
+        addClassName("muc03-view");
         setSpacing(true);
         setPadding(true);
 
@@ -75,25 +78,20 @@ public class MUC03View extends VerticalLayout {
 
         // Round status
         Div roundStatus = new Div();
-        roundStatus.getStyle().set("font-size", "1.2em")
-                .set("font-weight", "bold").set("margin-bottom", "0.5em");
+        roundStatus.addClassName("round-status");
         roundStatus.bindText(muc03Signals.getRoundNumberSignal()
                 .map(round -> round == 0 ? "Click START to begin"
                         : "Round " + round));
 
         Div clicksStatus = new Div();
-        clicksStatus.getStyle().set("font-size", "1em").set("color",
-                "var(--vaadin-text-color-secondary)");
+        clicksStatus.addClassName("clicks-status");
         clicksStatus.bindText(muc03Signals.getClicksRemainingSignal().map(
                 clicks -> clicks > 0 ? "Targets remaining: " + clicks : ""));
 
         // Game area
         Div gameArea = new Div();
         gameArea.setWidthFull();
-        gameArea.getStyle().set("position", "relative")
-                .set("background-color", "#f5f5f5")
-                .set("border", "2px solid #e0e0e0").set("border-radius", "4px")
-                .set("height", "300px").set("margin", "1em 0");
+        gameArea.addClassName("game-area");
 
         // Target button
         Button targetButton = new Button("CLICK ME!", event -> {
@@ -101,8 +99,7 @@ public class MUC03View extends VerticalLayout {
         });
         targetButton.addThemeName("primary");
         targetButton.addThemeName("large");
-        targetButton.getStyle().set("position", "absolute").set("z-index",
-                "10");
+        targetButton.addClassName("target-button");
 
         // Bind button text to show clicks remaining
         targetButton.bindText(muc03Signals.getClicksRemainingSignal()
@@ -140,8 +137,7 @@ public class MUC03View extends VerticalLayout {
         // Leaderboard
         H3 leaderboardTitle = new H3("Leaderboard");
         Div leaderboardDiv = new Div();
-        leaderboardDiv.getStyle().set("background-color", "#e3f2fd")
-                .set("padding", "1em").set("border-radius", "4px");
+        leaderboardDiv.addClassName("leaderboard");
 
         // Bind leaderboard display - sorted by score descending
         leaderboardDiv
@@ -158,9 +154,7 @@ public class MUC03View extends VerticalLayout {
 
         // Info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "💡 This demonstrates atomic operations and conflict resolution in multi-user scenarios. "
                         + "Each round has 5 targets that appear with random delays (500-2000ms) at random positions. "
@@ -241,18 +235,16 @@ public class MUC03View extends VerticalLayout {
         item.setSpacing(true);
         item.setAlignItems(
                 com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment.CENTER);
-        item.getStyle().set("padding", "0.5em")
-                .set("background-color",
-                        isCurrentSession ? "#fff3e0" : "transparent")
-                .set("border-radius", "4px")
-                .set("font-weight", isCurrentSession ? "bold" : "normal");
+        item.addClassName("leaderboard-item");
+        if (isCurrentSession) {
+            item.addClassName("current-session");
+        }
 
         Image avatar = new Image(MainLayout.getProfilePicturePath(username),
                 "");
         avatar.setWidth("32px");
         avatar.setHeight("32px");
-        avatar.getStyle().set("border-radius", "50%").set("object-fit",
-                "cover");
+        avatar.addClassName("leaderboard-avatar");
 
         Span nameLabel = new Span();
         nameLabel.bindText(Signal.computed(() -> String.format("%s: %d points",

--- a/signals/src/main/java/com/example/muc04/MUC04View.java
+++ b/signals/src/main/java/com/example/muc04/MUC04View.java
@@ -12,6 +12,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -40,6 +41,7 @@ import com.vaadin.flow.signals.shared.SharedValueSignal;
 @Route(value = "muc-04", layout = MainLayout.class)
 @PageTitle("Multi-User Case 4: Collaborative Editing")
 @Menu(order = 53, title = "MUC 4: Collaborative Editing")
+@StyleSheet("muc04.css")
 @PermitAll
 public class MUC04View extends VerticalLayout {
 
@@ -64,6 +66,7 @@ public class MUC04View extends VerticalLayout {
         this.muc04Signals = muc04Signals;
         this.lockingEnabledSignal = muc04Signals.getLockingEnabledSignal();
 
+        addClassName("muc04-view");
         setSpacing(true);
         setPadding(true);
 
@@ -105,8 +108,7 @@ public class MUC04View extends VerticalLayout {
 
     private Div createEditorsPanel() {
         var editorsDiv = new Div();
-        editorsDiv.getStyle().set("background-color", "#e3f2fd")
-                .set("padding", "1em").set("border-radius", "4px");
+        editorsDiv.addClassName("editors-panel");
 
         addFieldEditorList(editorsDiv, "companyName", "Company Name");
         addFieldEditorList(editorsDiv, "address", "Address");
@@ -123,11 +125,11 @@ public class MUC04View extends VerticalLayout {
         fieldDiv.bindVisible(editors.map(list -> !list.isEmpty()));
 
         var fieldLabel = new Span(label + ": ");
-        fieldLabel.getStyle().set("font-weight", "bold");
+        fieldLabel.addClassName("editors-panel-field-label");
         fieldDiv.add(fieldLabel);
 
         var namesContainer = new Div();
-        namesContainer.getStyle().set("display", "inline");
+        namesContainer.addClassName("editors-panel-names-container");
         namesContainer.bindChildren(editors, this::createEditorName);
         fieldDiv.add(namesContainer);
 
@@ -137,7 +139,7 @@ public class MUC04View extends VerticalLayout {
     private Span createEditorName(SharedValueSignal<User> userSignal) {
         var user = userSignal.peek();
         var name = new Span(user.name());
-        name.getStyle().set("margin-right", "0.5em");
+        name.addClassName("editor-name");
         return name;
     }
 

--- a/signals/src/main/java/com/example/muc06/MUC06View.java
+++ b/signals/src/main/java/com/example/muc06/MUC06View.java
@@ -14,6 +14,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -46,6 +47,7 @@ import com.vaadin.flow.signals.shared.SharedValueSignal;
 @Route(value = "muc-06", layout = MainLayout.class)
 @PageTitle("MUC 6: Shared Task List")
 @Menu(order = 55, title = "MUC 6: Shared Task List")
+@StyleSheet("muc06.css")
 @PermitAll
 public class MUC06View extends VerticalLayout {
 
@@ -66,6 +68,7 @@ public class MUC06View extends VerticalLayout {
         this.muc06Signals = muc06Signals;
         this.userSessionRegistry = userSessionRegistry;
 
+        addClassName("muc06-view");
         setSpacing(true);
         setPadding(true);
 
@@ -98,24 +101,21 @@ public class MUC06View extends VerticalLayout {
 
         // Statistics panel
         Div statsBox = new Div();
-        statsBox.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "1em").set("display", "flex")
-                .set("gap", "2em");
+        statsBox.addClassName("stats-box");
 
         Span totalLabel = new Span();
         totalLabel.bindText(totalSignal.map(n -> "Total: " + n));
-        totalLabel.getStyle().set("font-weight", "500");
+        totalLabel.addClassName("stat-label");
 
         Span completedLabel = new Span();
         completedLabel.bindText(completedSignal.map(n -> "Completed: " + n));
-        completedLabel.getStyle().set("color", "var(--aura-green)")
-                .set("font-weight", "500");
+        completedLabel.addClassName("stat-label");
+        completedLabel.addClassName("stat-completed");
 
         Span pendingLabel = new Span();
         pendingLabel.bindText(pendingSignal.map(n -> "Pending: " + n));
-        pendingLabel.getStyle().set("color", "var(--aura-accent-color)")
-                .set("font-weight", "500");
+        pendingLabel.addClassName("stat-label");
+        pendingLabel.addClassName("stat-pending");
 
         statsBox.add(totalLabel, completedLabel, pendingLabel);
 
@@ -123,9 +123,7 @@ public class MUC06View extends VerticalLayout {
         H3 tasksTitle = new H3("Shared Tasks");
 
         Div tasksContainer = new Div();
-        tasksContainer.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("gap", "0.5em")
-                .set("margin-bottom", "1em");
+        tasksContainer.addClassName("tasks-container");
 
         tasksContainer.bindChildren(tasksSignal,
                 taskSignal -> createTaskRow(taskSignal, tasksSignal));
@@ -141,9 +139,7 @@ public class MUC06View extends VerticalLayout {
 
         // Info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "💡 This demonstrates real-time collaborative editing with shared signals. "
                         + "In production:\n"
@@ -203,9 +199,7 @@ public class MUC06View extends VerticalLayout {
         row.setDefaultVerticalComponentAlignment(Alignment.CENTER);
         row.setWidthFull();
         row.setPadding(true);
-        row.getStyle().set("background-color", "#ffffff").set("border",
-                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("border-radius", "4px");
+        row.addClassName("task-row");
 
         return row;
     }

--- a/signals/src/main/java/com/example/usecase02/UseCase02View.java
+++ b/signals/src/main/java/com/example/usecase02/UseCase02View.java
@@ -9,6 +9,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -26,10 +27,12 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-02", layout = MainLayout.class)
 @PageTitle("Use Case 2: Progressive Disclosure with Nested Conditions")
 @Menu(order = 2, title = "UC 2: Nested Conditions")
+@StyleSheet("usecase02.css")
 @PermitAll
 public class UseCase02View extends VerticalLayout {
 
     public UseCase02View() {
+        addClassName("usecase02-view");
         setSpacing(true);
         setPadding(true);
 
@@ -170,14 +173,12 @@ public class UseCase02View extends VerticalLayout {
         var resultTextSignal = new ValueSignal<>("");
 
         Div resultDisplay = new Div();
-        resultDisplay.getStyle().set("margin-top", "2em").set("padding", "1em")
-                .set("border", "1px solid #ccc").set("border-radius", "4px")
-                .set("background-color", "#f5f5f5");
+        resultDisplay.addClassName("result-display");
         resultDisplay
                 .bindVisible(resultTextSignal.map(text -> !text.isBlank()));
 
         Pre resultText = new Pre(resultTextSignal);
-        resultText.getStyle().set("margin", "0");
+        resultText.addClassName("result-text");
 
         resultDisplay.add(new H3("Collected Form Data"), resultText);
 

--- a/signals/src/main/java/com/example/usecase03/UseCase03View.java
+++ b/signals/src/main/java/com/example/usecase03/UseCase03View.java
@@ -8,6 +8,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
@@ -29,6 +30,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-03", layout = MainLayout.class)
 @PageTitle("Use Case 3: Interactive SVG Shape Editor")
 @Menu(order = 3, title = "UC 3: Interactive SVG Shape Editor")
+@StyleSheet("usecase03.css")
 @PermitAll
 public class UseCase03View extends VerticalLayout {
 
@@ -76,19 +78,20 @@ public class UseCase03View extends VerticalLayout {
     public UseCase03View() {
         resetAll();
 
+        addClassName("usecase03-view");
         setSpacing(true);
         setPadding(true);
         setWidthFull();
 
         H2 title = new H2("Use Case 3: Interactive SVG Shape Editor");
-        title.getStyle().set("margin-bottom", "0");
+        title.addClassName("view-title");
 
         Paragraph description = new Paragraph(
                 "Click on a shape to select it, or use the tabs below. "
                         + "Demonstrates extensive bindAttribute() usage with SVG elements. "
                         + "Each shape is controlled by multiple signals that bind to SVG attributes like position, size, colors, and transforms. "
                         + "(19 writable + 4 computed = 23 signals total).");
-        description.getStyle().set("margin-top", "0.5em");
+        description.addClassName("view-description");
 
         // Main content: controls on left, canvas on right
         HorizontalLayout mainContent = new HorizontalLayout();
@@ -98,11 +101,11 @@ public class UseCase03View extends VerticalLayout {
         // Left panel: shape selector and controls
         VerticalLayout leftPanel = createLeftPanel();
         leftPanel.setWidth("280px");
-        leftPanel.getStyle().set("flex-shrink", "0");
+        leftPanel.addClassName("left-panel");
 
         // Right panel: SVG canvas
         Div svgContainer = createSvgCanvas();
-        svgContainer.getStyle().set("flex", "1");
+        svgContainer.addClassName("svg-container");
 
         mainContent.add(leftPanel, svgContainer);
 
@@ -136,18 +139,14 @@ public class UseCase03View extends VerticalLayout {
 
     private Div createSvgCanvas() {
         Div container = new Div();
-        container.getStyle().set("border",
-                "2px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)")
-                .set("padding", "20px").set("background", "white")
-                .set("border-radius", "8px")
-                .set("box-shadow", "0 2px 8px rgba(0,0,0,0.1)");
+        // .svg-container class is added on the wrapper by the caller
 
         Element svg = new Element("svg");
         svg.setAttribute("viewBox", "0 0 500 500");
         svg.setAttribute("width", "100%");
         svg.setAttribute("height", "500");
         svg.setAttribute("style", "max-width: 100%;");
-        svg.getStyle().set("background", "#fafafa").set("border-radius", "4px");
+        svg.getClassList().add("svg-canvas");
 
         // Add background grid for reference
         Element defs = new Element("defs");
@@ -190,8 +189,8 @@ public class UseCase03View extends VerticalLayout {
         });
 
         // Add cursor pointer style for shapes
-        rectElement.getStyle().set("cursor", "pointer");
-        starElement.getStyle().set("cursor", "pointer");
+        rectElement.getClassList().add("clickable-shape");
+        starElement.getClassList().add("clickable-shape");
 
         container.getElement().appendChild(svg);
         return container;
@@ -288,9 +287,7 @@ public class UseCase03View extends VerticalLayout {
 
         // Position section
         Span positionLabel = new Span("Position");
-        positionLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500");
+        positionLabel.addClassName("section-label");
 
         IntegerSlider xSlider = new IntegerSlider("X", 0, 500);
         bindSliderToInteger(xSlider, rectXSignal);
@@ -302,9 +299,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Size section
         Span sizeLabel = new Span("Size");
-        sizeLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        sizeLabel.addClassName("section-label");
+        sizeLabel.addClassName("section-label-with-margin");
 
         IntegerSlider widthSlider = new IntegerSlider("Width", 50, 250);
         bindSliderToInteger(widthSlider, rectWidthSignal);
@@ -321,9 +317,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Appearance section
         Span appearanceLabel = new Span("Appearance");
-        appearanceLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        appearanceLabel.addClassName("section-label");
+        appearanceLabel.addClassName("section-label-with-margin");
 
         ComboBox<String> fillColorField = createColorPicker("Fill");
         fillColorField.bindValue(rectFillSignal, rectFillSignal::set);
@@ -340,9 +335,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Transform section
         Span transformLabel = new Span("Transform");
-        transformLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        transformLabel.addClassName("section-label");
+        transformLabel.addClassName("section-label-with-margin");
 
         IntegerSlider rotationSlider = new IntegerSlider("Rotation", 0, 360);
         bindSliderToInteger(rotationSlider, rectRotationSignal);
@@ -368,9 +362,7 @@ public class UseCase03View extends VerticalLayout {
 
         // Position section
         Span positionLabel = new Span("Position");
-        positionLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500");
+        positionLabel.addClassName("section-label");
 
         IntegerSlider cxSlider = new IntegerSlider("Center X", 0, 500);
         bindSliderToInteger(cxSlider, starCxSignal);
@@ -382,9 +374,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Shape section
         Span shapeLabel = new Span("Shape");
-        shapeLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        shapeLabel.addClassName("section-label");
+        shapeLabel.addClassName("section-label-with-margin");
 
         IntegerSlider pointsSlider = new IntegerSlider("Points", 3, 10);
         bindSliderToInteger(pointsSlider, starPointsSignal);
@@ -396,9 +387,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Appearance section
         Span appearanceLabel = new Span("Appearance");
-        appearanceLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        appearanceLabel.addClassName("section-label");
+        appearanceLabel.addClassName("section-label-with-margin");
 
         ComboBox<String> fillColorField = createColorPicker("Fill");
         fillColorField.bindValue(starFillSignal, starFillSignal::set);
@@ -415,9 +405,8 @@ public class UseCase03View extends VerticalLayout {
 
         // Transform section
         Span transformLabel = new Span("Transform");
-        transformLabel.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500").set("margin-top", "8px");
+        transformLabel.addClassName("section-label");
+        transformLabel.addClassName("section-label-with-margin");
 
         IntegerSlider rotationSlider = new IntegerSlider("Rotation", 0, 360);
         bindSliderToInteger(rotationSlider, starRotationSignal);
@@ -455,6 +444,8 @@ public class UseCase03View extends VerticalLayout {
             layout.setSpacing(true);
 
             Div swatch = new Div();
+            // ComboBox renders items into a popover outside the view, so
+            // nested CSS would not match — keep these styles inline.
             swatch.getStyle().set("width", "20px").set("height", "20px")
                     .set("background-color", color)
                     .set("border",

--- a/signals/src/main/java/com/example/usecase06/UseCase06View.java
+++ b/signals/src/main/java/com/example/usecase06/UseCase06View.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -30,10 +31,12 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-06", layout = MainLayout.class)
 @PageTitle("Use Case 6: Shopping Cart with Real-time Totals")
 @Menu(order = 6, title = "UC 6: Shopping Cart")
+@StyleSheet("usecase06.css")
 @PermitAll
 public class UseCase06View extends VerticalLayout {
 
     public UseCase06View() {
+        addClassName("usecase06-view");
         setSpacing(true);
         setPadding(true);
 
@@ -88,9 +91,7 @@ public class UseCase06View extends VerticalLayout {
         // Products list
         var productsTitle = new H3("Available Products");
         var productsContainer = new Div();
-        productsContainer.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "1em");
+        productsContainer.addClassName("products-container");
         products.forEach(product -> productsContainer
                 .add(createProductRow(product, cartItemsSignal)));
 
@@ -106,17 +107,14 @@ public class UseCase06View extends VerticalLayout {
         cartHeader.setAlignItems(Alignment.CENTER);
         cartHeader.expand(cartTitle);
         var cartItemsContainer = new Div();
-        cartItemsContainer.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "1em");
+        cartItemsContainer.addClassName("cart-items-container");
 
         var cartItemsList = new Div();
         cartItemsList.bindChildren(cartItemsSignal,
                 itemSignal -> createCartItemRow(itemSignal, cartItemsSignal));
 
         var emptyCart = new Paragraph("Empty cart");
-        emptyCart.getStyle().set("margin", "0").set("font-style", "italic")
-                .set("color", "var(--vaadin-text-color-secondary)");
+        emptyCart.addClassName("empty-cart-text");
         emptyCart.bindVisible(cartItemsSignal.map(List::isEmpty));
         cartItemsContainer.add(emptyCart, cartItemsList);
 
@@ -141,50 +139,38 @@ public class UseCase06View extends VerticalLayout {
 
         // Totals display
         var totalsBox = new Div();
-        totalsBox.getStyle().set("background-color", "#e8f5e9")
-                .set("padding", "1.5em").set("border-radius", "4px")
-                .set("margin-top", "1em");
+        totalsBox.addClassName("totals-box");
 
         var summaryTitle = new H3("Order Summary");
-        summaryTitle.getStyle().set("margin-top", "0");
+        summaryTitle.addClassName("summary-title");
 
         var subtotalLabel = new Span(formatter("Subtotal: $", subtotalSignal));
-        subtotalLabel.getStyle().set("display", "block").set("margin-bottom",
-                "0.5em");
+        subtotalLabel.addClassName("total-line");
 
         var discountLabel = new Span(formatter("Discount: -$", discountSignal));
         discountLabel.bindVisible(
                 () -> discountSignal.get().compareTo(BigDecimal.ZERO) > 0);
-        discountLabel.getStyle().set("display", "block")
-                .set("margin-bottom", "0.5em")
-                .set("color", "var(--aura-green)");
+        discountLabel.addClassName("total-line");
+        discountLabel.addClassName("total-line-discount");
 
         var shippingLabel = new Span(formatter("Shipping: $", shippingSignal));
-        shippingLabel.getStyle().set("display", "block").set("margin-bottom",
-                "0.5em");
+        shippingLabel.addClassName("total-line");
 
         var taxLabel = new Span(formatter("Tax (8%): $", taxSignal));
-        taxLabel.getStyle().set("display", "block").set("margin-bottom",
-                "0.5em");
+        taxLabel.addClassName("total-line");
 
         var divider = new Div();
-        divider.getStyle().set("border-top",
-                "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("margin", "0.75em 0");
+        divider.addClassName("totals-divider");
 
         var totalLabel = new Span(formatter("Total: $", totalSignal));
-        totalLabel.getStyle().set("display", "block").set("font-weight", "bold")
-                .set("font-size", "1.5em")
-                .set("color", "var(--aura-accent-color)");
+        totalLabel.addClassName("total-grand");
 
         totalsBox.add(summaryTitle, subtotalLabel, discountLabel, shippingLabel,
                 taxLabel, divider, totalLabel);
 
         // Info box
         var infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "💡 This use case demonstrates computed signals with multiple levels of calculation. "
                         + "The subtotal is computed from cart items, the discount is computed from the subtotal and discount code, "
@@ -201,13 +187,11 @@ public class UseCase06View extends VerticalLayout {
         row.setWidthFull();
         row.setAlignItems(Alignment.CENTER);
         row.setSpacing(true);
-        row.getStyle().set("background-color", "#ffffff")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "0.5em");
+        row.addClassName("product-row");
 
         var nameLabel = new Span(
                 format(product.name() + " - $", product.price()));
-        nameLabel.getStyle().set("flex-grow", "1").set("font-weight", "500");
+        nameLabel.addClassName("row-name");
 
         var addButton = new Button("Add",
                 e -> addToCart(product, cartItemsSignal));
@@ -224,14 +208,12 @@ public class UseCase06View extends VerticalLayout {
         row.setWidthFull();
         row.setAlignItems(Alignment.CENTER);
         row.setSpacing(true);
-        row.getStyle().set("background-color", "#ffffff")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "0.5em");
+        row.addClassName("cart-item-row");
 
         var nameLabel = new Span(
                 itemSignal.map(item -> format(item.product().name() + " - $",
                         item.product().price())));
-        nameLabel.getStyle().set("flex-grow", "1").set("font-weight", "500");
+        nameLabel.addClassName("row-name");
 
         var quantityField = new IntegerField();
         quantityField.setMin(1);
@@ -255,9 +237,7 @@ public class UseCase06View extends VerticalLayout {
                 formatter("$", itemSignal.map(CartItem::totalPrice)));
 
         itemTotalLabel.setWidth("100px");
-        itemTotalLabel.getStyle().set("text-align", "right")
-                .set("font-weight", "bold")
-                .set("color", "var(--aura-accent-color)");
+        itemTotalLabel.addClassName("item-total");
 
         var removeButton = new Button("Remove", e -> {
             cartItemsSignal.remove(itemSignal);

--- a/signals/src/main/java/com/example/usecase08/UseCase08View.java
+++ b/signals/src/main/java/com/example/usecase08/UseCase08View.java
@@ -8,6 +8,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -30,10 +31,12 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-08", layout = MainLayout.class)
 @PageTitle("Use Case 8: Multi-Step Wizard with Validation")
 @Menu(order = 8, title = "UC 8: Multi-Step Wizard")
+@StyleSheet("usecase08.css")
 @PermitAll
 public class UseCase08View extends VerticalLayout {
 
     public UseCase08View() {
+        addClassName("usecase08-view");
         setSpacing(true);
         setPadding(true);
 
@@ -144,7 +147,7 @@ public class UseCase08View extends VerticalLayout {
         step4Layout.add(new H3("Step 4: Review Your Information"));
 
         Div reviewDiv = new Div();
-        reviewDiv.getStyle().set("white-space", "pre-line");
+        reviewDiv.addClassName("review-content");
         // Update review when entering this step
         Signal.effect(reviewDiv, () -> {
             if (currentStepSignal.get() == Step.REVIEW) {
@@ -228,7 +231,7 @@ public class UseCase08View extends VerticalLayout {
             };
             return "Step " + stepNumber + " of 4";
         });
-        progressIndicator.getStyle().set("font-weight", "bold");
+        progressIndicator.addClassName("progress-indicator");
 
         add(title, description, progressIndicator, step1Layout, step2Layout,
                 step3Layout, step4Layout, navigationLayout);

--- a/signals/src/main/java/com/example/usecase09/UseCase09View.java
+++ b/signals/src/main/java/com/example/usecase09/UseCase09View.java
@@ -8,6 +8,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
@@ -27,10 +28,12 @@ import com.vaadin.flow.router.Route;
 @Route(value = "use-case-09", layout = MainLayout.class)
 @PageTitle("Use Case 9: Form with Binder Integration and Signal Validation")
 @Menu(order = 9, title = "UC 9: Binder Integration")
+@StyleSheet("usecase09.css")
 @PermitAll
 public class UseCase09View extends VerticalLayout {
 
     public UseCase09View() {
+        addClassName("usecase09-view");
         setSpacing(true);
         setPadding(true);
 
@@ -119,10 +122,8 @@ public class UseCase09View extends VerticalLayout {
         Span statusLabel = new Span(
                 () -> okStatusSignal.get() ? "Form is valid - Ready to submit"
                         : "Please complete all required fields correctly");
-        statusLabel.getStyle().bind("color",
-                () -> okStatusSignal.get() ? "green" : "orange");
-        statusLabel.getStyle().bind("font-weight",
-                () -> okStatusSignal.get() ? "bold" : "normal");
+        statusLabel.addClassName("status-label");
+        statusLabel.getClassNames().bind("is-valid", okStatusSignal);
         statusDiv.add(statusLabel);
 
         add(title, description, usernameField, emailField, passwordField,

--- a/signals/src/main/java/com/example/usecase10/UseCase10View.java
+++ b/signals/src/main/java/com/example/usecase10/UseCase10View.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -44,6 +45,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-10", layout = MainLayout.class)
 @PageTitle("Use Case 10: Bridging Events to Signals")
 @Menu(order = 10, title = "UC 10: Events to Signals")
+@StyleSheet("usecase10.css")
 @PermitAll
 public class UseCase10View extends VerticalLayout {
 
@@ -59,6 +61,7 @@ public class UseCase10View extends VerticalLayout {
             false);
 
     public UseCase10View() {
+        addClassName("usecase10-view");
         setSpacing(true);
         setPadding(true);
 
@@ -87,8 +90,7 @@ public class UseCase10View extends VerticalLayout {
 
         // --- Cards row ---
         Div cardsRow = new Div(uploadCard, shortcutCard, darkModeCard);
-        cardsRow.getStyle().set("display", "flex").set("flex-wrap", "wrap")
-                .set("gap", "1em");
+        cardsRow.addClassName("cards-row");
 
         // --- Composition section ---
         Div compositionSection = buildCompositionSection();
@@ -136,7 +138,7 @@ public class UseCase10View extends VerticalLayout {
         // Status label bound to signal
         Paragraph statusLabel = new Paragraph(
                 uploadStateSignal.map(UploadState::label));
-        statusLabel.getStyle().set("font-weight", "bold");
+        statusLabel.addClassName("upload-status-label");
 
         // Progress bar bound to signal
         ProgressBar progressBar = new ProgressBar(0, 100, 0);
@@ -158,14 +160,11 @@ public class UseCase10View extends VerticalLayout {
 
     private void buildShortcutCard(Div card) {
         Span shortcutLabel = new Span(lastShortcutSignal);
-        shortcutLabel.getStyle().set("font-weight", "bold").set("font-size",
-                "1.1em");
+        shortcutLabel.addClassName("shortcut-label");
 
         Paragraph hint = new Paragraph(
                 "Try pressing Ctrl+K, Ctrl+B, or Ctrl+J");
-        hint.getStyle().set("font-size", "0.85em")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-style", "italic");
+        hint.addClassName("hint-text");
 
         card.add(shortcutLabel, hint);
     }
@@ -181,9 +180,7 @@ public class UseCase10View extends VerticalLayout {
 
         Paragraph hint = new Paragraph(
                 "Try toggling OS dark mode or browser theme");
-        hint.getStyle().set("font-size", "0.85em")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-style", "italic");
+        hint.addClassName("hint-text");
 
         card.add(indicator, hint);
     }
@@ -194,13 +191,10 @@ public class UseCase10View extends VerticalLayout {
 
     private Div buildCompositionSection() {
         Div section = new Div();
-        section.getStyle().set("margin-top", "1.5em").set("padding", "1.5em")
-                .set("background-color",
-                        "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
-                .set("border-radius", "8px");
+        section.addClassName("composition-section");
 
         H3 heading = new H3("Composed System Summary");
-        heading.getStyle().set("margin-top", "0");
+        heading.addClassName("composition-heading");
 
         Paragraph intro = new Paragraph(
                 "All three signals combined into one Signal.computed() — "
@@ -228,12 +222,7 @@ public class UseCase10View extends VerticalLayout {
         });
 
         Paragraph summaryText = new Paragraph(summarySignal);
-        summaryText.getStyle().set("font-family", "monospace")
-                .set("font-size", "1.1em").set("font-weight", "bold")
-                .set("padding", "0.75em")
-                .set("background-color", "var(--aura-background-color)")
-                .set("border-radius", "4px").set("border",
-                        "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)");
+        summaryText.addClassName("composition-summary-text");
 
         section.add(heading, intro, summaryText);
         return section;
@@ -293,21 +282,13 @@ public class UseCase10View extends VerticalLayout {
 
     private Div createCard(String title, String subtitle) {
         Div card = new Div();
-        card.getStyle().set("border",
-                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("border-radius", "8px").set("padding", "1.5em")
-                .set("flex", "1 1 250px").set("min-width", "250px")
-                .set("background-color", "var(--aura-background-color)");
+        card.addClassName("card");
 
         H3 cardTitle = new H3(title);
-        cardTitle.getStyle().set("margin-top", "0").set("margin-bottom",
-                "0.25em");
+        cardTitle.addClassName("card-title");
 
         Paragraph cardSubtitle = new Paragraph(subtitle);
-        cardSubtitle.getStyle().set("font-family", "monospace")
-                .set("font-size", "0.8em")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("margin-top", "0").set("margin-bottom", "1em");
+        cardSubtitle.addClassName("card-subtitle");
 
         card.add(cardTitle, cardSubtitle);
         return card;
@@ -316,18 +297,14 @@ public class UseCase10View extends VerticalLayout {
     private Div createStatusIndicator(Signal<String> labelSignal,
             Signal<Boolean> activeSignal) {
         Div row = new Div();
-        row.getStyle().set("display", "flex").set("align-items", "center")
-                .set("gap", "0.5em");
+        row.addClassName("status-indicator");
 
         Span dot = new Span();
-        dot.getStyle().set("width", "12px").set("height", "12px")
-                .set("border-radius", "50%").set("display", "inline-block");
-        dot.getStyle().bind("background-color", () -> activeSignal.get()
-                ? "color-mix(in srgb, var(--vaadin-text-color) 80%, transparent)"
-                : "color-mix(in srgb, var(--vaadin-text-color) 30%, transparent)");
+        dot.addClassName("status-indicator-dot");
+        dot.getClassNames().bind("is-active", activeSignal);
 
         Span label = new Span(labelSignal);
-        label.getStyle().set("font-weight", "bold").set("font-size", "1.1em");
+        label.addClassName("status-indicator-label");
 
         row.add(dot, label);
         return row;

--- a/signals/src/main/java/com/example/usecase11/UseCase11View.java
+++ b/signals/src/main/java/com/example/usecase11/UseCase11View.java
@@ -7,6 +7,7 @@ import com.example.MissingAPI.ComponentSize;
 import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -34,6 +35,7 @@ import com.vaadin.flow.signals.Signal;
 @Route(value = "use-case-11", layout = MainLayout.class)
 @PageTitle("Use Case 11: Responsive Layout")
 @Menu(order = 11, title = "UC 11: Responsive Layout")
+@StyleSheet("usecase11.css")
 @PermitAll
 public class UseCase11View extends VerticalLayout {
 
@@ -48,6 +50,7 @@ public class UseCase11View extends VerticalLayout {
     private Div responsiveContent;
 
     public UseCase11View() {
+        addClassName("usecase11-view");
         setSpacing(true);
         setPadding(true);
         setSizeFull();
@@ -55,8 +58,7 @@ public class UseCase11View extends VerticalLayout {
         // Create responsive content container first so we can set up the size
         // signal before building other panels that depend on it
         responsiveContent = new Div();
-        responsiveContent.getStyle().set("padding", "1em").set("height", "100%")
-                .set("overflow-y", "auto").set("background-color", "#ffffff");
+        responsiveContent.addClassName("responsive-content");
         containerSizeSignal = MissingAPI.sizeSignal(responsiveContent);
         isSmall = containerSizeSignal
                 .map(size -> size.width() < SMALL_BREAKPOINT);
@@ -92,9 +94,7 @@ public class UseCase11View extends VerticalLayout {
 
         // Info box
         Div tipBox = new Div();
-        tipBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "1em").set("font-style", "italic");
+        tipBox.addClassName("tip-box");
         tipBox.add(new Paragraph(
                 "💡 Drag the splitter to resize the content area. "
                         + "The responsive content will adapt to different widths, "
@@ -106,12 +106,10 @@ public class UseCase11View extends VerticalLayout {
 
     private Div createInfoPanel() {
         Div panel = new Div();
-        panel.getStyle().set("padding", "1em")
-                .set("background-color", "#f5f5f5").set("height", "100%")
-                .set("overflow-y", "auto");
+        panel.addClassName("info-panel");
 
         H3 title = new H3("Info Panel");
-        title.getStyle().set("margin-top", "0");
+        title.addClassName("info-panel-title");
 
         Paragraph info = new Paragraph(
                 "This is a static side panel. The main content on the left adapts "
@@ -121,19 +119,15 @@ public class UseCase11View extends VerticalLayout {
 
         // Container size display
         Div sizeDisplay = new Div();
-        sizeDisplay.getStyle().set("background-color", "#ffffff")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin", "1em 0");
+        sizeDisplay.addClassName("size-display");
 
         Paragraph widthPara = new Paragraph(
                 () -> "Width: " + containerSizeSignal.get().width() + "px");
-        widthPara.getStyle().set("font-family", "monospace").set("margin",
-                "0.25em 0");
+        widthPara.addClassName("size-line");
 
         Paragraph heightPara = new Paragraph(
                 () -> "Height: " + containerSizeSignal.get().height() + "px");
-        heightPara.getStyle().set("font-family", "monospace").set("margin",
-                "0.25em 0");
+        heightPara.addClassName("size-line");
 
         Paragraph breakpointPara = new Paragraph(() -> {
             if (isSmall.get())
@@ -142,8 +136,7 @@ public class UseCase11View extends VerticalLayout {
                 return "💻 Medium (400-700px)";
             return "🖥️ Large (≥ 700px)";
         });
-        breakpointPara.getStyle().set("font-weight", "bold").set("margin",
-                "0.5em 0 0 0");
+        breakpointPara.addClassName("breakpoint-line");
 
         sizeDisplay.add(widthPara, heightPara, breakpointPara);
 
@@ -156,21 +149,21 @@ public class UseCase11View extends VerticalLayout {
         Div smallContent = createSection("📱 Small Width Layout",
                 "This is the mobile view (width < 400px). Navigation is stacked vertically, "
                         + "and complex UI elements are simplified or hidden.",
-                "#fff3e0");
+                "small-layout");
         smallContent.bindVisible(isSmall);
 
         // Medium width content
         Div mediumContent = createSection("💻 Medium Width Layout",
                 "This is the tablet view (400px ≤ width < 700px). Navigation can be horizontal, "
                         + "and more content is visible with a balanced layout.",
-                "#f3e5f5");
+                "medium-layout");
         mediumContent.bindVisible(isMedium);
 
         // Large width content
         Div largeContent = createSection("🖥️ Large Width Layout",
                 "This is the desktop view (width ≥ 700px). All features are visible, "
                         + "with multi-column layouts and detailed information.",
-                "#e8f5e9");
+                "large-layout");
         largeContent.bindVisible(isLarge);
 
         // Responsive card grid
@@ -182,18 +175,16 @@ public class UseCase11View extends VerticalLayout {
     }
 
     private Div createSection(String title, String content,
-            String backgroundColor) {
+            String variantClass) {
         Div section = new Div();
-        section.getStyle().set("background-color", backgroundColor)
-                .set("padding", "1.5em").set("border-radius", "8px")
-                .set("margin", "0.5em 0");
+        section.addClassName("section");
+        section.addClassName(variantClass);
 
         H3 sectionTitle = new H3(title);
-        sectionTitle.getStyle().set("margin-top", "0").set("margin-bottom",
-                "0.5em");
+        sectionTitle.addClassName("section-title");
 
         Paragraph sectionContent = new Paragraph(content);
-        sectionContent.getStyle().set("margin", "0");
+        sectionContent.addClassName("section-content");
 
         section.add(sectionTitle, sectionContent);
         return section;
@@ -201,35 +192,25 @@ public class UseCase11View extends VerticalLayout {
 
     private Component createResponsiveCardGrid() {
         Div gridContainer = new Div();
+        gridContainer.addClassName("card-grid");
 
         // Create sample cards
         for (int i = 1; i <= 6; i++) {
             Div card = new Div();
-            card.getStyle().set("background-color", "#f9f9f9")
-                    .set("border", "1px solid #e0e0e0")
-                    .set("border-radius", "4px").set("padding", "1em")
-                    .set("margin", "0.5em").set("flex", "1 1 150px")
-                    .set("min-width", "120px");
+            card.addClassName("grid-card");
 
             H3 cardTitle = new H3("Card " + i);
-            cardTitle.getStyle().set("margin", "0 0 0.5em 0").set("font-size",
-                    "1em");
+            cardTitle.addClassName("grid-card-title");
 
             Paragraph cardContent = new Paragraph("Content item " + i);
-            cardContent.getStyle().set("margin", "0").set("font-size",
-                    "0.875em");
+            cardContent.addClassName("grid-card-content");
 
             card.add(cardTitle, cardContent);
             gridContainer.add(card);
         }
 
-        // Set responsive flex layout based on container size
-        gridContainer.getStyle().set("display", "flex").set("margin", "1em 0");
-
-        gridContainer.getStyle().bind("flex-direction",
-                () -> isSmall.get() ? "column" : "row");
-        gridContainer.getStyle().bind("flex-wrap",
-                () -> isSmall.get() ? "nowrap" : "wrap");
+        // Toggle small layout class based on container size
+        gridContainer.getClassNames().bind("is-small", isSmall);
 
         return gridContainer;
     }

--- a/signals/src/main/java/com/example/usecase13/UseCase13View.java
+++ b/signals/src/main/java/com/example/usecase13/UseCase13View.java
@@ -13,6 +13,7 @@ import com.example.views.MainLayout;
 import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.card.Card;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -42,6 +43,7 @@ import com.vaadin.flow.signals.shared.SharedValueSignal;
 @Route(value = "use-case-13", layout = MainLayout.class)
 @PageTitle("Use Case 13: Real-Time Active Users")
 @Menu(order = 13, title = "UC 13: Real-Time Active Users")
+@StyleSheet("usecase13.css")
 @PermitAll
 public class UseCase13View extends VerticalLayout {
 
@@ -52,6 +54,7 @@ public class UseCase13View extends VerticalLayout {
         this.userSessionRegistry = userSessionRegistry;
         this.routeToTitleMap = buildRouteToTitleMap();
 
+        addClassName("usecase13-view");
         setSpacing(true);
         setPadding(true);
 
@@ -65,26 +68,20 @@ public class UseCase13View extends VerticalLayout {
                         + "Try opening multiple browser tabs with different users to see live synchronization!");
 
         Div counterBox = new Div();
-        counterBox.getStyle().set("background",
-                "color-mix(in srgb, var(--aura-accent-color) 10%, transparent)")
-                .set("padding", "1em").set("border-radius", "8px")
-                .set("border-left", "4px solid var(--aura-accent-color)")
-                .set("margin", "1em 0");
+        counterBox.addClassName("counter-box");
 
         H3 counterTitle = new H3(() -> "👥 Currently Online: "
                 + userSessionRegistry.getActiveUsersSignal().get().size());
-        counterTitle.getStyle().set("margin", "0");
+        counterTitle.addClassName("counter-title");
 
         counterBox.add(counterTitle);
 
         // User list container
         H3 userListTitle = new H3("Active Users");
-        userListTitle.getStyle().set("margin-top", "1.5em").set("margin-bottom",
-                "0.5em");
+        userListTitle.addClassName("user-list-title");
 
         Div userListContainer = new Div();
-        userListContainer.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("gap", "1em");
+        userListContainer.addClassName("user-list-container");
 
         // Get current session ID for highlighting
         String currentSessionId = SessionIdHelper.getCurrentSessionId();
@@ -96,13 +93,10 @@ public class UseCase13View extends VerticalLayout {
 
         // Educational info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background", "#e0f7fa").set("padding", "1em")
-                .set("border-radius", "8px")
-                .set("border-left", "4px solid #00BCD4")
-                .set("margin-top", "2em");
+        infoBox.addClassName("info-box");
 
         H3 infoTitle = new H3("💡 How This Works");
-        infoTitle.getStyle().set("margin-top", "0");
+        infoTitle.addClassName("info-title");
 
         VerticalLayout infoContent = new VerticalLayout();
         infoContent.setSpacing(false);
@@ -130,6 +124,7 @@ public class UseCase13View extends VerticalLayout {
     private Card createUserCard(SharedValueSignal<UserInfo> userSignal,
             String currentSessionId) {
         Card card = new Card();
+        card.addClassName("user-card");
 
         // These never change, so no need for signal bindings
         boolean isCurrentSession = userSignal.peek().sessionId()
@@ -138,16 +133,12 @@ public class UseCase13View extends VerticalLayout {
 
         // Highlight current user's session
         if (isCurrentSession) {
-            card.getStyle().set("border", "2px solid var(--aura-accent-color)")
-                    .set("background",
-                            "color-mix(in srgb, var(--aura-accent-color) 10%, transparent)");
+            card.addClassName("current-session");
         }
 
         // Dim inactive tabs
         var isTabActive = userSignal.map(info -> info.isTabActive());
-        card.getStyle().bind("opacity", () -> isTabActive.get() ? null : "0.6");
-        card.getStyle().bind("filter",
-                () -> isTabActive.get() ? null : "grayscale(30%)");
+        card.getClassNames().bind("tab-inactive", isTabActive.map(a -> !a));
 
         // Header: Tab Status + Avatar + Username/Nickname + Role Badge
         HorizontalLayout header = new HorizontalLayout();
@@ -158,7 +149,7 @@ public class UseCase13View extends VerticalLayout {
         Span tabIndicator = new Span(() -> isTabActive.get() ? "🟢" : "⚫");
         tabIndicator.getElement().bindAttribute("title",
                 () -> isTabActive.get() ? "Tab is active" : "Tab is inactive");
-        tabIndicator.getStyle().set("flex-shrink", "0");
+        tabIndicator.addClassName("tab-indicator");
 
         // Avatar with colored ring
         ColoredAvatar avatar = new ColoredAvatar(username,
@@ -202,7 +193,7 @@ public class UseCase13View extends VerticalLayout {
             }
             return displayName;
         });
-        nameSpan.getStyle().set("font-weight", "bold").set("flex-grow", "1");
+        nameSpan.addClassName("name-span");
 
         // Role badge
         Span roleBadge = createRoleBadge(username);
@@ -219,7 +210,7 @@ public class UseCase13View extends VerticalLayout {
         HorizontalLayout viewRow = new HorizontalLayout();
         viewRow.setAlignItems(FlexComponent.Alignment.CENTER);
         viewRow.setSpacing(false);
-        viewRow.getStyle().set("gap", "0.5em");
+        viewRow.addClassName("row-with-gap");
 
         Span viewIcon = new Span("📍");
         Signal<@Nullable String> currentView = userSignal
@@ -227,7 +218,7 @@ public class UseCase13View extends VerticalLayout {
         Span viewText = new Span(() -> "Viewing: "
                 + (currentView.get() != null ? formatViewName(currentView.get())
                         : "Unknown"));
-        viewText.getStyle().set("font-size", "var(--aura-font-size-s)");
+        viewText.addClassName("secondary-text");
 
         viewRow.add(viewIcon, viewText);
 
@@ -235,14 +226,13 @@ public class UseCase13View extends VerticalLayout {
         HorizontalLayout durationRow = new HorizontalLayout();
         durationRow.setAlignItems(FlexComponent.Alignment.CENTER);
         durationRow.setSpacing(false);
-        durationRow.getStyle().set("gap", "0.5em");
+        durationRow.addClassName("row-with-gap");
 
         Span durationIcon = new Span("🕐");
         Span durationTextSpan = new Span(
                 () -> "Online for " + formatDuration(System.currentTimeMillis()
                         - userSignal.get().sessionStartTime()));
-        durationTextSpan.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)");
+        durationTextSpan.addClassName("secondary-muted");
 
         durationRow.add(durationIcon, durationTextSpan);
 
@@ -250,7 +240,7 @@ public class UseCase13View extends VerticalLayout {
         HorizontalLayout interactionRow = new HorizontalLayout();
         interactionRow.setAlignItems(FlexComponent.Alignment.CENTER);
         interactionRow.setSpacing(false);
-        interactionRow.getStyle().set("gap", "0.5em");
+        interactionRow.addClassName("row-with-gap");
 
         Span interactionIcon = new Span("⚡");
         Span interactionTextSpan = new Span(() -> {
@@ -261,9 +251,7 @@ public class UseCase13View extends VerticalLayout {
                             + " ago";
             return interactionText;
         });
-        interactionTextSpan.getStyle()
-                .set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)");
+        interactionTextSpan.addClassName("secondary-muted");
 
         interactionRow.add(interactionIcon, interactionTextSpan);
 
@@ -293,10 +281,9 @@ public class UseCase13View extends VerticalLayout {
         };
 
         Span badge = new Span("[" + badgeLabel + "]");
-        badge.getStyle().set("padding", "2px 6px").set("border-radius", "4px")
-                .set("background", badgeColor).set("color", "white")
-                .set("font-size", "var(--aura-font-size-xs)")
-                .set("font-weight", "bold").set("flex-shrink", "0");
+        badge.addClassName("role-badge");
+        // Per-role color is dynamic — keep inline
+        badge.getStyle().set("background", badgeColor);
 
         return badge;
     }

--- a/signals/src/main/java/com/example/usecase14/UseCase14View.java
+++ b/signals/src/main/java/com/example/usecase14/UseCase14View.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -45,6 +46,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-14", layout = MainLayout.class)
 @PageTitle("Use Case 14: Async Data Loading")
 @Menu(order = 14, title = "UC 14: Async Data Loading")
+@StyleSheet("usecase14.css")
 @PermitAll
 public class UseCase14View extends VerticalLayout {
     private enum LoadingState {
@@ -64,6 +66,7 @@ public class UseCase14View extends VerticalLayout {
 
     public UseCase14View(AnalyticsService analyticsService) {
         this.analyticsService = analyticsService;
+        addClassName("usecase14-view");
         setSpacing(true);
         setPadding(true);
 
@@ -96,8 +99,7 @@ public class UseCase14View extends VerticalLayout {
         });
 
         Div errorToggle = new Div();
-        errorToggle.getStyle().set("display", "flex")
-                .set("align-items", "center").set("gap", "0.5em");
+        errorToggle.addClassName("error-toggle");
 
         var checkbox = new Checkbox("Simulate Error");
         checkbox.bindValue(shouldFailSignal, shouldFailSignal::set);
@@ -107,26 +109,19 @@ public class UseCase14View extends VerticalLayout {
 
         // State display box
         Div stateBox = new Div();
-        stateBox.getStyle().set("border",
-                "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("border-radius", "8px").set("padding", "1.5em")
-                .set("margin", "1em 0").set("min-height", "300px");
+        stateBox.addClassName("state-box");
 
         // Idle state
         Div idleContent = new Div();
         Paragraph idleMessage = new Paragraph(
                 "👆 Click 'Generate Analytics Report' to start the two-step process: fetch data, then generate comprehensive report with sales metrics and performance data");
-        idleMessage.getStyle()
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-style", "italic");
+        idleMessage.addClassName("idle-message");
         idleContent.add(idleMessage);
         idleContent.bindVisible(() -> stateSignal.get() == LoadingState.IDLE);
 
         // Loading state
         Div loadingContent = new Div();
-        loadingContent.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("align-items", "center")
-                .set("gap", "1em");
+        loadingContent.addClassName("loading-content");
 
         ProgressBar progressBar = new ProgressBar();
         progressBar.setIndeterminate(true);
@@ -138,7 +133,7 @@ public class UseCase14View extends VerticalLayout {
                 case GENERATING -> "Generating report... (2/2)";
                 default -> "";
                 });
-        loadingMessage.getStyle().set("color", "var(--aura-accent-color)");
+        loadingMessage.addClassName("loading-message");
 
         loadingContent.add(progressBar, loadingMessage);
         loadingContent.bindVisible(isLoadingSignal);
@@ -149,15 +144,11 @@ public class UseCase14View extends VerticalLayout {
                 reportDataSignal.map(report -> !report.isEmpty()
                         ? "Analytics Report - " + report.getPeriod()
                         : "Analytics Report"));
-        successTitle.getStyle().set("margin-top", "0").set("color",
-                "var(--aura-green)");
+        successTitle.addClassName("success-title");
 
         // Metrics grid
         Div metricsGrid = new Div();
-        metricsGrid.getStyle().set("display", "grid")
-                .set("grid-template-columns",
-                        "repeat(auto-fit, minmax(200px, 1fr))")
-                .set("gap", "1em").set("margin-top", "1em");
+        metricsGrid.addClassName("metrics-grid");
 
         // Create metric cards with signals
         Signal<String> revenueSignal = reportDataSignal.map(report -> {
@@ -204,17 +195,14 @@ public class UseCase14View extends VerticalLayout {
 
         // Error state
         Div errorContent = new Div();
-        errorContent.getStyle().set("background-color", "#ffebee")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("border-left", "4px solid var(--aura-red)");
+        errorContent.addClassName("error-content");
 
         H3 errorTitle = new H3("❌ Report Generation Failed");
-        errorTitle.getStyle().set("margin-top", "0").set("color",
-                "var(--aura-red)");
+        errorTitle.addClassName("error-title");
 
         Paragraph errorMessage = new Paragraph(
                 "Analytics report generation failed. Please contact the administrator.");
-        errorMessage.getStyle().set("margin", "0.5em 0");
+        errorMessage.addClassName("error-message");
 
         errorContent.add(errorTitle, errorMessage);
         errorContent.bindVisible(() -> stateSignal.get() == LoadingState.ERROR);
@@ -262,19 +250,17 @@ public class UseCase14View extends VerticalLayout {
 
         // Use title slot for label
         Span labelSpan = new Span(label);
-        labelSpan.getStyle().set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-weight", "500");
+        labelSpan.addClassName("metric-label");
         card.setTitle(labelSpan);
 
         // Main content slot for value display
         Span valueSpan = new Span(valueSignal);
-        valueSpan.getStyle().set("font-size", "2.5em")
-                .set("font-weight", "bold").set("color", color)
-                .set("line-height", "1");
+        valueSpan.addClassName("metric-value");
+        // Per-metric color is dynamic — keep inline
+        valueSpan.getStyle().set("color", color);
         card.add(valueSpan);
 
-        // Custom styling for colored border
+        // Per-metric border color is dynamic — keep inline
         card.getStyle().set("border-left", "4px solid " + color);
 
         return card;

--- a/signals/src/main/java/com/example/usecase15/UseCase15View.java
+++ b/signals/src/main/java/com/example/usecase15/UseCase15View.java
@@ -17,6 +17,7 @@ import org.jsoup.safety.Safelist;
 import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -49,6 +50,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-15", layout = MainLayout.class)
 @PageTitle("Use Case 15: Debounced Search")
 @Menu(order = 15, title = "UC 15: Debounced Search")
+@StyleSheet("usecase15.css")
 @PermitAll
 public class UseCase15View extends VerticalLayout {
 
@@ -110,6 +112,7 @@ public class UseCase15View extends VerticalLayout {
     private volatile @Nullable ScheduledFuture<?> pendingDebounce = null;
 
     public UseCase15View() {
+        addClassName("usecase15-view");
         setSpacing(true);
         setPadding(true);
 
@@ -140,48 +143,37 @@ public class UseCase15View extends VerticalLayout {
 
         // Search stats
         Div statsBox = new Div();
-        statsBox.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin", "1em 0").set("display", "flex").set("gap", "2em")
-                .set("flex-wrap", "wrap").set("align-items", "center");
+        statsBox.addClassName("stats-box");
 
         Div instantQueryDiv = new Div();
         Span instantLabel = new Span("Instant value: ");
-        instantLabel.getStyle().set("color",
-                "var(--vaadin-text-color-secondary)");
+        instantLabel.addClassName("stat-label");
         Span instantValue = new Span(instantQuerySignal
                 .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
-        instantValue.getStyle().set("font-family", "monospace")
-                .set("font-weight", "bold");
+        instantValue.addClassName("stat-value");
         instantQueryDiv.add(instantLabel, instantValue);
 
         Div debouncedQueryDiv = new Div();
         Span debouncedLabel = new Span("Debounced value (1000ms): ");
-        debouncedLabel.getStyle().set("color",
-                "var(--vaadin-text-color-secondary)");
+        debouncedLabel.addClassName("stat-label");
         Span debouncedValue = new Span(searchQuerySignal
                 .map(q -> q.isEmpty() ? "(empty)" : "\"" + q + "\""));
-        debouncedValue.getStyle().set("font-family", "monospace")
-                .set("font-weight", "bold")
-                .set("color", "var(--aura-accent-color)");
+        debouncedValue.addClassName("stat-value-accent");
         debouncedQueryDiv.add(debouncedLabel, debouncedValue);
 
         Div keystrokeCountDiv = new Div();
         Span keystrokeLabel = new Span("Keystrokes: ");
-        keystrokeLabel.getStyle().set("color",
-                "var(--vaadin-text-color-secondary)");
+        keystrokeLabel.addClassName("stat-label");
         Span keystrokeValue = new Span(
                 keystrokeCountSignal.map(String::valueOf));
-        keystrokeValue.getStyle().set("font-weight", "bold");
+        keystrokeValue.addClassName("stat-value-bold");
         keystrokeCountDiv.add(keystrokeLabel, keystrokeValue);
 
         Div searchCountDiv = new Div();
         Span countLabel = new Span("Searches performed: ");
-        countLabel.getStyle().set("color",
-                "var(--vaadin-text-color-secondary)");
+        countLabel.addClassName("stat-label");
         Span countValue = new Span(searchCountSignal.map(String::valueOf));
-        countValue.getStyle().set("font-weight", "bold").set("color",
-                "var(--aura-green)");
+        countValue.addClassName("stat-value-success");
         searchCountDiv.add(countLabel, countValue);
 
         statsBox.add(instantQueryDiv, debouncedQueryDiv, keystrokeCountDiv,
@@ -189,16 +181,15 @@ public class UseCase15View extends VerticalLayout {
 
         // Search status
         Div statusBox = new Div();
-        statusBox.getStyle().set("min-height", "30px").set("display", "flex")
-                .set("align-items", "center").set("gap", "0.5em");
+        statusBox.addClassName("status-box");
 
         Icon searchingIcon = new Icon(VaadinIcon.SPINNER);
-        searchingIcon.getStyle().set("animation", "spin 1s linear infinite");
+        searchingIcon.addClassName("searching-icon");
         searchingIcon.bindVisible(isSearchingSignal);
 
         Span statusText = new Span(isSearchingSignal
                 .map(searching -> searching ? "Searching..." : ""));
-        statusText.getStyle().set("color", "var(--aura-accent-color)");
+        statusText.addClassName("status-text");
 
         statusBox.add(searchingIcon, statusText);
 
@@ -221,9 +212,7 @@ public class UseCase15View extends VerticalLayout {
         H3 resultsTitle = new H3(resultsTitleSignal);
 
         Div resultsContainer = new Div();
-        resultsContainer.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("gap", "0.5em")
-                .set("margin-top", "1em");
+        resultsContainer.addClassName("results-container");
 
         // Peek rather than binding since products are immutable
         resultsContainer.bindChildren(searchResultsSignal,
@@ -231,19 +220,12 @@ public class UseCase15View extends VerticalLayout {
 
         // Info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "Debouncing is critical for performance in production applications. "
                         + "Without debouncing, typing 'laptop' would trigger 6 searches (one per character). "
                         + "With 1000ms debouncing, it triggers just 1 search after you stop typing. "
                         + "Compare the Keystrokes and Searches performed counters to see the savings."));
-
-        // Add CSS for spinner animation
-        getElement().executeJs("const style = document.createElement('style');"
-                + "style.textContent = '@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }';"
-                + "document.head.appendChild(style);");
 
         add(title, description, searchField, statsBox, statusBox, resultsTitle,
                 resultsContainer, infoBox);
@@ -318,15 +300,11 @@ public class UseCase15View extends VerticalLayout {
 
     private Div createProductCard(Product product) {
         Div card = new Div();
-        card.getStyle().set("background-color", "#ffffff").set("border",
-                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("border-radius", "4px").set("padding", "1em")
-                .set("display", "flex").set("justify-content", "space-between")
-                .set("align-items", "center");
+        card.addClassName("product-card");
 
         Div leftSide = new Div();
         Div nameDiv = new Div();
-        nameDiv.getStyle().set("font-weight", "bold");
+        nameDiv.addClassName("product-name");
 
         // Highlight matching text
         String query = searchQuerySignal.peek();
@@ -334,15 +312,13 @@ public class UseCase15View extends VerticalLayout {
                 highlightMatch(product.name(), query));
 
         Div categoryDiv = new Div(product.category());
-        categoryDiv.getStyle().set("font-size", "0.9em").set("color",
-                "var(--vaadin-text-color-secondary)");
+        categoryDiv.addClassName("product-category");
 
         leftSide.add(nameDiv, categoryDiv);
 
         Div priceDiv = new Div(
                 "$" + product.price().setScale(2, RoundingMode.HALF_UP));
-        priceDiv.getStyle().set("font-weight", "bold").set("color",
-                "var(--aura-accent-color)");
+        priceDiv.addClassName("product-price");
 
         card.add(leftSide, priceDiv);
         return card;

--- a/signals/src/main/java/com/example/usecase16/UseCase16View.java
+++ b/signals/src/main/java/com/example/usecase16/UseCase16View.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
@@ -43,6 +44,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-16", layout = MainLayout.class)
 @PageTitle("Use Case 16: URL State Integration")
 @Menu(order = 16, title = "UC 16: URL State Integration")
+@StyleSheet("usecase16.css")
 @PermitAll
 public class UseCase16View extends VerticalLayout
         implements BeforeEnterObserver {
@@ -90,6 +92,7 @@ public class UseCase16View extends VerticalLayout
     private boolean isInitializing = true;
 
     public UseCase16View() {
+        addClassName("usecase16-view");
         setSpacing(true);
         setPadding(true);
 
@@ -122,12 +125,10 @@ public class UseCase16View extends VerticalLayout
 
         // Current URL display
         Div urlBox = new Div();
-        urlBox.getStyle().set("background-color", "#e3f2fd")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin", "1em 0");
+        urlBox.addClassName("url-box");
 
         H3 urlTitle = new H3("Current URL");
-        urlTitle.getStyle().set("margin-top", "0");
+        urlTitle.addClassName("url-title");
 
         // Update URL display based on signals
         Signal<String> currentUrlSignal = Signal.computed(() -> {
@@ -139,10 +140,7 @@ public class UseCase16View extends VerticalLayout
         });
 
         Paragraph urlDisplay = new Paragraph(currentUrlSignal);
-        urlDisplay.getStyle().set("font-family", "monospace")
-                .set("word-break", "break-all")
-                .set("background-color", "#ffffff").set("padding", "0.5em")
-                .set("border-radius", "4px");
+        urlDisplay.addClassName("url-display");
 
         urlBox.add(urlTitle, urlDisplay);
 
@@ -172,18 +170,14 @@ public class UseCase16View extends VerticalLayout
         });
 
         Div resultsContainer = new Div();
-        resultsContainer.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("gap", "0.5em")
-                .set("margin-top", "1em");
+        resultsContainer.addClassName("results-container");
 
         resultsContainer.bindChildren(filteredArticlesSignal,
                 this::createArticleCard);
 
         // Info box
         Div infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "💡 Router integration with signals enables deep linking and shareable URLs. "
                         + "This pattern is essential for SEO, bookmarking, and sharing specific app states. "
@@ -202,29 +196,21 @@ public class UseCase16View extends VerticalLayout
         // Articles are read-only so no need to create bindings
         var article = articleSignal.peek();
         Div card = new Div();
-        card.getStyle().set("background-color", "#ffffff").set("border",
-                "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("border-radius", "4px").set("padding", "1em");
+        card.addClassName("article-card");
 
         Div headerDiv = new Div();
-        headerDiv.getStyle().set("display", "flex")
-                .set("justify-content", "space-between")
-                .set("align-items", "center").set("margin-bottom", "0.5em");
+        headerDiv.addClassName("article-header");
 
         Div titleDiv = new Div(article.title());
-        titleDiv.getStyle().set("font-weight", "bold").set("font-size",
-                "1.1em");
+        titleDiv.addClassName("article-title");
 
         Div categoryBadge = new Div(article.category());
-        categoryBadge.getStyle().set("background-color", "#e0e0e0")
-                .set("padding", "0.25em 0.5em").set("border-radius", "4px")
-                .set("font-size", "0.85em");
+        categoryBadge.addClassName("category-badge");
 
         headerDiv.add(titleDiv, categoryBadge);
 
         Div contentDiv = new Div(article.content());
-        contentDiv.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "0.9em");
+        contentDiv.addClassName("article-content");
 
         card.add(headerDiv, contentDiv);
         return card;

--- a/signals/src/main/java/com/example/usecase17/UseCase17View.java
+++ b/signals/src/main/java/com/example/usecase17/UseCase17View.java
@@ -12,6 +12,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -42,6 +43,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-17", layout = MainLayout.class)
 @PageTitle("Use Case 17: Custom PC Builder")
 @Menu(order = 17, title = "UC 17: PC Builder (70 signals)")
+@StyleSheet("usecase17.css")
 @PermitAll
 public class UseCase17View extends VerticalLayout {
 
@@ -131,6 +133,7 @@ public class UseCase17View extends VerticalLayout {
             true);
 
     public UseCase17View() {
+        addClassName("usecase17-view");
         setSpacing(true);
         setPadding(true);
         setWidthFull();
@@ -473,9 +476,7 @@ public class UseCase17View extends VerticalLayout {
 
         // Signal count display
         Div signalCountBox = new Div();
-        signalCountBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "0.75em").set("border-radius", "4px")
-                .set("margin-bottom", "1em").set("font-size", "0.9em");
+        signalCountBox.addClassName("signal-count-box");
         signalCountBox.add(new Span(
                 "📊 Active Signals: 12 component selections + 40+ computed values + 15 compatibility checks + 8 performance metrics = ~70 total signals"));
 
@@ -533,7 +534,7 @@ public class UseCase17View extends VerticalLayout {
         column.setPadding(false);
 
         H3 header = new H3("Component Selection");
-        header.getStyle().set("margin-top", "0");
+        header.addClassName("column-header");
 
         column.add(header);
         column.add(createComponentSelector("CPU", PCData.ALL_CPUS, cpuSignal));
@@ -570,12 +571,10 @@ public class UseCase17View extends VerticalLayout {
         column.setPadding(false);
 
         H3 header = new H3("Build Summary");
-        header.getStyle().set("margin-top", "0");
+        header.addClassName("column-header");
 
         Div summary = new Div();
-        summary.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("font-size", "0.9em");
+        summary.addClassName("summary-box");
 
         ListSignal<Component> selectedComponentsSignal = new ListSignal<>();
 
@@ -615,26 +614,24 @@ public class UseCase17View extends VerticalLayout {
         column.setPadding(false);
 
         H3 header = new H3("Statistics");
-        header.getStyle().set("margin-top", "0");
+        header.addClassName("column-header");
 
         // Price box
         Div priceBox = createStatBox("Total Price",
                 totalPriceSignal
                         .map(p -> "$" + p.setScale(0, RoundingMode.HALF_UP)),
-                "#e8f5e9");
+                "price-box");
 
         // Power box
         Div powerBox = new Div();
-        powerBox.getStyle().set("background-color", "#fff3e0")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "0.5em");
+        powerBox.addClassName("stat-box");
+        powerBox.addClassName("power-box");
 
         Span powerLabel = new Span("Power Consumption");
-        powerLabel.getStyle().set("display", "block").set("font-weight", "bold")
-                .set("margin-bottom", "0.5em");
+        powerLabel.addClassName("stat-label");
 
         Span powerValue = new Span(totalPowerSignal.map(p -> p + "W total"));
-        powerValue.getStyle().set("display", "block");
+        powerValue.addClassName("power-value");
 
         Signal<String> psuStatusText = Signal.computed(() -> {
             PSU psu = psuSignal.get();
@@ -647,37 +644,35 @@ public class UseCase17View extends VerticalLayout {
                             : "⚠ Insufficient");
         });
         Span psuStatus = new Span(psuStatusText);
-        psuStatus.getStyle().set("display", "block");
+        psuStatus.addClassName("power-value");
 
         powerBox.add(powerLabel, powerValue, psuStatus);
 
-        // Compatibility box
+        // Compatibility box (color depends on compatibility signal)
         Div compatBox = createStatBox("Compatibility",
                 compatibilityCheckCountSignal
                         .map(count -> count + "/13 checks passing"),
-                allCompatibleSignal.map(ok -> ok ? "#e8f5e9" : "#ffebee"));
+                "compat-box");
+        compatBox.getClassNames().bind("is-ok", allCompatibleSignal);
 
         // Performance box
         Div perfBox = new Div();
-        perfBox.getStyle().set("background-color", "#e3f2fd")
-                .set("padding", "1em").set("border-radius", "4px");
+        perfBox.addClassName("stat-box");
+        perfBox.addClassName("perf-box");
 
         Span perfLabel = new Span("Performance");
-        perfLabel.getStyle().set("display", "block").set("font-weight", "bold")
-                .set("margin-bottom", "0.5em");
+        perfLabel.addClassName("stat-label");
 
         Span perfRating = new Span(performanceRatingSignal);
-        perfRating.getStyle().set("display", "block").set("font-size", "1.2em")
-                .set("color", "var(--aura-accent-color)");
+        perfRating.addClassName("perf-rating");
 
         Span perfGaming = new Span(
                 gamingScoreSignal.map(s -> "Gaming: " + s + "/100"));
-        perfGaming.getStyle().set("display", "block").set("font-size", "0.9em");
+        perfGaming.addClassName("perf-detail");
 
         Span perfBottleneck = new Span(
                 bottleneckSignal.map(b -> "Bottleneck: " + b));
-        perfBottleneck.getStyle().set("display", "block").set("font-size",
-                "0.9em");
+        perfBottleneck.addClassName("perf-detail");
 
         perfBox.add(perfLabel, perfRating, perfGaming, perfBottleneck);
 
@@ -686,35 +681,16 @@ public class UseCase17View extends VerticalLayout {
     }
 
     private Div createStatBox(String label, Signal<String> valueSignal,
-            String bgColor) {
+            String variantClass) {
         Div box = new Div();
-        box.getStyle().set("background-color", bgColor).set("padding", "1em")
-                .set("border-radius", "4px").set("margin-bottom", "0.5em");
+        box.addClassName("stat-box");
+        box.addClassName(variantClass);
 
         Span labelSpan = new Span(label);
-        labelSpan.getStyle().set("display", "block").set("font-weight", "bold")
-                .set("margin-bottom", "0.5em");
+        labelSpan.addClassName("stat-label");
 
         Span valueSpan = new Span(valueSignal);
-        valueSpan.getStyle().set("display", "block").set("font-size", "1.2em");
-
-        box.add(labelSpan, valueSpan);
-        return box;
-    }
-
-    private Div createStatBox(String label, Signal<String> valueSignal,
-            Signal<String> bgColorSignal) {
-        Div box = new Div();
-        box.getStyle().bind("background-color", bgColorSignal);
-        box.getStyle().set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "0.5em");
-
-        Span labelSpan = new Span(label);
-        labelSpan.getStyle().set("display", "block").set("font-weight", "bold")
-                .set("margin-bottom", "0.5em");
-
-        Span valueSpan = new Span(valueSignal);
-        valueSpan.getStyle().set("display", "block").set("font-size", "1.2em");
+        valueSpan.addClassName("stat-value");
 
         box.add(labelSpan, valueSpan);
         return box;
@@ -722,12 +698,10 @@ public class UseCase17View extends VerticalLayout {
 
     private Div buildCompatibilitySection() {
         Div section = new Div();
-        section.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em");
+        section.addClassName("compatibility-section");
 
         H3 header = new H3("Compatibility Checks");
-        header.getStyle().set("margin-top", "0");
+        header.addClassName("column-header");
 
         Div checksContainer = new Div();
 
@@ -776,16 +750,14 @@ public class UseCase17View extends VerticalLayout {
 
     private Div createComponentSummaryItem(ValueSignal<Component> compSignal) {
         Div item = new Div();
-        item.getStyle().set("margin-bottom", "0.5em").set("display", "flex")
-                .set("justify-content", "space-between");
+        item.addClassName("component-summary-item");
 
         Span name = new Span(() -> compSignal.get().getName());
-        name.getStyle().set("flex", "1");
+        name.addClassName("component-summary-name");
 
         Span price = new Span(() -> "$" + compSignal.get().getPrice()
                 .setScale(0, RoundingMode.HALF_UP));
-        price.getStyle().set("font-weight", "bold").set("color",
-                "var(--aura-accent-color)");
+        price.addClassName("component-summary-price");
 
         item.add(name, price);
         return item;
@@ -793,8 +765,7 @@ public class UseCase17View extends VerticalLayout {
 
     private Div createCompatibilityCheckDiv(ValueSignal<String> statusSignal) {
         Div checkDiv = new Div();
-        checkDiv.getStyle().set("padding", "0.25em 0").set("font-size",
-                "0.9em");
+        checkDiv.addClassName("compatibility-check-row");
         checkDiv.getElement().bindProperty("innerHTML", statusSignal, null);
         return checkDiv;
     }

--- a/signals/src/main/java/com/example/usecase18/AbstractTaskChatView.java
+++ b/signals/src/main/java/com/example/usecase18/AbstractTaskChatView.java
@@ -141,7 +141,7 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         mainPanel.setHeightFull();
         mainPanel.setSpacing(true);
         mainPanel.setAlignItems(Alignment.STRETCH);
-        mainPanel.getStyle().set("min-height", "0");
+        mainPanel.addClassName("main-panel");
 
         // Left side: AI Chat
         VerticalLayout chatPanel = buildChatPanel();
@@ -161,10 +161,10 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         chatPanel.setHeightFull();
         chatPanel.setPadding(false);
         chatPanel.setSpacing(true);
-        chatPanel.getStyle().set("min-width", "0");
+        chatPanel.addClassName("chat-panel");
 
         H2 chatTitle = new H2("AI Task Assistant");
-        chatTitle.getStyle().set("margin", "0");
+        chatTitle.addClassName("panel-title");
 
         Paragraph chatDescription = new Paragraph(
                 "Chat with the AI to manage your tasks. Try commands like 'Add a task to buy groceries' or 'List my tasks'.");
@@ -181,10 +181,10 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         taskPanel.setHeightFull();
         taskPanel.setPadding(false);
         taskPanel.setSpacing(true);
-        taskPanel.getStyle().set("min-width", "0");
+        taskPanel.addClassName("task-panel");
 
         H2 title = new H2("Task Management");
-        title.getStyle().set("margin", "0");
+        title.addClassName("panel-title");
 
         VerticalLayout gridContainer = buildTaskGrid();
 
@@ -218,18 +218,16 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
     private Div createStatCard(String label, Signal<Integer> valueSignal,
             String color) {
         Div card = new Div();
-        card.getStyle().set("flex", "1").set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "8px")
-                .set("text-align", "center");
+        card.addClassName("stat-card");
 
         Span valueLabel = new Span();
         valueLabel.bindText(valueSignal.map(String::valueOf));
-        valueLabel.getStyle().set("font-size", "2em").set("font-weight", "bold")
-                .set("color", color).set("display", "block");
+        valueLabel.addClassName("stat-card-value");
+        // Per-card color is dynamic — keep inline
+        valueLabel.getStyle().set("color", color);
 
         Span titleLabel = new Span(label);
-        titleLabel.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "0.875em");
+        titleLabel.addClassName("stat-card-label");
 
         card.add(valueLabel, titleLabel);
         return card;
@@ -285,7 +283,7 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         gridContainer.setWidthFull();
         gridContainer.setPadding(false);
         gridContainer.setSpacing(false);
-        gridContainer.getStyle().set("min-height", "0");
+        gridContainer.addClassName("grid-container");
 
         Grid<Task> grid = new Grid<>(Task.class, false);
         grid.addColumn(Task::title).setHeader("Title").setFlexGrow(2)
@@ -387,7 +385,7 @@ public abstract class AbstractTaskChatView extends VerticalLayout {
         chatContainer.setWidthFull();
         chatContainer.setPadding(false);
         chatContainer.setSpacing(true);
-        chatContainer.getStyle().set("min-height", "0");
+        chatContainer.addClassName("chat-container");
 
         // Message list
         messageList = new MessageList();

--- a/signals/src/main/java/com/example/usecase18/UseCase18View.java
+++ b/signals/src/main/java/com/example/usecase18/UseCase18View.java
@@ -9,6 +9,7 @@ import com.example.security.CurrentUserSignal;
 import com.example.signals.UserSessionRegistry;
 import com.example.views.MainLayout;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -17,6 +18,7 @@ import com.vaadin.flow.signals.shared.SharedListSignal;
 @Route(value = "use-case-18", layout = MainLayout.class)
 @PageTitle("Use Case 18: LLM-Powered Task List")
 @Menu(order = 18, title = "UC 18: LLM Task List")
+@StyleSheet("usecase18.css")
 @PermitAll
 public class UseCase18View extends AbstractTaskChatView {
 
@@ -31,6 +33,7 @@ public class UseCase18View extends AbstractTaskChatView {
                 currentUserSignal, // Current user for avatar/name
                 userSessionRegistry // For display name lookup
         );
+        addClassName("usecase18-view");
 
         // Initialize sample tasks for single-user view
         tasksSignal.insertLast(Task

--- a/signals/src/main/java/com/example/usecase19/UseCase19View.java
+++ b/signals/src/main/java/com/example/usecase19/UseCase19View.java
@@ -9,6 +9,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
@@ -41,6 +42,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-19", layout = MainLayout.class)
 @PageTitle("Use Case 19: Parallel Loading")
 @Menu(order = 19, title = "UC 19: Parallel Loading")
+@StyleSheet("usecase19.css")
 @PermitAll
 public class UseCase19View extends VerticalLayout {
 
@@ -55,6 +57,7 @@ public class UseCase19View extends VerticalLayout {
 
     public UseCase19View(DataLoadingService dataLoadingService) {
         this.dataLoadingService = dataLoadingService;
+        addClassName("usecase19-view");
         setSpacing(true);
         setPadding(true);
 
@@ -86,9 +89,7 @@ public class UseCase19View extends VerticalLayout {
 
         // Items container with flexbox
         Div itemsContainer = new Div();
-        itemsContainer.getStyle().set("display", "flex")
-                .set("flex-wrap", "wrap").set("gap", "1em")
-                .set("margin", "1em 0");
+        itemsContainer.addClassName("items-container");
 
         // Bind cards to items signal
         itemsContainer.bindChildren(itemsSignal, this::createDataItemCard);
@@ -191,9 +192,7 @@ public class UseCase19View extends VerticalLayout {
      */
     private Card createDataItemCard(ValueSignal<DataItem> itemSignal) {
         Card card = new Card();
-
-        // Set card size for flex layout
-        card.getStyle().set("flex", "1 1 300px").set("min-width", "300px");
+        card.addClassName("data-card");
 
         // Header with item name
         Signal<String> nameSignal = itemSignal.map(DataItem::name);
@@ -203,10 +202,7 @@ public class UseCase19View extends VerticalLayout {
 
         // IDLE state content
         Div idleContent = new Div();
-        idleContent.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("align-items", "center")
-                .set("gap", "0.5em").set("padding", "2em")
-                .set("color", "var(--vaadin-text-color-secondary)");
+        idleContent.addClassName("idle-content");
 
         Icon idleIcon = new Icon(VaadinIcon.CIRCLE);
         idleIcon.setColor(
@@ -214,7 +210,7 @@ public class UseCase19View extends VerticalLayout {
         idleIcon.setSize("2em");
 
         Span idleText = new Span("Ready to load");
-        idleText.getStyle().set("font-style", "italic");
+        idleText.addClassName("idle-text");
 
         idleContent.add(idleIcon, idleText);
         Signal<Boolean> isIdleSignal = itemSignal
@@ -223,16 +219,14 @@ public class UseCase19View extends VerticalLayout {
 
         // LOADING state content
         Div loadingContent = new Div();
-        loadingContent.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("align-items", "center")
-                .set("gap", "1em").set("padding", "2em");
+        loadingContent.addClassName("loading-content");
 
         ProgressBar progressBar = new ProgressBar();
         progressBar.setIndeterminate(true);
         progressBar.setWidth("80%");
 
         Span loadingText = new Span("Loading...");
-        loadingText.getStyle().set("color", "var(--aura-accent-color)");
+        loadingText.addClassName("loading-text");
 
         loadingContent.add(progressBar, loadingText);
         Signal<Boolean> isLoadingSignal = itemSignal
@@ -241,28 +235,21 @@ public class UseCase19View extends VerticalLayout {
 
         // SUCCESS state content
         Div successContent = new Div();
-        successContent.getStyle().set("padding", "1em");
+        successContent.addClassName("success-content");
 
         Div successHeader = new Div();
-        successHeader.getStyle().set("display", "flex")
-                .set("align-items", "center").set("gap", "0.5em")
-                .set("margin-bottom", "1em");
+        successHeader.addClassName("state-header");
 
         Icon successIcon = new Icon(VaadinIcon.CHECK_CIRCLE);
         successIcon.setColor("var(--aura-green)");
 
         Span successLabel = new Span("Loaded successfully");
-        successLabel.getStyle().set("color", "var(--aura-green)")
-                .set("font-weight", "500");
+        successLabel.addClassName("success-label");
 
         successHeader.add(successIcon, successLabel);
 
         Div dataContent = new Div();
-        dataContent.getStyle().set("background-color",
-                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("white-space", "pre-line").set("font-family", "monospace")
-                .set("font-size", "0.875em");
+        dataContent.addClassName("data-content");
 
         Span dataText = new Span();
         dataText.bindText(
@@ -276,27 +263,21 @@ public class UseCase19View extends VerticalLayout {
 
         // ERROR state content
         Div errorContent = new Div();
-        errorContent.getStyle().set("padding", "1em");
+        errorContent.addClassName("error-content");
 
         Div errorHeader = new Div();
-        errorHeader.getStyle().set("display", "flex")
-                .set("align-items", "center").set("gap", "0.5em")
-                .set("margin-bottom", "1em");
+        errorHeader.addClassName("state-header");
 
         Icon errorIcon = new Icon(VaadinIcon.CLOSE_CIRCLE);
         errorIcon.setColor("var(--aura-red)");
 
         Span errorLabel = new Span("Failed to load");
-        errorLabel.getStyle().set("color", "var(--aura-red)").set("font-weight",
-                "500");
+        errorLabel.addClassName("error-label");
 
         errorHeader.add(errorIcon, errorLabel);
 
         Div errorMessage = new Div();
-        errorMessage.getStyle().set("background-color", "#ffebee")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-bottom", "1em")
-                .set("color", "var(--aura-red-text)");
+        errorMessage.addClassName("error-message");
 
         Span errorText = new Span();
         errorText.bindText(itemSignal.map(
@@ -315,17 +296,16 @@ public class UseCase19View extends VerticalLayout {
         // Add all state contents to card
         card.add(idleContent, loadingContent, successContent, errorContent);
 
-        // Card styling based on state - use direct style binding
-        card.getStyle().bind("border-left", itemSignal.map(item -> {
-            String color = switch (item.state()) {
-            case IDLE ->
-                "color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)";
-            case LOADING, GENERATING -> "var(--aura-accent-color)";
-            case SUCCESS -> "var(--aura-green)";
-            case ERROR -> "var(--aura-red)";
-            };
-            return "4px solid " + color;
-        }));
+        // Card styling based on state - swap state-* class
+        card.getClassNames().bind("state-idle",
+                itemSignal.map(i -> i.state() == LoadingState.IDLE));
+        card.getClassNames().bind("state-loading",
+                itemSignal.map(i -> i.state() == LoadingState.LOADING
+                        || i.state() == LoadingState.GENERATING));
+        card.getClassNames().bind("state-success",
+                itemSignal.map(i -> i.state() == LoadingState.SUCCESS));
+        card.getClassNames().bind("state-error",
+                itemSignal.map(i -> i.state() == LoadingState.ERROR));
 
         return card;
     }

--- a/signals/src/main/java/com/example/usecase20/UseCase20View.java
+++ b/signals/src/main/java/com/example/usecase20/UseCase20View.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.example.preferences.UserPreferences;
 import com.example.views.MainLayout;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
@@ -22,6 +23,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-20", layout = MainLayout.class)
 @PageTitle("Use Case 20: Session-scoped User Preferences")
 @Menu(order = 20, title = "UC 20: User Preferences")
+@StyleSheet("usecase20.css")
 @PermitAll
 public class UseCase20View extends VerticalLayout {
 
@@ -39,6 +41,7 @@ public class UseCase20View extends VerticalLayout {
     }
 
     public UseCase20View(UserPreferences preferences) {
+        addClassName("usecase20-view");
         setSpacing(true);
         setPadding(true);
 
@@ -62,19 +65,14 @@ public class UseCase20View extends VerticalLayout {
                     .filter(e -> e.getValue().equals(item))
                     .map(Map.Entry::getKey).findFirst().orElse(item);
             Div tile = new Div();
-            tile.getStyle().set("background-color", item)
-                    .set("padding", "0.5rem 0.75rem")
-                    .set("border-radius", "8px")
-                    .set("border",
-                            "1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                    .set("min-width", "180px").set("min-height", "40px")
-                    .set("display", "flex").set("align-items", "center")
-                    .set("justify-content", "center")
-                    .set("box-sizing", "border-box");
+            tile.addClassName("color-tile");
+            // Per-item color is dynamic — keep inline
+            tile.getStyle().set("background-color", item);
             String textColor = chooseTextColor(item);
             Paragraph text = new Paragraph(label);
-            text.getStyle().set("margin", "0").set("font-weight", "500")
-                    .set("color", textColor);
+            text.addClassName("color-tile-text");
+            // Per-item text color is dynamic — keep inline
+            text.getStyle().set("color", textColor);
             tile.add(text);
             return tile;
         }));

--- a/signals/src/main/java/com/example/usecase21/UseCase21View.java
+++ b/signals/src/main/java/com/example/usecase21/UseCase21View.java
@@ -9,6 +9,7 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -28,10 +29,12 @@ import static com.example.usecase21.TranslationService.translate;
 @Route(value = "use-case-21", layout = MainLayout.class)
 @PageTitle("Use Case 21: Signals-Based i18n")
 @Menu(order = 21, title = "UC 21: Signals-Based i18n")
+@StyleSheet("usecase21.css")
 @PermitAll
 public class UseCase21View extends VerticalLayout {
 
     public UseCase21View() {
+        addClassName("usecase21-view");
         setSpacing(true);
         setPadding(true);
 
@@ -149,7 +152,7 @@ public class UseCase21View extends VerticalLayout {
         Span languageLabel = new Span();
         languageLabel
                 .bindText(translate("uc21.status.language").map(s -> s + ":"));
-        languageLabel.getStyle().set("font-weight", "bold");
+        languageLabel.addClassName("row-label");
 
         Span languageValue = new Span();
         Signal<String> languageNameSignal = Signal.computed(() -> {
@@ -167,15 +170,12 @@ public class UseCase21View extends VerticalLayout {
 
         Span localeLabel = new Span();
         localeLabel.bindText(translate("uc21.status.locale").map(s -> s + ":"));
-        localeLabel.getStyle().set("font-weight", "bold");
+        localeLabel.addClassName("row-label");
 
         Span localeValue = new Span();
         localeValue.bindText(
                 UI.getCurrent().localeSignal().map(Locale::toLanguageTag));
-        localeValue.getStyle().set("font-family", "monospace").set(
-                "background-color",
-                "color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)")
-                .set("padding", "0.25em 0.5em").set("border-radius", "4px");
+        localeValue.addClassName("locale-code");
 
         localeRow.add(localeLabel, localeValue);
 
@@ -185,10 +185,7 @@ public class UseCase21View extends VerticalLayout {
 
     private Div createCard() {
         Div card = new Div();
-        card.getStyle().set("background-color",
-                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
-                .set("border-radius", "8px").set("padding", "1.5em")
-                .set("margin-bottom", "1em");
+        card.addClassName("card");
         return card;
     }
 }

--- a/signals/src/main/java/com/example/usecase22/UseCase22View.java
+++ b/signals/src/main/java/com/example/usecase22/UseCase22View.java
@@ -4,6 +4,7 @@ import jakarta.annotation.security.PermitAll;
 
 import com.example.views.MainLayout;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -23,10 +24,12 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-22", layout = MainLayout.class)
 @PageTitle("Use Case 22: Two-Way Mapped Signals")
 @Menu(order = 22, title = "UC 22: Two-Way Mapped Signals")
+@StyleSheet("usecase22.css")
 @PermitAll
 public class UseCase22View extends VerticalLayout {
 
     public UseCase22View() {
+        addClassName("usecase22-view");
         setSpacing(true);
         setPadding(true);
 
@@ -70,11 +73,10 @@ public class UseCase22View extends VerticalLayout {
         var section = new VerticalLayout();
         section.setSpacing(true);
         section.setPadding(true);
-        section.getStyle().set("background-color", "#e3f2fd")
-                .set("border-radius", "8px");
+        section.addClassName("personal-section");
 
         var sectionTitle = new H3("Personal Information");
-        sectionTitle.getStyle().set("margin-top", "0");
+        sectionTitle.addClassName("section-title");
 
         // First name - direct field mapping
         var firstNameField = new TextField("First Name");
@@ -109,8 +111,7 @@ public class UseCase22View extends VerticalLayout {
             Person p = personSignal.get();
             return "Full name: " + p.firstName() + " " + p.lastName();
         }));
-        fullNameLabel.getStyle().set("font-weight", "bold").set("color",
-                "var(--aura-accent-color)");
+        fullNameLabel.addClassName("full-name-label");
 
         section.add(sectionTitle, firstNameField, lastNameField, emailField,
                 ageField, fullNameLabel);
@@ -122,11 +123,10 @@ public class UseCase22View extends VerticalLayout {
         var section = new VerticalLayout();
         section.setSpacing(true);
         section.setPadding(true);
-        section.getStyle().set("background-color", "#fff3e0")
-                .set("border-radius", "8px");
+        section.addClassName("address-section");
 
         var sectionTitle = new H3("Address (Nested Mapping)");
-        sectionTitle.getStyle().set("margin-top", "0");
+        sectionTitle.addClassName("section-title");
 
         // Read-only mapped signal for Address
         Signal<Address> addressSignal = personSignal.map(Person::address);
@@ -163,9 +163,7 @@ public class UseCase22View extends VerticalLayout {
             return "Formatted: " + addr.street() + ", " + addr.city() + " "
                     + addr.zipCode() + ", " + addr.country();
         }));
-        formattedAddressLabel.getStyle().set("font-weight", "bold")
-                .set("color", "var(--aura-accent-color)")
-                .set("word-break", "break-word");
+        formattedAddressLabel.addClassName("formatted-address-label");
 
         section.add(sectionTitle, streetField, cityField, zipCodeField,
                 countryField, formattedAddressLabel);
@@ -174,17 +172,13 @@ public class UseCase22View extends VerticalLayout {
 
     private Div createStateDisplay(Signal<Person> personSignal) {
         var stateBox = new Div();
-        stateBox.getStyle().set("background-color", "#e8f5e9")
-                .set("padding", "1.5em").set("border-radius", "8px")
-                .set("margin-top", "1em");
+        stateBox.addClassName("state-box");
 
         var stateTitle = new H3("Live State (Single Source of Truth)");
-        stateTitle.getStyle().set("margin-top", "0");
+        stateTitle.addClassName("section-title");
 
         var stateDisplay = new Pre();
-        stateDisplay.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("overflow-x", "auto").set("font-size", "0.9em");
+        stateDisplay.addClassName("state-display");
         stateDisplay.bindText(
                 Signal.computed(() -> formatPersonAsJson(personSignal.get())));
 
@@ -194,18 +188,13 @@ public class UseCase22View extends VerticalLayout {
 
     private Div createPatternExplanation() {
         var infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1.5em").set("border-radius", "8px")
-                .set("margin-top", "1em");
+        infoBox.addClassName("info-box");
 
         var patternTitle = new H3("Pattern: Two-Way Mapped Signals");
-        patternTitle.getStyle().set("margin-top", "0");
+        patternTitle.addClassName("section-title");
 
         var codeExample = new Pre();
-        codeExample.getStyle().set("background-color", "#263238")
-                .set("color", "#aed581").set("padding", "1em")
-                .set("border-radius", "4px").set("overflow-x", "auto")
-                .set("font-size", "0.85em");
+        codeExample.addClassName("code-example");
         codeExample.setText(
                 """
                         // Direct field binding with map + updater
@@ -229,7 +218,7 @@ public class UseCase22View extends VerticalLayout {
                         + "This eliminates manual synchronization code and keeps your data model immutable.");
 
         var whenToUse = new H3("When to Use");
-        whenToUse.getStyle().set("margin-bottom", "0.5em");
+        whenToUse.addClassName("when-to-use");
 
         var useCases = new Paragraph(
                 "Use two-way mapped signals for simple field-to-record binding without validation. "

--- a/signals/src/main/java/com/example/usecase23/UseCase23View.java
+++ b/signals/src/main/java/com/example/usecase23/UseCase23View.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.charts.model.Marker;
 import com.vaadin.flow.component.charts.model.PlotOptionsAreaspline;
 import com.vaadin.flow.component.charts.model.PointPlacement;
 import com.vaadin.flow.component.charts.model.XAxis;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
@@ -46,6 +47,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @PageTitle("Use Case 23: Real-time Dashboard")
 @Route(value = "use-case-23", layout = MainLayout.class)
 @Menu(order = 23, title = "UC 23: Real-time Dashboard")
+@StyleSheet("usecase23.css")
 @PermitAll
 public class UseCase23View extends Main {
 
@@ -69,7 +71,7 @@ public class UseCase23View extends Main {
     private @Nullable String taskId;
 
     public UseCase23View(SchedulerService schedulerService) {
-        addClassName("dashboard-view");
+        addClassName("usecase23-view");
 
         Board board = new Board();
         board.addRow(
@@ -268,12 +270,10 @@ public class UseCase23View extends Main {
 
     private HorizontalLayout createHeader(String title, String subtitle) {
         H2 h2 = new H2(title);
-        h2.getStyle().set("font-size", "var(--aura-font-size-xl)").set("margin",
-                "0");
+        h2.addClassName("panel-header-title");
 
         Span span = new Span(subtitle);
-        span.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-xs)");
+        span.addClassName("panel-header-subtitle");
 
         VerticalLayout column = new VerticalLayout(h2, span);
         column.setPadding(false);
@@ -401,13 +401,10 @@ public class UseCase23View extends Main {
                     .map(percentage -> percentage > 0);
 
             H2 h2 = new H2(title);
-            h2.getStyle().set("font-weight", "400").set("margin", "0")
-                    .set("color", "var(--vaadin-text-color-secondary)")
-                    .set("font-size", "var(--aura-font-size-xs)");
+            h2.addClassName("highlight-card-title");
 
             Span valueSpan = new Span();
-            valueSpan.getStyle().set("font-weight", "600").set("font-size",
-                    "2.5em");
+            valueSpan.addClassName("highlight-card-value");
             valueSpan.bindText(signal.map(format::apply));
 
             Span percentageSpan = new Span();
@@ -416,7 +413,7 @@ public class UseCase23View extends Main {
 
             Icon icon = new Icon(iconSignal);
             icon.setSize("10px");
-            icon.getStyle().setMarginRight("4px").setMarginLeft("0");
+            icon.addClassName("highlight-card-icon");
 
             Span badge = new Span();
             badge.add(icon, percentageSpan);
@@ -426,7 +423,7 @@ public class UseCase23View extends Main {
                             : List.of("badge", "error"));
 
             add(h2, valueSpan, badge);
-            getStyle().setGap("5px");
+            addClassName("highlight-card");
         }
 
         private String getPrefix(double percentage) {

--- a/signals/src/main/java/com/example/usecase24/UseCase24View.java
+++ b/signals/src/main/java/com/example/usecase24/UseCase24View.java
@@ -11,6 +11,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
@@ -31,6 +32,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-24", layout = MainLayout.class)
 @PageTitle("Use Case 24: VirtualList with Signal Data Source")
 @Menu(order = 24, title = "UC 24: VirtualList Notifications")
+@StyleSheet("usecase24.css")
 @PermitAll
 public class UseCase24View extends VerticalLayout {
 
@@ -38,6 +40,7 @@ public class UseCase24View extends VerticalLayout {
             .ofPattern("MMM d, yyyy HH:mm");
 
     public UseCase24View() {
+        addClassName("usecase24-view");
         setSpacing(true);
         setPadding(true);
 
@@ -153,17 +156,11 @@ public class UseCase24View extends VerticalLayout {
         // Header row with count and unread badge
         var countLabel = new Span();
         countLabel.bindText(countLabelSignal);
-        countLabel.getStyle().set("color",
-                "var(--vaadin-text-color-secondary)");
+        countLabel.addClassName("count-label");
 
         var unreadBadge = new Span();
         unreadBadge.bindText(unreadCountSignal.map(c -> c + " unread"));
-        unreadBadge.getStyle()
-                .set("background-color", "var(--aura-accent-color)")
-                .set("color", "white").set("padding", "0.25em 0.75em")
-                .set("border-radius", "1em")
-                .set("font-size", "var(--aura-font-size-s)")
-                .set("font-weight", "bold");
+        unreadBadge.addClassName("unread-badge");
         unreadBadge.bindVisible(unreadCountSignal.map(c -> c > 0));
 
         var headerRow = new HorizontalLayout(countLabel, unreadBadge);
@@ -184,16 +181,12 @@ public class UseCase24View extends VerticalLayout {
         // Empty state
         var emptyState = new Paragraph(
                 "No notifications to display. Try adjusting your filters or adding new notifications.");
-        emptyState.getStyle().set("text-align", "center").set("padding", "2em")
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-style", "italic");
+        emptyState.addClassName("empty-state");
         emptyState.bindVisible(filteredSignal.map(List::isEmpty));
 
         // Info box
         var infoBox = new Div();
-        infoBox.getStyle().set("background-color", "#e0f7fa")
-                .set("padding", "1em").set("border-radius", "4px")
-                .set("margin-top", "1em").set("font-style", "italic");
+        infoBox.addClassName("info-box");
         infoBox.add(new Paragraph(
                 "This use case demonstrates VirtualList bound to a signal-based data source. "
                         + "A ListSignal<Notification> is the source of truth. A computed signal filters by type and read status, "
@@ -208,67 +201,52 @@ public class UseCase24View extends VerticalLayout {
     Div createNotificationCard(Notification notification,
             ListSignal<Notification> notificationsSignal) {
         var card = new Div();
-        card.getStyle().set("display", "flex").set("align-items", "flex-start")
-                .set("gap", "1em").set("padding", "1em")
-                .set("margin", "0.25em 0").set("border-radius", "8px")
-                .set("border-left",
-                        "4px solid " + getTypeColor(notification.type()));
-
-        if (notification.read()) {
-            card.getStyle().set("background-color", "#fafafa");
-        } else {
-            card.getStyle().set("background-color", "#e3f2fd");
-        }
+        card.addClassName("notification-card");
+        card.addClassName(notification.read() ? "is-read" : "is-unread");
+        // Per-type border color is dynamic — keep inline
+        card.getStyle().set("border-left",
+                "4px solid " + getTypeColor(notification.type()));
 
         // Icon
         var icon = new Icon(getTypeIcon(notification.type()));
         icon.setSize("24px");
         icon.setColor(getTypeColor(notification.type()));
-        icon.getStyle().set("flex-shrink", "0").set("margin-top", "0.15em");
+        icon.addClassName("notification-icon");
 
         // Content
         var content = new Div();
-        content.getStyle().set("flex-grow", "1").set("min-width", "0");
+        content.addClassName("notification-content");
 
         // Title row with badge
         var titleSpan = new Span(notification.title());
-        titleSpan.getStyle().set("font-weight",
-                notification.read() ? "normal" : "bold");
+        titleSpan.addClassName("notification-title");
+        if (!notification.read()) {
+            titleSpan.addClassName("is-unread");
+        }
 
         var typeBadge = new Span(notification.type().name());
-        typeBadge.getStyle()
-                .set("background-color", getTypeColor(notification.type()))
-                .set("color", "white").set("padding", "0.1em 0.5em")
-                .set("border-radius", "0.75em")
-                .set("font-size", "var(--aura-font-size-xs)")
-                .set("margin-left", "0.5em");
+        typeBadge.addClassName("type-badge");
+        // Per-type color is dynamic — keep inline
+        typeBadge.getStyle().set("background-color",
+                getTypeColor(notification.type()));
 
         var titleRow = new Div(titleSpan, typeBadge);
-        titleRow.getStyle().set("display", "flex").set("align-items", "center")
-                .set("margin-bottom", "0.25em");
+        titleRow.addClassName("notification-title-row");
 
         // Message
         var messageSpan = new Span(notification.message());
-        messageSpan.getStyle()
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-s)")
-                .set("display", "block").set("margin-bottom", "0.5em");
+        messageSpan.addClassName("notification-message");
 
         // Timestamp
         var timestampSpan = new Span(
                 notification.timestamp().format(TIME_FORMAT));
-        timestampSpan.getStyle()
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-xs)")
-                .set("display", "block");
+        timestampSpan.addClassName("notification-timestamp");
 
         content.add(titleRow, messageSpan, timestampSpan);
 
         // Actions
         var actions = new Div();
-        actions.getStyle().set("display", "flex")
-                .set("flex-direction", "column").set("gap", "0.25em")
-                .set("flex-shrink", "0");
+        actions.addClassName("notification-actions");
 
         var toggleReadButton = new Button(
                 notification.read() ? "Mark Unread" : "Mark Read", e -> {

--- a/signals/src/main/java/com/example/usecase25/UseCase25View.java
+++ b/signals/src/main/java/com/example/usecase25/UseCase25View.java
@@ -11,6 +11,7 @@ import com.example.usecase23.SchedulerService;
 import com.example.views.MainLayout;
 import org.jspecify.annotations.Nullable;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Main;
@@ -27,6 +28,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @PageTitle("Use Case 25: Stock Ticker")
 @Route(value = "use-case-25", layout = MainLayout.class)
 @Menu(order = 25, title = "UC 25: Stock Ticker")
+@StyleSheet("usecase25.css")
 @PermitAll
 public class UseCase25View extends Main {
 
@@ -34,9 +36,7 @@ public class UseCase25View extends Main {
     private @Nullable String taskId;
 
     public UseCase25View(SchedulerService schedulerService) {
-        addClassName("stock-ticker-view");
-        getStyle().set("display", "block").set("padding",
-                "var(--vaadin-gap-l)");
+        addClassName("usecase25-view");
 
         var title = new H2("Use Case 25: Stock Ticker");
         var description = new Paragraph(
@@ -49,8 +49,7 @@ public class UseCase25View extends Main {
 
         // Stock rows container
         Div stockList = new Div();
-        stockList.getStyle().set("display", "flex").set("flex-direction",
-                "column");
+        stockList.addClassName("stock-list");
 
         for (StockQuote initial : StockPriceSimulator.INITIAL_STOCKS) {
             var stockSignal = stockSignals.insertLast(initial);
@@ -75,15 +74,7 @@ public class UseCase25View extends Main {
 
     private Div createHeaderRow() {
         Div row = new Div();
-        row.getStyle().set("display", "grid")
-                .set("grid-template-columns", "80px 1fr 120px 100px 100px")
-                .set("gap", "var(--vaadin-gap-s)")
-                .set("padding", "var(--vaadin-gap-s) var(--vaadin-gap-m)")
-                .set("border-bottom",
-                        "2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)")
-                .set("font-weight", "bold")
-                .set("font-size", "var(--aura-font-size-s)")
-                .set("color", "var(--vaadin-text-color-secondary)");
+        row.addClassName("header-row");
 
         row.add(headerCell("Symbol"), headerCell("Company"),
                 headerCell("Price", true), headerCell("Change", true),
@@ -98,39 +89,30 @@ public class UseCase25View extends Main {
     private Span headerCell(String text, boolean alignRight) {
         Span span = new Span(text);
         if (alignRight) {
-            span.getStyle().set("text-align", "right");
+            span.addClassName("header-cell-right");
         }
         return span;
     }
 
     private Div createStockRow(ValueSignal<StockQuote> stockSignal) {
         Div row = new Div();
-        row.getStyle().set("display", "grid")
-                .set("grid-template-columns", "80px 1fr 120px 100px 100px")
-                .set("gap", "var(--vaadin-gap-s)")
-                .set("padding", "var(--vaadin-gap-s) var(--vaadin-gap-m)")
-                .set("align-items", "center").set("border-bottom",
-                        "1px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent)");
+        row.addClassName("stock-row");
 
         // Symbol
         Span symbol = new Span();
         symbol.bindText(stockSignal.map(StockQuote::symbol));
-        symbol.getStyle().set("font-weight", "bold").set("font-family",
-                "monospace");
+        symbol.addClassName("symbol-cell");
 
         // Company name
         Span name = new Span();
         name.bindText(stockSignal.map(StockQuote::name));
-        name.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-s)");
+        name.addClassName("name-cell");
 
         // Price
         Span price = new Span();
         price.bindText(stockSignal
                 .map(q -> "$" + q.price().setScale(2, RoundingMode.HALF_UP)));
-        price.getStyle().set("text-align", "right")
-                .set("font-family", "monospace").set("font-weight", "600")
-                .set("border-radius", "4px").set("padding", "2px 6px");
+        price.addClassName("price-cell");
 
         // Change
         Span change = new Span();
@@ -139,8 +121,7 @@ public class UseCase25View extends Main {
                     : "";
             return prefix + q.change().setScale(2, RoundingMode.HALF_UP);
         }));
-        change.getStyle().set("text-align", "right").set("font-family",
-                "monospace");
+        change.addClassName("change-cell");
 
         // % Change
         Span pctChange = new Span();
@@ -151,8 +132,7 @@ public class UseCase25View extends Main {
             return prefix + q.changePercent().setScale(2, RoundingMode.HALF_UP)
                     + "%";
         }));
-        pctChange.getStyle().set("text-align", "right").set("font-family",
-                "monospace");
+        pctChange.addClassName("change-cell");
 
         // React to price changes with flash effect
         List<Element> flashTargets = List.of(price.getElement(),

--- a/signals/src/main/java/com/example/usecase26/UseCase26View.java
+++ b/signals/src/main/java/com/example/usecase26/UseCase26View.java
@@ -8,6 +8,7 @@ import com.example.views.MainLayout;
 import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
@@ -26,6 +27,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 @Route(value = "use-case-26", layout = MainLayout.class)
 @PageTitle("Use Case 26: Lazy Component Creation")
 @Menu(order = 26, title = "UC 26: Lazy Creation")
+@StyleSheet("usecase26.css")
 @PermitAll
 public class UseCase26View extends VerticalLayout {
 
@@ -34,6 +36,7 @@ public class UseCase26View extends VerticalLayout {
     private final ListSignal<String> creationLog = new ListSignal<>();
 
     public UseCase26View() {
+        addClassName("usecase26-view");
         setSpacing(true);
         setPadding(true);
 
@@ -66,8 +69,7 @@ public class UseCase26View extends VerticalLayout {
 
         // Creation log panel
         var logPanel = new Div();
-        logPanel.getStyle().set("background-color", "#f5f5f5")
-                .set("padding", "1em").set("border-radius", "4px");
+        logPanel.addClassName("log-panel");
         logPanel.add(new H3("Creation Log"));
         var logEntries = new Div();
         logEntries.bindChildren(creationLog,
@@ -76,7 +78,7 @@ public class UseCase26View extends VerticalLayout {
 
         // Main content: forms on the left, log on the right
         var formsArea = new Div(countrySelect, usWrapper, jpWrapper);
-        formsArea.getStyle().set("flex", "1");
+        formsArea.addClassName("forms-area");
 
         var contentLayout = new HorizontalLayout(formsArea, logPanel);
         contentLayout.setWidthFull();

--- a/signals/src/main/java/com/example/usecase27/UseCase27Layout.java
+++ b/signals/src/main/java/com/example/usecase27/UseCase27Layout.java
@@ -6,6 +6,7 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
@@ -25,6 +26,7 @@ import com.vaadin.flow.signals.Signal;
  * every subsequent navigation.
  */
 @ParentLayout(MainLayout.class)
+@StyleSheet("usecase27.css")
 @PermitAll
 public class UseCase27Layout extends Div implements RouterLayout {
 
@@ -36,22 +38,16 @@ public class UseCase27Layout extends Div implements RouterLayout {
     private int updateCount;
 
     public UseCase27Layout() {
+        addClassName("usecase27-view");
+
         breadcrumb.setId(BREADCRUMB_ID);
-        breadcrumb.getStyle().set("padding", "0.5em 0.75em").set(
-                "background-color",
-                "color-mix(in srgb, var(--vaadin-text-color) 5%, transparent)")
-                .set("border-radius", "4px")
-                .set("font-family", "var(--aura-font-family)");
+        breadcrumb.addClassName("breadcrumb");
 
         updateBadge.setId(UPDATE_COUNT_ID);
-        updateBadge.getStyle()
-                .set("color", "var(--vaadin-text-color-secondary)")
-                .set("font-size", "var(--aura-font-size-s)")
-                .set("margin-left", "0.75em");
+        updateBadge.addClassName("update-badge");
 
         Div header = new Div(breadcrumb, updateBadge);
-        header.getStyle().set("display", "flex").set("align-items", "center")
-                .set("padding", "0.5em 1em");
+        header.addClassName("layout-header");
         getElement().appendChild(header.getElement());
 
         Signal.effect(this, () -> {
@@ -88,8 +84,7 @@ public class UseCase27Layout extends Div implements RouterLayout {
 
     private static Span separator() {
         Span s = new Span(" › ");
-        s.getStyle().set("color", "var(--vaadin-text-color-secondary)")
-                .set("margin", "0 0.4em");
+        s.addClassName("breadcrumb-separator");
         return s;
     }
 }

--- a/signals/src/main/resources/META-INF/resources/muc01.css
+++ b/signals/src/main/resources/META-INF/resources/muc01.css
@@ -1,0 +1,41 @@
+.muc01-view {
+    .messages-container {
+        background-color: #f5f5f5;
+        border: 1px solid #e0e0e0;
+        border-radius: 4px;
+        padding: 1em;
+        min-height: 200px;
+        overflow-y: auto;
+        max-height: 400px;
+    }
+    .message-count {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-s);
+    }
+    .message-row {
+        background-color: #ffffff;
+        padding: 0.75em;
+        margin-bottom: 0.5em;
+        border-radius: 4px;
+        display: flex;
+        gap: 0.75em;
+    }
+    .message-content {
+        flex: 1;
+    }
+    .message-header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 0.5em;
+    }
+    .message-author {
+        font-weight: bold;
+    }
+    .message-timestamp {
+        font-size: 0.85em;
+        color: var(--vaadin-text-color-secondary);
+    }
+    .message-text {
+        color: var(--vaadin-text-color);
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/muc02.css
+++ b/signals/src/main/resources/META-INF/resources/muc02.css
@@ -1,0 +1,63 @@
+.muc02-view {
+    .cursor-canvas {
+        position: relative;
+        background-color: #f5f5f5;
+        outline: 2px solid #e0e0e0;
+        border-radius: 4px;
+        height: 400px;
+        margin: 1em 0;
+        cursor: crosshair;
+    }
+    .cursors-container {
+        position: relative;
+    }
+    .users-list {
+        background-color: #e3f2fd;
+        padding: 1em;
+        border-radius: 4px;
+    }
+    .info-box {
+        background-color: #fff3e0;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .cursor-list-item {
+        margin-bottom: 0.5em;
+    }
+    .color-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+    .user-label {
+        font-weight: 500;
+    }
+    .position-label {
+        font-family: monospace;
+        color: var(--vaadin-text-color-secondary);
+        margin-left: auto;
+    }
+    .cursor-indicator {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid white;
+        pointer-events: none;
+        transform: translate(-50%, -50%);
+        z-index: 1000;
+    }
+    .cursor-indicator-label {
+        position: absolute;
+        top: 25px;
+        left: 0;
+        white-space: nowrap;
+        color: white;
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 0.75em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/muc03.css
+++ b/signals/src/main/resources/META-INF/resources/muc03.css
@@ -1,0 +1,49 @@
+.muc03-view {
+    .round-status {
+        font-size: 1.2em;
+        font-weight: bold;
+        margin-bottom: 0.5em;
+    }
+    .clicks-status {
+        font-size: 1em;
+        color: var(--vaadin-text-color-secondary);
+    }
+    .game-area {
+        position: relative;
+        background-color: #f5f5f5;
+        border: 2px solid #e0e0e0;
+        border-radius: 4px;
+        height: 300px;
+        margin: 1em 0;
+    }
+    .target-button {
+        position: absolute;
+        z-index: 10;
+    }
+    .leaderboard {
+        background-color: #e3f2fd;
+        padding: 1em;
+        border-radius: 4px;
+    }
+    .info-box {
+        background-color: #fff3e0;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .leaderboard-item {
+        padding: 0.5em;
+        border-radius: 4px;
+        background-color: transparent;
+        font-weight: normal;
+    }
+    .leaderboard-item.current-session {
+        background-color: #fff3e0;
+        font-weight: bold;
+    }
+    .leaderboard-avatar {
+        border-radius: 50%;
+        object-fit: cover;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/muc04.css
+++ b/signals/src/main/resources/META-INF/resources/muc04.css
@@ -1,0 +1,16 @@
+.muc04-view {
+    .editors-panel {
+        background-color: #e3f2fd;
+        padding: 1em;
+        border-radius: 4px;
+    }
+    .editors-panel-field-label {
+        font-weight: bold;
+    }
+    .editors-panel-names-container {
+        display: inline;
+    }
+    .editor-name {
+        margin-right: 0.5em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/muc06.css
+++ b/signals/src/main/resources/META-INF/resources/muc06.css
@@ -1,0 +1,37 @@
+.muc06-view {
+    .stats-box {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+        display: flex;
+        gap: 2em;
+    }
+    .stat-label {
+        font-weight: 500;
+    }
+    .stat-completed {
+        color: var(--aura-green);
+    }
+    .stat-pending {
+        color: var(--aura-accent-color);
+    }
+    .tasks-container {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        margin-bottom: 1em;
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .task-row {
+        background-color: #ffffff;
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        border-radius: 4px;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/styles.css
+++ b/signals/src/main/resources/META-INF/resources/styles.css
@@ -33,19 +33,3 @@ html {
     --vaadin-user-color-29: #FFD600; /* Yellow Accent */
 }
 
-.price-up {
-    color: var(--aura-green);
-    animation: flash-green 0.6s ease-out;
-}
-.price-down {
-    color: var(--aura-red);
-    animation: flash-red 0.6s ease-out;
-}
-@keyframes flash-green {
-    0% { background-color: rgba(76, 175, 80, 0.3); }
-    100% { background-color: transparent; }
-}
-@keyframes flash-red {
-    0% { background-color: rgba(244, 67, 54, 0.3); }
-    100% { background-color: transparent; }
-}

--- a/signals/src/main/resources/META-INF/resources/usecase02.css
+++ b/signals/src/main/resources/META-INF/resources/usecase02.css
@@ -1,0 +1,12 @@
+.usecase02-view {
+    .result-display {
+        margin-top: 2em;
+        padding: 1em;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background-color: #f5f5f5;
+    }
+    .result-text {
+        margin: 0;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase03.css
+++ b/signals/src/main/resources/META-INF/resources/usecase03.css
@@ -1,0 +1,34 @@
+.usecase03-view {
+    .view-title {
+        margin-bottom: 0;
+    }
+    .view-description {
+        margin-top: 0.5em;
+    }
+    .left-panel {
+        flex-shrink: 0;
+    }
+    .svg-container {
+        flex: 1;
+        border: 2px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent);
+        padding: 20px;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+    .svg-canvas {
+        background: #fafafa;
+        border-radius: 4px;
+    }
+    .clickable-shape {
+        cursor: pointer;
+    }
+    .section-label {
+        font-size: var(--aura-font-size-s);
+        color: var(--vaadin-text-color-secondary);
+        font-weight: 500;
+    }
+    .section-label-with-margin {
+        margin-top: 8px;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase06.css
+++ b/signals/src/main/resources/META-INF/resources/usecase06.css
@@ -1,0 +1,68 @@
+.usecase06-view {
+    .products-container {
+        background-color: #fff3e0;
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+    }
+    .cart-items-container {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+    }
+    .empty-cart-text {
+        margin: 0;
+        font-style: italic;
+        color: var(--vaadin-text-color-secondary);
+    }
+    .product-row,
+    .cart-item-row {
+        background-color: #ffffff;
+        padding: 0.75em;
+        border-radius: 4px;
+        margin-bottom: 0.5em;
+    }
+    .row-name {
+        flex-grow: 1;
+        font-weight: 500;
+    }
+    .totals-box {
+        background-color: #e8f5e9;
+        padding: 1.5em;
+        border-radius: 4px;
+        margin-top: 1em;
+    }
+    .summary-title {
+        margin-top: 0;
+    }
+    .total-line {
+        display: block;
+        margin-bottom: 0.5em;
+    }
+    .total-line-discount {
+        color: var(--aura-green);
+    }
+    .totals-divider {
+        border-top: 2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        margin: 0.75em 0;
+    }
+    .total-grand {
+        display: block;
+        font-weight: bold;
+        font-size: 1.5em;
+        color: var(--aura-accent-color);
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .item-total {
+        text-align: right;
+        font-weight: bold;
+        color: var(--aura-accent-color);
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase08.css
+++ b/signals/src/main/resources/META-INF/resources/usecase08.css
@@ -1,0 +1,8 @@
+.usecase08-view {
+    .review-content {
+        white-space: pre-line;
+    }
+    .progress-indicator {
+        font-weight: bold;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase09.css
+++ b/signals/src/main/resources/META-INF/resources/usecase09.css
@@ -1,0 +1,10 @@
+.usecase09-view {
+    .status-label {
+        color: orange;
+        font-weight: normal;
+    }
+    .status-label.is-valid {
+        color: green;
+        font-weight: bold;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase10.css
+++ b/signals/src/main/resources/META-INF/resources/usecase10.css
@@ -1,0 +1,75 @@
+.usecase10-view {
+    .cards-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1em;
+    }
+    .card {
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        border-radius: 8px;
+        padding: 1.5em;
+        flex: 1 1 250px;
+        min-width: 250px;
+        background-color: var(--aura-background-color);
+    }
+    .card-title {
+        margin-top: 0;
+        margin-bottom: 0.25em;
+    }
+    .card-subtitle {
+        font-family: monospace;
+        font-size: 0.8em;
+        color: var(--vaadin-text-color-secondary);
+        margin-top: 0;
+        margin-bottom: 1em;
+    }
+    .upload-status-label {
+        font-weight: bold;
+    }
+    .shortcut-label {
+        font-weight: bold;
+        font-size: 1.1em;
+    }
+    .hint-text {
+        font-size: 0.85em;
+        color: var(--vaadin-text-color-secondary);
+        font-style: italic;
+    }
+    .status-indicator {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+    }
+    .status-indicator-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        display: inline-block;
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 30%, transparent);
+    }
+    .status-indicator-dot.is-active {
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 80%, transparent);
+    }
+    .status-indicator-label {
+        font-weight: bold;
+        font-size: 1.1em;
+    }
+    .composition-section {
+        margin-top: 1.5em;
+        padding: 1.5em;
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 5%, transparent);
+        border-radius: 8px;
+    }
+    .composition-heading {
+        margin-top: 0;
+    }
+    .composition-summary-text {
+        font-family: monospace;
+        font-size: 1.1em;
+        font-weight: bold;
+        padding: 0.75em;
+        background-color: var(--aura-background-color);
+        border-radius: 4px;
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase11.css
+++ b/signals/src/main/resources/META-INF/resources/usecase11.css
@@ -1,0 +1,86 @@
+.usecase11-view {
+    .responsive-content {
+        padding: 1em;
+        height: 100%;
+        overflow-y: auto;
+        background-color: #ffffff;
+    }
+    .info-panel {
+        padding: 1em;
+        background-color: #f5f5f5;
+        height: 100%;
+        overflow-y: auto;
+    }
+    .info-panel-title {
+        margin-top: 0;
+    }
+    .size-display {
+        background-color: #ffffff;
+        padding: 1em;
+        border-radius: 4px;
+        margin: 1em 0;
+    }
+    .size-line {
+        font-family: monospace;
+        margin: 0.25em 0;
+    }
+    .breakpoint-line {
+        font-weight: bold;
+        margin: 0.5em 0 0 0;
+    }
+    .tip-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+        font-style: italic;
+    }
+    .section {
+        padding: 1.5em;
+        border-radius: 8px;
+        margin: 0.5em 0;
+    }
+    .section.small-layout {
+        background-color: #fff3e0;
+    }
+    .section.medium-layout {
+        background-color: #f3e5f5;
+    }
+    .section.large-layout {
+        background-color: #e8f5e9;
+    }
+    .section-title {
+        margin-top: 0;
+        margin-bottom: 0.5em;
+    }
+    .section-content {
+        margin: 0;
+    }
+    .card-grid {
+        display: flex;
+        margin: 1em 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .card-grid.is-small {
+        flex-direction: column;
+        flex-wrap: nowrap;
+    }
+    .grid-card {
+        background-color: #f9f9f9;
+        border: 1px solid #e0e0e0;
+        border-radius: 4px;
+        padding: 1em;
+        margin: 0.5em;
+        flex: 1 1 150px;
+        min-width: 120px;
+    }
+    .grid-card-title {
+        margin: 0 0 0.5em 0;
+        font-size: 1em;
+    }
+    .grid-card-content {
+        margin: 0;
+        font-size: 0.875em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase13.css
+++ b/signals/src/main/resources/META-INF/resources/usecase13.css
@@ -1,0 +1,64 @@
+.usecase13-view {
+    .counter-box {
+        background: color-mix(in srgb, var(--aura-accent-color) 10%, transparent);
+        padding: 1em;
+        border-radius: 8px;
+        border-left: 4px solid var(--aura-accent-color);
+        margin: 1em 0;
+    }
+    .counter-title {
+        margin: 0;
+    }
+    .user-list-title {
+        margin-top: 1.5em;
+        margin-bottom: 0.5em;
+    }
+    .user-list-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+    }
+    .info-box {
+        background: #e0f7fa;
+        padding: 1em;
+        border-radius: 8px;
+        border-left: 4px solid #00BCD4;
+        margin-top: 2em;
+    }
+    .info-title {
+        margin-top: 0;
+    }
+    .user-card.current-session {
+        border: 2px solid var(--aura-accent-color);
+        background: color-mix(in srgb, var(--aura-accent-color) 10%, transparent);
+    }
+    .user-card.tab-inactive {
+        opacity: 0.6;
+        filter: grayscale(30%);
+    }
+    .tab-indicator {
+        flex-shrink: 0;
+    }
+    .name-span {
+        font-weight: bold;
+        flex-grow: 1;
+    }
+    .row-with-gap {
+        gap: 0.5em;
+    }
+    .secondary-text {
+        font-size: var(--aura-font-size-s);
+    }
+    .secondary-muted {
+        font-size: var(--aura-font-size-s);
+        color: var(--vaadin-text-color-secondary);
+    }
+    .role-badge {
+        padding: 2px 6px;
+        border-radius: 4px;
+        color: white;
+        font-size: var(--aura-font-size-xs);
+        font-weight: bold;
+        flex-shrink: 0;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase14.css
+++ b/signals/src/main/resources/META-INF/resources/usecase14.css
@@ -1,0 +1,60 @@
+.usecase14-view {
+    .error-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+    }
+    .state-box {
+        border: 2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        border-radius: 8px;
+        padding: 1.5em;
+        margin: 1em 0;
+        min-height: 300px;
+    }
+    .idle-message {
+        color: var(--vaadin-text-color-secondary);
+        font-style: italic;
+    }
+    .loading-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1em;
+    }
+    .loading-message {
+        color: var(--aura-accent-color);
+    }
+    .success-title {
+        margin-top: 0;
+        color: var(--aura-green);
+    }
+    .metrics-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1em;
+        margin-top: 1em;
+    }
+    .error-content {
+        background-color: #ffebee;
+        padding: 1em;
+        border-radius: 4px;
+        border-left: 4px solid var(--aura-red);
+    }
+    .error-title {
+        margin-top: 0;
+        color: var(--aura-red);
+    }
+    .error-message {
+        margin: 0.5em 0;
+    }
+    .metric-label {
+        font-size: var(--aura-font-size-s);
+        color: var(--vaadin-text-color-secondary);
+        font-weight: 500;
+    }
+    .metric-value {
+        font-size: 2.5em;
+        font-weight: bold;
+        line-height: 1;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase15.css
+++ b/signals/src/main/resources/META-INF/resources/usecase15.css
@@ -1,0 +1,81 @@
+.usecase15-view {
+    .stats-box {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        margin: 1em 0;
+        display: flex;
+        gap: 2em;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+    .stat-label {
+        color: var(--vaadin-text-color-secondary);
+    }
+    .stat-value {
+        font-family: monospace;
+        font-weight: bold;
+    }
+    .stat-value-accent {
+        font-family: monospace;
+        font-weight: bold;
+        color: var(--aura-accent-color);
+    }
+    .stat-value-success {
+        font-weight: bold;
+        color: var(--aura-green);
+    }
+    .stat-value-bold {
+        font-weight: bold;
+    }
+    .status-box {
+        min-height: 30px;
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+    }
+    .searching-icon {
+        animation: usecase15-spin 1s linear infinite;
+    }
+    .status-text {
+        color: var(--aura-accent-color);
+    }
+    .results-container {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        margin-top: 1em;
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .product-card {
+        background-color: #ffffff;
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        border-radius: 4px;
+        padding: 1em;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .product-name {
+        font-weight: bold;
+    }
+    .product-category {
+        font-size: 0.9em;
+        color: var(--vaadin-text-color-secondary);
+    }
+    .product-price {
+        font-weight: bold;
+        color: var(--aura-accent-color);
+    }
+}
+
+@keyframes usecase15-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase16.css
+++ b/signals/src/main/resources/META-INF/resources/usecase16.css
@@ -1,0 +1,57 @@
+.usecase16-view {
+    .url-box {
+        background-color: #e3f2fd;
+        padding: 1em;
+        border-radius: 4px;
+        margin: 1em 0;
+    }
+    .url-title {
+        margin-top: 0;
+    }
+    .url-display {
+        font-family: monospace;
+        word-break: break-all;
+        background-color: #ffffff;
+        padding: 0.5em;
+        border-radius: 4px;
+    }
+    .results-container {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        margin-top: 1em;
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .article-card {
+        background-color: #ffffff;
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        border-radius: 4px;
+        padding: 1em;
+    }
+    .article-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5em;
+    }
+    .article-title {
+        font-weight: bold;
+        font-size: 1.1em;
+    }
+    .category-badge {
+        background-color: #e0e0e0;
+        padding: 0.25em 0.5em;
+        border-radius: 4px;
+        font-size: 0.85em;
+    }
+    .article-content {
+        color: var(--vaadin-text-color-secondary);
+        font-size: 0.9em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase17.css
+++ b/signals/src/main/resources/META-INF/resources/usecase17.css
@@ -1,0 +1,81 @@
+.usecase17-view {
+    .signal-count-box {
+        background-color: #e0f7fa;
+        padding: 0.75em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+        font-size: 0.9em;
+    }
+    .column-header {
+        margin-top: 0;
+    }
+    .summary-box {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        font-size: 0.9em;
+    }
+    .stat-box {
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 0.5em;
+    }
+    .stat-box.price-box {
+        background-color: #e8f5e9;
+    }
+    .stat-box.power-box {
+        background-color: #fff3e0;
+    }
+    .stat-box.compat-box {
+        background-color: #ffebee;
+    }
+    .stat-box.compat-box.is-ok {
+        background-color: #e8f5e9;
+    }
+    .stat-box.perf-box {
+        background-color: #e3f2fd;
+    }
+    .stat-label {
+        display: block;
+        font-weight: bold;
+        margin-bottom: 0.5em;
+    }
+    .stat-value {
+        display: block;
+        font-size: 1.2em;
+    }
+    .power-value {
+        display: block;
+    }
+    .perf-rating {
+        display: block;
+        font-size: 1.2em;
+        color: var(--aura-accent-color);
+    }
+    .perf-detail {
+        display: block;
+        font-size: 0.9em;
+    }
+    .compatibility-section {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+    }
+    .compatibility-check-row {
+        padding: 0.25em 0;
+        font-size: 0.9em;
+    }
+    .component-summary-item {
+        margin-bottom: 0.5em;
+        display: flex;
+        justify-content: space-between;
+    }
+    .component-summary-name {
+        flex: 1;
+    }
+    .component-summary-price {
+        font-weight: bold;
+        color: var(--aura-accent-color);
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase18.css
+++ b/signals/src/main/resources/META-INF/resources/usecase18.css
@@ -1,0 +1,34 @@
+.usecase18-view {
+    .main-panel {
+        min-height: 0;
+    }
+    .chat-panel,
+    .task-panel {
+        min-width: 0;
+    }
+    .panel-title {
+        margin: 0;
+    }
+    .grid-container {
+        min-height: 0;
+    }
+    .chat-container {
+        min-height: 0;
+    }
+    .stat-card {
+        flex: 1;
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 8px;
+        text-align: center;
+    }
+    .stat-card-value {
+        font-size: 2em;
+        font-weight: bold;
+        display: block;
+    }
+    .stat-card-label {
+        color: var(--vaadin-text-color-secondary);
+        font-size: 0.875em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase19.css
+++ b/signals/src/main/resources/META-INF/resources/usecase19.css
@@ -1,0 +1,78 @@
+.usecase19-view {
+    .items-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1em;
+        margin: 1em 0;
+    }
+    .data-card {
+        flex: 1 1 300px;
+        min-width: 300px;
+    }
+    .data-card.state-idle {
+        border-left: 4px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+    }
+    .data-card.state-loading {
+        border-left: 4px solid var(--aura-accent-color);
+    }
+    .data-card.state-success {
+        border-left: 4px solid var(--aura-green);
+    }
+    .data-card.state-error {
+        border-left: 4px solid var(--aura-red);
+    }
+    .idle-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5em;
+        padding: 2em;
+        color: var(--vaadin-text-color-secondary);
+    }
+    .idle-text {
+        font-style: italic;
+    }
+    .loading-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1em;
+        padding: 2em;
+    }
+    .loading-text {
+        color: var(--aura-accent-color);
+    }
+    .success-content,
+    .error-content {
+        padding: 1em;
+    }
+    .state-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+        margin-bottom: 1em;
+    }
+    .success-label {
+        color: var(--aura-green);
+        font-weight: 500;
+    }
+    .error-label {
+        color: var(--aura-red);
+        font-weight: 500;
+    }
+    .data-content {
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 5%, transparent);
+        padding: 1em;
+        border-radius: 4px;
+        white-space: pre-line;
+        font-family: monospace;
+        font-size: 0.875em;
+    }
+    .error-message {
+        background-color: #ffebee;
+        padding: 1em;
+        border-radius: 4px;
+        margin-bottom: 1em;
+        color: var(--aura-red-text);
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase20.css
+++ b/signals/src/main/resources/META-INF/resources/usecase20.css
@@ -1,0 +1,17 @@
+.usecase20-view {
+    .color-tile {
+        padding: 0.5rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        min-width: 180px;
+        min-height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+    }
+    .color-tile-text {
+        margin: 0;
+        font-weight: 500;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase21.css
+++ b/signals/src/main/resources/META-INF/resources/usecase21.css
@@ -1,0 +1,17 @@
+.usecase21-view {
+    .card {
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 5%, transparent);
+        border-radius: 8px;
+        padding: 1.5em;
+        margin-bottom: 1em;
+    }
+    .row-label {
+        font-weight: bold;
+    }
+    .locale-code {
+        font-family: monospace;
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 10%, transparent);
+        padding: 0.25em 0.5em;
+        border-radius: 4px;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase22.css
+++ b/signals/src/main/resources/META-INF/resources/usecase22.css
@@ -1,0 +1,52 @@
+.usecase22-view {
+    .personal-section {
+        background-color: #e3f2fd;
+        border-radius: 8px;
+    }
+    .address-section {
+        background-color: #fff3e0;
+        border-radius: 8px;
+    }
+    .section-title {
+        margin-top: 0;
+    }
+    .full-name-label {
+        font-weight: bold;
+        color: var(--aura-accent-color);
+    }
+    .formatted-address-label {
+        font-weight: bold;
+        color: var(--aura-accent-color);
+        word-break: break-word;
+    }
+    .state-box {
+        background-color: #e8f5e9;
+        padding: 1.5em;
+        border-radius: 8px;
+        margin-top: 1em;
+    }
+    .state-display {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+        overflow-x: auto;
+        font-size: 0.9em;
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1.5em;
+        border-radius: 8px;
+        margin-top: 1em;
+    }
+    .code-example {
+        background-color: #263238;
+        color: #aed581;
+        padding: 1em;
+        border-radius: 4px;
+        overflow-x: auto;
+        font-size: 0.85em;
+    }
+    .when-to-use {
+        margin-bottom: 0.5em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase23.css
+++ b/signals/src/main/resources/META-INF/resources/usecase23.css
@@ -1,0 +1,27 @@
+.usecase23-view {
+    .panel-header-title {
+        font-size: var(--aura-font-size-xl);
+        margin: 0;
+    }
+    .panel-header-subtitle {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-xs);
+    }
+    .highlight-card {
+        gap: 5px;
+    }
+    .highlight-card-icon {
+        margin-right: 4px;
+        margin-left: 0;
+    }
+    .highlight-card-title {
+        font-weight: 400;
+        margin: 0;
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-xs);
+    }
+    .highlight-card-value {
+        font-weight: 600;
+        font-size: 2.5em;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase24.css
+++ b/signals/src/main/resources/META-INF/resources/usecase24.css
@@ -1,0 +1,83 @@
+.usecase24-view {
+    .count-label {
+        color: var(--vaadin-text-color-secondary);
+    }
+    .unread-badge {
+        background-color: var(--aura-accent-color);
+        color: white;
+        padding: 0.25em 0.75em;
+        border-radius: 1em;
+        font-size: var(--aura-font-size-s);
+        font-weight: bold;
+    }
+    .empty-state {
+        text-align: center;
+        padding: 2em;
+        color: var(--vaadin-text-color-secondary);
+        font-style: italic;
+    }
+    .info-box {
+        background-color: #e0f7fa;
+        padding: 1em;
+        border-radius: 4px;
+        margin-top: 1em;
+        font-style: italic;
+    }
+    .notification-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 1em;
+        padding: 1em;
+        margin: 0.25em 0;
+        border-radius: 8px;
+    }
+    .notification-card.is-read {
+        background-color: #fafafa;
+    }
+    .notification-card.is-unread {
+        background-color: #e3f2fd;
+    }
+    .notification-icon {
+        flex-shrink: 0;
+        margin-top: 0.15em;
+    }
+    .notification-content {
+        flex-grow: 1;
+        min-width: 0;
+    }
+    .notification-title-row {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0.25em;
+    }
+    .notification-title {
+        font-weight: normal;
+    }
+    .notification-title.is-unread {
+        font-weight: bold;
+    }
+    .type-badge {
+        color: white;
+        padding: 0.1em 0.5em;
+        border-radius: 0.75em;
+        font-size: var(--aura-font-size-xs);
+        margin-left: 0.5em;
+    }
+    .notification-message {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-s);
+        display: block;
+        margin-bottom: 0.5em;
+    }
+    .notification-timestamp {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-xs);
+        display: block;
+    }
+    .notification-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25em;
+        flex-shrink: 0;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase25.css
+++ b/signals/src/main/resources/META-INF/resources/usecase25.css
@@ -1,0 +1,67 @@
+.usecase25-view {
+    display: block;
+    padding: var(--vaadin-gap-l);
+
+    .header-row {
+        display: grid;
+        grid-template-columns: 80px 1fr 120px 100px 100px;
+        gap: var(--vaadin-gap-s);
+        padding: var(--vaadin-gap-s) var(--vaadin-gap-m);
+        border-bottom: 2px solid color-mix(in srgb, var(--vaadin-text-color) 20%, transparent);
+        font-weight: bold;
+        font-size: var(--aura-font-size-s);
+        color: var(--vaadin-text-color-secondary);
+    }
+    .stock-list {
+        display: flex;
+        flex-direction: column;
+    }
+    .stock-row {
+        display: grid;
+        grid-template-columns: 80px 1fr 120px 100px 100px;
+        gap: var(--vaadin-gap-s);
+        padding: var(--vaadin-gap-s) var(--vaadin-gap-m);
+        align-items: center;
+        border-bottom: 1px solid color-mix(in srgb, var(--vaadin-text-color) 10%, transparent);
+    }
+    .header-cell-right,
+    .cell-right {
+        text-align: right;
+    }
+    .symbol-cell {
+        font-weight: bold;
+        font-family: monospace;
+    }
+    .name-cell {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-s);
+    }
+    .price-cell {
+        text-align: right;
+        font-family: monospace;
+        font-weight: 600;
+        border-radius: 4px;
+        padding: 2px 6px;
+    }
+    .change-cell {
+        text-align: right;
+        font-family: monospace;
+    }
+    .price-up {
+        color: var(--aura-green);
+        animation: usecase25-flash-green 0.6s ease-out;
+    }
+    .price-down {
+        color: var(--aura-red);
+        animation: usecase25-flash-red 0.6s ease-out;
+    }
+}
+
+@keyframes usecase25-flash-green {
+    0% { background-color: rgba(76, 175, 80, 0.3); }
+    100% { background-color: transparent; }
+}
+@keyframes usecase25-flash-red {
+    0% { background-color: rgba(244, 67, 54, 0.3); }
+    100% { background-color: transparent; }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase26.css
+++ b/signals/src/main/resources/META-INF/resources/usecase26.css
@@ -1,0 +1,10 @@
+.usecase26-view {
+    .log-panel {
+        background-color: #f5f5f5;
+        padding: 1em;
+        border-radius: 4px;
+    }
+    .forms-area {
+        flex: 1;
+    }
+}

--- a/signals/src/main/resources/META-INF/resources/usecase27.css
+++ b/signals/src/main/resources/META-INF/resources/usecase27.css
@@ -1,0 +1,22 @@
+.usecase27-view {
+    .breadcrumb {
+        padding: 0.5em 0.75em;
+        background-color: color-mix(in srgb, var(--vaadin-text-color) 5%, transparent);
+        border-radius: 4px;
+        font-family: var(--aura-font-family);
+    }
+    .update-badge {
+        color: var(--vaadin-text-color-secondary);
+        font-size: var(--aura-font-size-s);
+        margin-left: 0.75em;
+    }
+    .layout-header {
+        display: flex;
+        align-items: center;
+        padding: 0.5em 1em;
+    }
+    .breadcrumb-separator {
+        color: var(--vaadin-text-color-secondary);
+        margin: 0 0.4em;
+    }
+}

--- a/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
+++ b/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
@@ -69,11 +69,10 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
 
         Card card = $view(Card.class).all().getFirst();
 
-        // IDLE state should have contrast border
-        assertTrue(card.getStyle().get("border-left").contains(
-                "color-mix(in srgb, var(--vaadin-text-color) 20%, transparent)"),
-                "IDLE card should have contrast border but was: "
-                        + card.getStyle().get("border-left"));
+        // IDLE state should carry the state-idle class (rendered via CSS)
+        assertTrue(card.getClassNames().contains("state-idle"),
+                "IDLE card should have state-idle class but was: "
+                        + card.getClassNames());
     }
 
     @Test
@@ -88,13 +87,11 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         test(loadButton).click();
         runPendingSignalsTasks();
 
-        // Cards in LOADING state should have primary-color border
+        // Cards in LOADING state should carry the state-loading class
         Card card = $view(Card.class).all().getFirst();
-        assertTrue(
-                card.getStyle().get("border-left")
-                        .contains("var(--aura-accent-color)"),
-                "LOADING card should have primary border but was: "
-                        + card.getStyle().get("border-left"));
+        assertTrue(card.getClassNames().contains("state-loading"),
+                "LOADING card should have state-loading class but was: "
+                        + card.getClassNames());
     }
 
     @Test


### PR DESCRIPTION
Every muc and usecase view that had inline getStyle().set(...) calls now
adds a <pkg>-view root class, loads a <pkg>.css file via @StyleSheet,
and the CSS rules are nested under that root selector.

Discrete state styling (valid/invalid badges, layout breakpoints, card
states, etc.) now toggles class names instead of inline styles.

The flash-green/flash-red keyframes and .price-up/.price-down rules
move from styles.css into usecase25.css (their only user), and the
keyframes are renamed to usecase25-flash-green/-red to avoid the
shared global names.

Truly per-instance dynamic values stay inline: per-user senderColor,
live cursor x/y, per-role/per-metric/per-type colors, ComboBox
ComponentRenderer swatches (rendered in an overlay outside the view
root), and similar data-driven values.
