### PR TITLE
signals: Enable verbose npm logging to debug deploy hang

### DIFF
--- a/signals/Dockerfile
+++ b/signals/Dockerfile
@@ -18,12 +18,15 @@ COPY . $HOME
 #
 #   $ docker build --secret id=offlineKey,src=$HOME/.vaadin/offlineKey .
 
+ENV npm_config_loglevel=verbose
+ENV npm_config_progress=false
+
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=secret,id=proKey \
     --mount=type=secret,id=offlineKey \
     sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey 2>/dev/null || cat /run/secrets/proKey 2>/dev/null || echo "") && \
     OFFLINE_KEY=$(cat /run/secrets/offlineKey 2>/dev/null || echo "") && \
-    ./mvnw -U -pl signals -am clean package -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
+    ./mvnw -U -e -pl signals -am clean package -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
 
 FROM eclipse-temurin:25-jre-alpine
 COPY --from=build /app/signals/target/*.jar app.jar


### PR DESCRIPTION
Sets npm_config_loglevel=verbose and npm_config_progress=false in the build stage, and runs Maven with -e, so the CI build prints per-package npm activity around the frontend install step where the deploy was hanging.
