### PR TITLE
tests: Replace deprecated $/$view with find/findInView

### DIFF
--- a/fullscreen/src/test/java/com/example/uc1/ImageLightboxViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc1/ImageLightboxViewTest.java
@@ -22,10 +22,10 @@ class ImageLightboxViewTest extends SpringBrowserlessTest {
     void viewRendersWithHeadingAndThumbnails() {
         navigate(ImageLightboxView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Image lightbox".equals(h.getText())));
 
-        long thumbCount = $view(Div.class).all().stream()
+        long thumbCount = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("lightbox-thumb"))
                 .count();
         assertEquals(6, thumbCount, "expected one thumb per photo");
@@ -36,14 +36,14 @@ class ImageLightboxViewTest extends SpringBrowserlessTest {
         navigate(ImageLightboxView.class);
         runPendingSignalsTasks();
 
-        Div ocean = $view(Div.class).all().stream()
+        Div ocean = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("lightbox-thumb"))
                 .filter(d -> "Ocean".equals(d.getText())).findFirst()
                 .orElseThrow();
         test(ocean).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Ocean".equals(s.getText())),
                 "selected name should update on thumbnail click");
     }
@@ -72,7 +72,7 @@ class ImageLightboxViewTest extends SpringBrowserlessTest {
 
     private void assertBadgeContains(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getClassNames().contains("status-badge")
                                 && s.getText() != null
                                 && s.getText().contains(fragment)),

--- a/fullscreen/src/test/java/com/example/uc2/SlideshowViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc2/SlideshowViewTest.java
@@ -21,13 +21,13 @@ class SlideshowViewTest extends SpringBrowserlessTest {
     void viewRendersWithControls() {
         navigate(SlideshowView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC2 — Slideshow / presentation mode")));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Previous".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Next".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Present".equals(b.getText())));
     }
 
@@ -38,7 +38,7 @@ class SlideshowViewTest extends SpringBrowserlessTest {
 
         assertSlideCounterShows("Slide 1 of 5");
 
-        Button next = $view(Button.class).all().stream()
+        Button next = findInView(Button.class).all().stream()
                 .filter(b -> "Next".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(next).click();
@@ -71,13 +71,13 @@ class SlideshowViewTest extends SpringBrowserlessTest {
 
     private void assertSlideCounterShows(String text) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> text.equals(s.getText())),
                 "expected slide counter to read \"" + text + "\"");
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("status-badge")
                         && s.getText() != null
                         && s.getText().contains(fragment)),

--- a/fullscreen/src/test/java/com/example/uc3/DistractionFreeEditorViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc3/DistractionFreeEditorViewTest.java
@@ -23,14 +23,14 @@ class DistractionFreeEditorViewTest extends SpringBrowserlessTest {
     void viewRendersWithEditorAndExpandButton() {
         navigate(DistractionFreeEditorView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC3 — Distraction-free editor")));
-        assertTrue(!$view(TextArea.class).all().isEmpty());
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(!findInView(TextArea.class).all().isEmpty());
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Expand to fullscreen".equals(b.getText())));
         // Done is bindVisible(fullscreen), so it is hidden (and not surfaced
-        // by $view) while the page is not fullscreen.
-        assertFalse($view(Button.class).all().stream()
+        // by findInView) while the page is not fullscreen.
+        assertFalse(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Done".equals(b.getText())));
     }
 
@@ -41,13 +41,13 @@ class DistractionFreeEditorViewTest extends SpringBrowserlessTest {
 
         FullscreenTestSupport.setFullscreenState(FullscreenState.FULLSCREEN);
         runPendingSignalsTasks();
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Done".equals(b.getText())),
                 "Done button should be visible while fullscreen");
 
         FullscreenTestSupport.setFullscreenState(FullscreenState.NOT_FULLSCREEN);
         runPendingSignalsTasks();
-        assertFalse($view(Button.class).all().stream()
+        assertFalse(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Done".equals(b.getText())),
                 "Done button should hide again when leaving fullscreen");
     }
@@ -57,12 +57,12 @@ class DistractionFreeEditorViewTest extends SpringBrowserlessTest {
         navigate(DistractionFreeEditorView.class);
         runPendingSignalsTasks();
 
-        TextArea editor = $view(TextArea.class).all().getFirst();
+        TextArea editor = findInView(TextArea.class).all().getFirst();
         test(editor).setValue("hello world this is fullscreen");
         runPendingSignalsTasks();
 
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> "5 words".equals(s.getText())),
                 "word count should report 5 words after typing");
     }
@@ -84,7 +84,7 @@ class DistractionFreeEditorViewTest extends SpringBrowserlessTest {
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("status-badge")
                         && s.getText() != null
                         && s.getText().contains(fragment)),

--- a/fullscreen/src/test/java/com/example/uc4/ReactiveLayoutViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc4/ReactiveLayoutViewTest.java
@@ -22,10 +22,10 @@ class ReactiveLayoutViewTest extends SpringBrowserlessTest {
     void viewRendersWithDashboardAndSixMetrics() {
         navigate(ReactiveLayoutView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC4 — Reactive layout".equals(h.getText())));
 
-        long metricCardCount = $view(Div.class).all().stream()
+        long metricCardCount = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("metric-card"))
                 .count();
         assertEquals(6, metricCardCount,
@@ -60,21 +60,21 @@ class ReactiveLayoutViewTest extends SpringBrowserlessTest {
 
         FullscreenTestSupport.setFullscreenState(FullscreenState.FULLSCREEN);
         runPendingSignalsTasks();
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("density-aside")
                         && "Density: spacious (3 columns)".equals(s.getText())),
                 "density aside should announce spacious layout");
 
         FullscreenTestSupport.setFullscreenState(FullscreenState.NOT_FULLSCREEN);
         runPendingSignalsTasks();
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("density-aside")
                         && "Density: compact (2 columns)".equals(s.getText())),
                 "density aside should announce compact layout");
     }
 
     private void assertDashboardHas(String cls, boolean expected) {
-        Div dashboard = $view(Div.class).all().stream()
+        Div dashboard = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("dashboard"))
                 .findFirst().orElseThrow();
         assertEquals(expected, dashboard.getClassNames().contains(cls),

--- a/fullscreen/src/test/java/com/example/uc5/KioskExitDetectionViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc5/KioskExitDetectionViewTest.java
@@ -25,11 +25,11 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
     void viewRendersWithKioskControlsAndLandingScreen() {
         navigate(KioskExitDetectionView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC5 — Kiosk: visitor sign-in")));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Enter kiosk".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Start sign-in".equals(b.getText())),
                 "landing screen should expose Start sign-in");
     }
@@ -45,13 +45,13 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         clickButton("Start sign-in");
         runPendingSignalsTasks();
 
-        TextField name = $view(TextField.class).all().stream()
+        TextField name = findInView(TextField.class).all().stream()
                 .filter(f -> "Your name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(name).setValue("Ada Lovelace");
 
         @SuppressWarnings("unchecked")
-        Select<String> purpose = $view(Select.class).all().stream()
+        Select<String> purpose = findInView(Select.class).all().stream()
                 .filter(s -> "Purpose of visit".equals(s.getLabel()))
                 .findFirst().orElseThrow();
         purpose.setValue("Meeting");
@@ -61,10 +61,10 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Confirmation screen now visible, log records the sign-in.
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "New visitor".equals(b.getText())),
                 "confirmation screen should expose New visitor");
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Signed in: Ada Lovelace")),
                 "log should record the sign-in");
@@ -82,11 +82,11 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         FullscreenTestSupport.setFullscreenState(FullscreenState.NOT_FULLSCREEN);
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("UNEXPECTED")),
                 "log should contain an unexpected-exit entry");
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("unexpected-warning")
                         && s.getText() != null && !s.getText().isEmpty()),
                 "warning span should be visible after an unexpected exit");
@@ -104,7 +104,7 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         clickButton("Staff");
         runPendingSignalsTasks();
 
-        PasswordField pin = $view(PasswordField.class).all().stream()
+        PasswordField pin = findInView(PasswordField.class).all().stream()
                 .findFirst().orElseThrow();
         test(pin).setValue(KioskExitDetectionView.STAFF_PIN);
         clickButton("Confirm");
@@ -112,11 +112,11 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         FullscreenTestSupport.setFullscreenState(FullscreenState.NOT_FULLSCREEN);
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Staff exit confirmed")),
                 "log should record the staff exit");
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("expected")
                         && !d.getText().contains("UNEXPECTED")),
@@ -137,24 +137,24 @@ class KioskExitDetectionViewTest extends SpringBrowserlessTest {
         clickButton("Staff");
         runPendingSignalsTasks();
 
-        PasswordField pin = $view(PasswordField.class).all().stream()
+        PasswordField pin = findInView(PasswordField.class).all().stream()
                 .findFirst().orElseThrow();
         test(pin).setValue("0000");
         clickButton("Confirm");
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Failed staff exit attempt")),
                 "log should record the failed staff attempt");
         // The dialog is still open (still rendering its Cancel button).
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Cancel".equals(b.getText())),
                 "staff prompt should still be open after a wrong PIN");
     }
 
     private void clickButton(String text) {
-        Button button = $view(Button.class).all().stream()
+        Button button = findInView(Button.class).all().stream()
                 .filter(b -> text.equals(b.getText())).findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "button \"" + text + "\" not found"));

--- a/fullscreen/src/test/java/com/example/uc6/ChartExpandViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc6/ChartExpandViewTest.java
@@ -23,16 +23,16 @@ class ChartExpandViewTest extends SpringBrowserlessTest {
     void viewRendersWithThreeChartCardsAndExpandButtons() {
         navigate(ChartExpandView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC6 — Chart expand-to-fullscreen"
                         .equals(h.getText())));
 
-        long chartCardCount = $view(Div.class).all().stream()
+        long chartCardCount = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("chart-card"))
                 .count();
         assertEquals(3, chartCardCount, "expected three chart cards");
 
-        long expandButtons = $view(Button.class).all().stream()
+        long expandButtons = findInView(Button.class).all().stream()
                 .filter(b -> "Expand".equals(b.getText())).count();
         assertEquals(3, expandButtons, "expected one Expand button per card");
     }
@@ -48,7 +48,7 @@ class ChartExpandViewTest extends SpringBrowserlessTest {
         // Click the Expand button next to the "Conversion" card. The middle
         // Expand button corresponds to it (cards are added in CHART_TITLES
         // order: Visitors, Conversion, Revenue).
-        Button conversionExpand = $view(Button.class).all().stream()
+        Button conversionExpand = findInView(Button.class).all().stream()
                 .filter(b -> "Expand".equals(b.getText())).skip(1).findFirst()
                 .orElseThrow();
         test(conversionExpand).click();
@@ -62,7 +62,7 @@ class ChartExpandViewTest extends SpringBrowserlessTest {
         navigate(ChartExpandView.class);
         runPendingSignalsTasks();
 
-        Button visitorsExpand = $view(Button.class).all().stream()
+        Button visitorsExpand = findInView(Button.class).all().stream()
                 .filter(b -> "Expand".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(visitorsExpand).click();
@@ -86,7 +86,7 @@ class ChartExpandViewTest extends SpringBrowserlessTest {
     private void assertExpandedTitles(String... titles) {
         java.util.Set<String> expected = java.util.Set.of(titles);
         java.util.Set<String> actual = new java.util.LinkedHashSet<>();
-        for (Div card : $view(Div.class).all().stream()
+        for (Div card : findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("chart-card"))
                 .toList()) {
             if (card.getClassNames().contains("expanded")) {

--- a/fullscreen/src/test/java/com/example/uc7/AppFullscreenViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc7/AppFullscreenViewTest.java
@@ -21,11 +21,11 @@ class AppFullscreenViewTest extends SpringBrowserlessTest {
     void viewRendersWithEnterExitAndBadge() {
         navigate(AppFullscreenView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC7 — View this app fullscreen")));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Enter fullscreen".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Exit fullscreen".equals(b.getText())));
     }
 
@@ -48,7 +48,7 @@ class AppFullscreenViewTest extends SpringBrowserlessTest {
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getClassNames().contains("status-badge")
                         && s.getText() != null
                         && s.getText().contains(fragment)),

--- a/geolocation/src/test/java/com/example/uc1/OneShotOnClickViewTest.java
+++ b/geolocation/src/test/java/com/example/uc1/OneShotOnClickViewTest.java
@@ -20,10 +20,10 @@ class OneShotOnClickViewTest extends BrowserlessTest {
         geolocation.setLocation(60.1699, 24.9384, 25.0);
         navigate(OneShotOnClickView.class);
 
-        Button locate = $(Button.class).withText("Use my location").single();
+        Button locate = find(Button.class).withText("Use my location").single();
         test(locate).click();
 
-        Span result = $(Span.class).withTextContaining("lat=").single();
+        Span result = find(Span.class).withTextContaining("lat=").single();
         assertTrue(result.getText().contains("60.16990"),
                 "Result span should show latitude, was: " + result.getText());
         assertTrue(result.getText().contains("24.93840"),
@@ -36,10 +36,10 @@ class OneShotOnClickViewTest extends BrowserlessTest {
         geolocation.denyPermission();
         navigate(OneShotOnClickView.class);
 
-        Button locate = $(Button.class).withText("Use my location").single();
+        Button locate = find(Button.class).withText("Use my location").single();
         test(locate).click();
 
-        Span result = $(Span.class).withTextContaining("permission").single();
+        Span result = find(Span.class).withTextContaining("permission").single();
         assertTrue(result.getText().contains("denied"),
                 "Result span should explain that permission was denied, was: "
                         + result.getText());

--- a/geolocation/src/test/java/com/example/uc2/TrackingViewTest.java
+++ b/geolocation/src/test/java/com/example/uc2/TrackingViewTest.java
@@ -21,18 +21,18 @@ class TrackingViewTest extends BrowserlessTest {
         geolocation.grantPermission();
         navigate(TrackingView.class);
 
-        Button toggle = $(Button.class).withText("Start tracking").single();
+        Button toggle = find(Button.class).withText("Start tracking").single();
         test(toggle).click();
 
         assertEquals(1, geolocation.activeTrackers().size(),
                 "Exactly one tracker session should be active after starting");
 
         geolocation.setLocation(60.1699, 24.9384, 15.0);
-        Span status = $(Span.class).withText("Update #1").single();
+        Span status = find(Span.class).withText("Update #1").single();
         assertEquals("Update #1", status.getText());
 
         geolocation.setLocation(60.1700, 24.9385, 12.0);
-        status = $(Span.class).withText("Update #2").single();
+        status = find(Span.class).withText("Update #2").single();
         assertEquals("Update #2", status.getText());
     }
 
@@ -42,13 +42,13 @@ class TrackingViewTest extends BrowserlessTest {
         geolocation.grantPermission();
         navigate(TrackingView.class);
 
-        Button toggle = $(Button.class).withText("Start tracking").single();
+        Button toggle = find(Button.class).withText("Start tracking").single();
         test(toggle).click();
 
         geolocation.setUnavailable(GeolocationErrorCode.POSITION_UNAVAILABLE,
                 "position unavailable");
 
-        Span status = $(Span.class).withTextContaining("Could not determine")
+        Span status = find(Span.class).withTextContaining("Could not determine")
                 .single();
         assertTrue(status.getText().contains("location"),
                 "Status should describe the location failure, was: "

--- a/geolocation/src/test/java/com/example/uc3/AutoFetchViewTest.java
+++ b/geolocation/src/test/java/com/example/uc3/AutoFetchViewTest.java
@@ -22,7 +22,7 @@ class AutoFetchViewTest extends BrowserlessTest {
 
         navigate(AutoFetchView.class);
 
-        Span localContent = $(Span.class).withTextContaining("Local content")
+        Span localContent = find(Span.class).withTextContaining("Local content")
                 .single();
         assertTrue(localContent.getText().contains("60.1699"),
                 "Local content should show latitude, was: "
@@ -39,11 +39,11 @@ class AutoFetchViewTest extends BrowserlessTest {
         assertTrue(geolocation.requests().isEmpty(),
                 "No pending get() request should remain when permission is DENIED");
 
-        Button locate = $(Button.class).withText("Use my location").single();
+        Button locate = find(Button.class).withText("Use my location").single();
         assertTrue(locate.isVisible(),
                 "The explicit locate button should be visible for DENIED");
 
-        Span hint = $(Span.class)
+        Span hint = find(Span.class)
                 .withTextContaining("Location permission was denied").single();
         assertEquals("Location permission was denied for this site.",
                 hint.getText());

--- a/geolocation/src/test/java/com/example/uc4/DenialViewTest.java
+++ b/geolocation/src/test/java/com/example/uc4/DenialViewTest.java
@@ -19,16 +19,16 @@ class DenialViewTest extends BrowserlessTest {
         navigate(DenialView.class);
 
         @SuppressWarnings("unchecked")
-        Select<GeolocationAvailability> select = $(Select.class)
+        Select<GeolocationAvailability> select = find(Select.class)
                 .withCaption("Browser-reported availability").single();
         test(select).selectItem("DENIED");
 
-        TextField postcode = $(TextField.class).withCaption("Postcode")
+        TextField postcode = find(TextField.class).withCaption("Postcode")
                 .single();
         assertTrue(postcode.isVisible(),
                 "Postcode field should be visible when availability is DENIED");
 
-        Span hint = $(Span.class).withTextContaining("Location is blocked")
+        Span hint = find(Span.class).withTextContaining("Location is blocked")
                 .single();
         assertTrue(hint.isVisible(),
                 "Hint span should be visible when availability is DENIED");

--- a/geolocation/src/test/java/com/example/uc5/DetailedDataViewTest.java
+++ b/geolocation/src/test/java/com/example/uc5/DetailedDataViewTest.java
@@ -26,22 +26,22 @@ class DetailedDataViewTest extends BrowserlessTest {
 
         navigate(DetailedDataView.class);
 
-        Button fetch = $(Button.class).withText("Read full position").single();
+        Button fetch = find(Button.class).withText("Read full position").single();
         test(fetch).click();
 
-        assertTrue($(Span.class).withTextContaining("51.507400°").exists(),
+        assertTrue(find(Span.class).withTextContaining("51.507400°").exists(),
                 "Latitude field should be rendered");
-        assertTrue($(Span.class).withTextContaining("-0.127800°").exists(),
+        assertTrue(find(Span.class).withTextContaining("-0.127800°").exists(),
                 "Longitude field should be rendered");
-        assertTrue($(Span.class).withTextContaining("10.0 m").exists(),
+        assertTrue(find(Span.class).withTextContaining("10.0 m").exists(),
                 "Accuracy field should be rendered");
-        assertTrue($(Span.class).withTextContaining("12.5 m").exists(),
+        assertTrue(find(Span.class).withTextContaining("12.5 m").exists(),
                 "Altitude field should be rendered");
-        assertTrue($(Span.class).withTextContaining("3.0 m").exists(),
+        assertTrue(find(Span.class).withTextContaining("3.0 m").exists(),
                 "Altitude accuracy field should be rendered");
-        assertTrue($(Span.class).withTextContaining("90.0°").exists(),
+        assertTrue(find(Span.class).withTextContaining("90.0°").exists(),
                 "Heading field should be rendered");
-        assertTrue($(Span.class).withTextContaining("1.50 m/s").exists(),
+        assertTrue(find(Span.class).withTextContaining("1.50 m/s").exists(),
                 "Speed field should be rendered");
     }
 
@@ -53,13 +53,13 @@ class DetailedDataViewTest extends BrowserlessTest {
 
         navigate(DetailedDataView.class);
 
-        Button fetch = $(Button.class).withText("Read full position").single();
+        Button fetch = find(Button.class).withText("Read full position").single();
         test(fetch).click();
 
-        assertTrue($(Span.class).withTextContaining("48.856600°").exists(),
+        assertTrue(find(Span.class).withTextContaining("48.856600°").exists(),
                 "Latitude field should be rendered");
 
-        int dashCount = $(Span.class).withText("—").all().size();
+        int dashCount = find(Span.class).withText("—").all().size();
         assertTrue(dashCount >= 4,
                 "At least 4 fields should be shown as '—' for null coordinates, found: "
                         + dashCount);

--- a/geolocation/src/test/java/com/example/uc6/OptionsViewTest.java
+++ b/geolocation/src/test/java/com/example/uc6/OptionsViewTest.java
@@ -23,7 +23,7 @@ class OptionsViewTest extends BrowserlessTest {
         GeolocationSimulator geolocation = GeolocationSimulator.current();
         navigate(OptionsView.class);
 
-        List<Button> runs = $(Button.class).withText("Run").all();
+        List<Button> runs = find(Button.class).withText("Run").all();
         assertEquals(4, runs.size(), "Expected 4 Run buttons, one per profile");
 
         Button profileC = runs.get(2);

--- a/geolocation/src/test/java/com/example/uc7/FormFieldViewTest.java
+++ b/geolocation/src/test/java/com/example/uc7/FormFieldViewTest.java
@@ -22,27 +22,27 @@ class FormFieldViewTest extends BrowserlessTest {
         geolocation.setLocation(51.5074, -0.1278, 20.0);
         navigate(FormFieldView.class);
 
-        Button submit = $(Button.class).withText("Report pothole").single();
+        Button submit = find(Button.class).withText("Report pothole").single();
         assertFalse(submit.isEnabled(),
                 "Submit should be disabled before description and location are set");
 
-        TextField description = $(TextField.class).withCaption("Description")
+        TextField description = find(TextField.class).withCaption("Description")
                 .single();
         test(description).setValue("Cracked pavement near bus stop");
 
-        Button pin = $(Button.class).withText("Pin my location").single();
+        Button pin = find(Button.class).withText("Pin my location").single();
         test(pin).click();
 
         assertTrue(submit.isEnabled(),
                 "Submit should be enabled after both description and good-accuracy location are set");
 
-        Span pinLabel = $(Span.class).withTextContaining("Pinned at").single();
+        Span pinLabel = find(Span.class).withTextContaining("Pinned at").single();
         assertTrue(pinLabel.getText().contains("51.50740"),
                 "Pin label should show latitude, was: " + pinLabel.getText());
 
         test(submit).click();
 
-        Span resetLabel = $(Span.class).withText("No location pinned yet")
+        Span resetLabel = find(Span.class).withText("No location pinned yet")
                 .single();
         assertTrue(resetLabel.isVisible(),
                 "Pin label should reset to default after submission");
@@ -58,18 +58,18 @@ class FormFieldViewTest extends BrowserlessTest {
         geolocation.setLocation(51.5074, -0.1278, 100.0);
         navigate(FormFieldView.class);
 
-        TextField description = $(TextField.class).withCaption("Description")
+        TextField description = find(TextField.class).withCaption("Description")
                 .single();
         test(description).setValue("Pothole on main road");
 
-        Button pin = $(Button.class).withText("Pin my location").single();
+        Button pin = find(Button.class).withText("Pin my location").single();
         test(pin).click();
 
-        Button submit = $(Button.class).withText("Report pothole").single();
+        Button submit = find(Button.class).withText("Report pothole").single();
         assertFalse(submit.isEnabled(),
                 "Submit should remain disabled when accuracy exceeds the threshold");
 
-        Span pinLabel = $(Span.class).withText("No location pinned yet")
+        Span pinLabel = find(Span.class).withText("No location pinned yet")
                 .single();
         assertTrue(pinLabel.isVisible(),
                 "Pin label should stay at default when accuracy is too poor");

--- a/geolocation/src/test/java/com/example/uc8/DbTrackingViewTest.java
+++ b/geolocation/src/test/java/com/example/uc8/DbTrackingViewTest.java
@@ -25,21 +25,21 @@ class DbTrackingViewTest extends SpringBrowserlessTest {
         geolocation.grantPermission();
         navigate(DbTrackingView.class);
 
-        Grid<TrackedPosition> grid = $view(Grid.class).single();
+        Grid<TrackedPosition> grid = findInView(Grid.class).single();
         assertEquals(0, test(grid).size(),
                 "Grid should be empty before tracking starts");
 
-        Button start = $(Button.class).withText("Start tracking").single();
+        Button start = find(Button.class).withText("Start tracking").single();
         test(start).click();
 
         geolocation.setLocation(60.1699, 24.9384, 15.0);
-        Span status = $(Span.class).withText("Saved update #1 to DB").single();
+        Span status = find(Span.class).withText("Saved update #1 to DB").single();
         assertEquals("Saved update #1 to DB", status.getText());
         assertEquals(1, test(grid).size(),
                 "Grid should reflect one row from the database");
 
         geolocation.setLocation(60.1700, 24.9385, 12.0);
-        status = $(Span.class).withText("Saved update #2 to DB").single();
+        status = find(Span.class).withText("Saved update #2 to DB").single();
         assertEquals("Saved update #2 to DB", status.getText());
         assertEquals(2, test(grid).size(),
                 "Grid should reflect two rows from the database");
@@ -52,15 +52,15 @@ class DbTrackingViewTest extends SpringBrowserlessTest {
         geolocation.grantPermission();
         navigate(DbTrackingView.class);
 
-        test($(Button.class).withText("Start tracking").single()).click();
+        test(find(Button.class).withText("Start tracking").single()).click();
         geolocation.setLocation(60.1699, 24.9384, 15.0);
         geolocation.setLocation(60.1700, 24.9385, 12.0);
 
-        Grid<TrackedPosition> grid = $view(Grid.class).single();
+        Grid<TrackedPosition> grid = findInView(Grid.class).single();
         assertEquals(2, test(grid).size(),
                 "Grid should have two rows before clearing");
 
-        test($(Button.class).withText("Clear history").single()).click();
+        test(find(Button.class).withText("Clear history").single()).click();
 
         assertEquals(0, test(grid).size(),
                 "Grid should be empty after clearing history");
@@ -72,18 +72,18 @@ class DbTrackingViewTest extends SpringBrowserlessTest {
         geolocation.grantPermission();
         navigate(DbTrackingView.class);
 
-        test($(Button.class).withText("Start tracking").single()).click();
+        test(find(Button.class).withText("Start tracking").single()).click();
         geolocation.setLocation(60.1699, 24.9384, 15.0);
 
-        test($(Button.class).withText("Stop tracking").single()).click();
+        test(find(Button.class).withText("Stop tracking").single()).click();
 
-        Span status = $(Span.class).withTextContaining("Stopped after")
+        Span status = find(Span.class).withTextContaining("Stopped after")
                 .single();
         assertTrue(status.getText().contains("1"),
                 "Stopped status should reflect one update, was: "
                         + status.getText());
         assertTrue(
-                $(Button.class).withText("Resume tracking").single()
+                find(Button.class).withText("Resume tracking").single()
                         .isVisible(),
                 "Start button should be re-labelled to Resume after stop");
     }
@@ -94,12 +94,12 @@ class DbTrackingViewTest extends SpringBrowserlessTest {
         geolocation.grantPermission();
         navigate(DbTrackingView.class);
 
-        test($(Button.class).withText("Start tracking").single()).click();
+        test(find(Button.class).withText("Start tracking").single()).click();
 
         geolocation.setUnavailable(GeolocationErrorCode.POSITION_UNAVAILABLE,
                 "position unavailable");
 
-        Span status = $(Span.class).withTextContaining("Could not determine")
+        Span status = find(Span.class).withTextContaining("Could not determine")
                 .single();
         assertTrue(status.getText().contains("location"),
                 "Status should describe the location failure, was: "

--- a/page-visibility/src/test/java/com/example/uc1/UpdateWhenActiveViewTest.java
+++ b/page-visibility/src/test/java/com/example/uc1/UpdateWhenActiveViewTest.java
@@ -21,9 +21,9 @@ class UpdateWhenActiveViewTest extends SpringBrowserlessTest {
     void viewRendersWithExpectedHeadings() {
         navigate(UpdateWhenActiveView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Update when active".equals(h.getText())));
-        assertTrue($view(H2.class).all().stream()
+        assertTrue(findInView(H2.class).all().stream()
                 .anyMatch(h -> "Status".equals(h.getText())));
     }
 
@@ -47,7 +47,7 @@ class UpdateWhenActiveViewTest extends SpringBrowserlessTest {
 
     private void assertBadgeContains(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains(fragment)),
                 "expected status badge to contain \"" + fragment + "\"");

--- a/page-visibility/src/test/java/com/example/uc2/PresenceAvatarsViewTest.java
+++ b/page-visibility/src/test/java/com/example/uc2/PresenceAvatarsViewTest.java
@@ -30,7 +30,7 @@ class PresenceAvatarsViewTest extends SpringBrowserlessTest {
         assertEquals(1, registry.size(),
                 "the visiting user should be the sole presence");
         assertTrue(
-                $view(H2.class).all().stream()
+                findInView(H2.class).all().stream()
                         .anyMatch(h -> "In the room".equals(h.getText())),
                 "view should render the 'In the room' heading");
     }
@@ -54,7 +54,7 @@ class PresenceAvatarsViewTest extends SpringBrowserlessTest {
         PageVisibilityTestSupport.setPageVisibility(PageVisibility.VISIBLE);
         runPendingSignalsTasks();
 
-        ColoredAvatar avatar = $view(ColoredAvatar.class).all().stream()
+        ColoredAvatar avatar = findInView(ColoredAvatar.class).all().stream()
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("no avatar rendered"));
         assertTrue(

--- a/page-visibility/src/test/java/com/example/uc3/NotificationGatingViewTest.java
+++ b/page-visibility/src/test/java/com/example/uc3/NotificationGatingViewTest.java
@@ -21,9 +21,9 @@ class NotificationGatingViewTest extends SpringBrowserlessTest {
     void viewRendersWithSubscribeAndSendButtons() {
         navigate(NotificationGatingView.class);
 
-        assertTrue($view(Button.class).all().stream().anyMatch(
+        assertTrue(findInView(Button.class).all().stream().anyMatch(
                 b -> "Enable browser notifications".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Send me a notification in 5 seconds"
                         .equals(b.getText())));
     }
@@ -48,7 +48,7 @@ class NotificationGatingViewTest extends SpringBrowserlessTest {
 
     private void assertLogContains(String fragment) {
         assertTrue(
-                $view(Div.class).all().stream()
+                findInView(Div.class).all().stream()
                         .anyMatch(d -> d.getText() != null
                                 && d.getText().contains(fragment)),
                 "expected delivery log to contain \"" + fragment + "\"");

--- a/page-visibility/src/test/java/com/example/uc4/RefreshStaleDataViewTest.java
+++ b/page-visibility/src/test/java/com/example/uc4/RefreshStaleDataViewTest.java
@@ -24,12 +24,12 @@ class RefreshStaleDataViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // The card shows a 4-decimal exchange rate.
-        assertTrue($view(Span.class).all().stream().anyMatch(s -> {
+        assertTrue(findInView(Span.class).all().stream().anyMatch(s -> {
             String t = s.getText();
             return t != null && t.matches("\\d+\\.\\d{4}");
         }), "rate value should be rendered as 0.0000-style number");
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Refresh now".equals(b.getText())));
     }
 
@@ -38,7 +38,7 @@ class RefreshStaleDataViewTest extends SpringBrowserlessTest {
         navigate(RefreshStaleDataView.class);
         runPendingSignalsTasks();
 
-        Span before = $view(Span.class).all().stream()
+        Span before = findInView(Span.class).all().stream()
                 .filter(s -> s.getText() != null
                         && s.getText().matches("\\d+\\.\\d{4}"))
                 .findFirst().orElseThrow();
@@ -48,7 +48,7 @@ class RefreshStaleDataViewTest extends SpringBrowserlessTest {
         // value (the random walk has a 50% chance per click of changing
         // direction, but the value differs from the previous one with very
         // high probability after a few clicks).
-        Button refresh = $view(Button.class).all().stream()
+        Button refresh = findInView(Button.class).all().stream()
                 .filter(b -> "Refresh now".equals(b.getText())).findFirst()
                 .orElseThrow();
         for (int i = 0; i < 10; i++) {
@@ -56,7 +56,7 @@ class RefreshStaleDataViewTest extends SpringBrowserlessTest {
             runPendingSignalsTasks();
         }
 
-        Span after = $view(Span.class).all().stream()
+        Span after = findInView(Span.class).all().stream()
                 .filter(s -> s.getText() != null
                         && s.getText().matches("\\d+\\.\\d{4}"))
                 .findFirst().orElseThrow();

--- a/screen-orientation/src/test/java/com/example/uc1/AdaptiveLayoutViewTest.java
+++ b/screen-orientation/src/test/java/com/example/uc1/AdaptiveLayoutViewTest.java
@@ -21,7 +21,7 @@ class AdaptiveLayoutViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndContainer() {
         navigate(AdaptiveLayoutView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Adaptive layout".equals(h.getText())));
         assertTrue(hasContainer(), "expected the uc1-container to be rendered");
     }
@@ -48,12 +48,12 @@ class AdaptiveLayoutViewTest extends SpringBrowserlessTest {
     }
 
     private boolean hasContainer() {
-        return $view(Div.class).all().stream().anyMatch(d -> d.getClassNames()
+        return findInView(Div.class).all().stream().anyMatch(d -> d.getClassNames()
                 .stream().anyMatch(c -> c.equals("uc1-container")));
     }
 
     private void assertContainerClass(String cls) {
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("uc1-container"))
                 .anyMatch(d -> d.getClassNames().contains(cls)),
                 "expected uc1-container to carry class " + cls);
@@ -61,7 +61,7 @@ class AdaptiveLayoutViewTest extends SpringBrowserlessTest {
 
     private void assertBadgeContains(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains(fragment)),
                 "expected mode badge to contain \"" + fragment + "\"");

--- a/screen-orientation/src/test/java/com/example/uc2/OrientationViewerViewTest.java
+++ b/screen-orientation/src/test/java/com/example/uc2/OrientationViewerViewTest.java
@@ -22,7 +22,7 @@ class OrientationViewerViewTest extends SpringBrowserlessTest {
         navigate(OrientationViewerView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC2 — Orientation viewer".equals(h.getText())));
         assertSpanText("UNKNOWN");
         assertSpanText("Waiting for client bootstrap");
@@ -58,7 +58,7 @@ class OrientationViewerViewTest extends SpringBrowserlessTest {
     }
 
     private void assertSpanText(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains(fragment)),
                 "expected a span containing \"" + fragment + "\"");
@@ -66,7 +66,7 @@ class OrientationViewerViewTest extends SpringBrowserlessTest {
 
     private void assertArrowRotation(int degrees) {
         assertTrue(
-                $view(Div.class).all().stream()
+                findInView(Div.class).all().stream()
                         .filter(d -> d.getClassNames().contains("uc2-arrow"))
                         .anyMatch(d -> {
                             String transform = d.getStyle().get("transform");

--- a/screen-orientation/src/test/java/com/example/uc3/RotatePromptViewTest.java
+++ b/screen-orientation/src/test/java/com/example/uc3/RotatePromptViewTest.java
@@ -23,10 +23,10 @@ class RotatePromptViewTest extends SpringBrowserlessTest {
         navigate(RotatePromptView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC3 — Rotate-your-device overlay")));
         assertTrue(hasOverlay());
-        assertTrue($view(RadioButtonGroup.class).all().size() >= 1,
+        assertTrue(findInView(RadioButtonGroup.class).all().size() >= 1,
                 "expected the required-orientation picker");
     }
 
@@ -67,12 +67,12 @@ class RotatePromptViewTest extends SpringBrowserlessTest {
     }
 
     private boolean hasOverlay() {
-        return $view(Div.class).all().stream()
+        return findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getClassNames().contains("uc3-overlay"));
     }
 
     private void assertOverlayHidden(boolean hidden) {
-        boolean carriesHiddenClass = $view(Div.class).all().stream()
+        boolean carriesHiddenClass = findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("uc3-overlay"))
                 .anyMatch(d -> d.getClassNames().contains("hidden"));
         if (hidden) {
@@ -86,7 +86,7 @@ class RotatePromptViewTest extends SpringBrowserlessTest {
 
     private void assertStatusContains(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains(fragment)),
                 "expected status badge text containing \"" + fragment + "\"");

--- a/screen-orientation/src/test/java/com/example/uc4/LockForVideoViewTest.java
+++ b/screen-orientation/src/test/java/com/example/uc4/LockForVideoViewTest.java
@@ -27,11 +27,11 @@ class LockForVideoViewTest extends SpringBrowserlessTest {
         navigate(LockForVideoView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC4 — Lock landscape for video".equals(h.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> b.getText().startsWith("Play")));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> b.getText().startsWith("Stop")));
         assertSpanText("Idle");
     }
@@ -41,10 +41,10 @@ class LockForVideoViewTest extends SpringBrowserlessTest {
         navigate(LockForVideoView.class);
         runPendingSignalsTasks();
 
-        Button play = $view(Button.class).all().stream()
+        Button play = findInView(Button.class).all().stream()
                 .filter(b -> b.getText().startsWith("Play")).findFirst()
                 .orElseThrow();
-        Button stop = $view(Button.class).all().stream()
+        Button stop = findInView(Button.class).all().stream()
                 .filter(b -> b.getText().startsWith("Stop")).findFirst()
                 .orElseThrow();
 
@@ -60,7 +60,7 @@ class LockForVideoViewTest extends SpringBrowserlessTest {
 
     private void assertSpanText(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains(fragment)),
                 "expected a span containing \"" + fragment + "\"");

--- a/screen-orientation/src/test/java/com/example/uc5/LockErrorViewTest.java
+++ b/screen-orientation/src/test/java/com/example/uc5/LockErrorViewTest.java
@@ -20,18 +20,18 @@ class LockErrorViewTest extends SpringBrowserlessTest {
         navigate(LockErrorView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC5 — Lock error UX".equals(h.getText())));
-        assertTrue($view(Button.class).all().stream().anyMatch(
+        assertTrue(findInView(Button.class).all().stream().anyMatch(
                 b -> b.getText().startsWith("Lock without fullscreen")),
                 "expected the SecurityError-style trigger button");
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> b.getText().startsWith("Two locks in a row")),
                 "expected the AbortError-style trigger button");
 
         // The log starts with one info line so users see the area before
         // they click anything.
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("uc5-error-log"))
                 .flatMap(d -> d.getChildren()).count() >= 1,
                 "expected the log to contain the initial info line");
@@ -44,7 +44,7 @@ class LockErrorViewTest extends SpringBrowserlessTest {
 
         long before = logLineCount();
 
-        Button portrait = $view(Button.class).all().stream()
+        Button portrait = findInView(Button.class).all().stream()
                 .filter(b -> "Lock to portrait".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(portrait).click();
@@ -59,7 +59,7 @@ class LockErrorViewTest extends SpringBrowserlessTest {
     }
 
     private long logLineCount() {
-        return $view(Div.class).all().stream()
+        return findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("uc5-error-log"))
                 .flatMap(d -> d.getChildren()).count();
     }

--- a/signals/src/test/java/com/example/muc01/MUC01ViewTest.java
+++ b/signals/src/test/java/com/example/muc01/MUC01ViewTest.java
@@ -28,10 +28,10 @@ class MUC01ViewTest extends SpringBrowserlessTest {
     void viewRendersWithMessageInputAndButtons() {
         navigate(MUC01View.class);
 
-        assertEquals(1, $view(TextField.class).all().size());
-        assertTrue($view(Button.class).all().stream()
+        assertEquals(1, findInView(TextField.class).all().size());
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Send Message".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Clear All Messages".equals(b.getText())));
     }
 
@@ -40,17 +40,17 @@ class MUC01ViewTest extends SpringBrowserlessTest {
         navigate(MUC01View.class);
         runPendingSignalsTasks();
 
-        TextField messageInput = $view(TextField.class).single();
+        TextField messageInput = findInView(TextField.class).single();
         test(messageInput).setValue("Hello from User A");
 
-        Button sendButton = $view(Button.class).all().stream()
+        Button sendButton = findInView(Button.class).all().stream()
                 .filter(b -> "Send Message".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(sendButton).click();
         runPendingSignalsTasks();
 
         // Message count should show 1
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Total messages: 1")));
     }
@@ -66,14 +66,14 @@ class MUC01ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // User A's view should show the message
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Total messages: 1")));
         // The message text should be rendered
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> "Hello from User B".equals(d.getText())));
         // The author name should be rendered
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> "User B".equals(d.getText())));
     }
 
@@ -83,9 +83,9 @@ class MUC01ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // User A sends a message
-        TextField messageInput = $view(TextField.class).single();
+        TextField messageInput = findInView(TextField.class).single();
         test(messageInput).setValue("Hello from A");
-        Button sendButton = $view(Button.class).all().stream()
+        Button sendButton = findInView(Button.class).all().stream()
                 .filter(b -> "Send Message".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(sendButton).click();
@@ -97,7 +97,7 @@ class MUC01ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Both messages should be counted
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Total messages: 2")));
     }
@@ -114,18 +114,18 @@ class MUC01ViewTest extends SpringBrowserlessTest {
                 new MUC01Signals.Message("userB", "User B", "Message 2"));
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Total messages: 2")));
 
         // Clear all
-        Button clearButton = $view(Button.class).all().stream()
+        Button clearButton = findInView(Button.class).all().stream()
                 .filter(b -> "Clear All Messages".equals(b.getText()))
                 .findFirst().orElseThrow();
         test(clearButton).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Total messages: 0")));
     }

--- a/signals/src/test/java/com/example/muc03/MUC03NicknameUpdateTest.java
+++ b/signals/src/test/java/com/example/muc03/MUC03NicknameUpdateTest.java
@@ -52,7 +52,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
 
         // Verify userB's name appears in the leaderboard
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains("userB")
                                 && s.getText().contains("1 points")),
@@ -65,7 +65,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
 
         // The leaderboard should now show the nickname instead
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains("CoolPlayer")
                                 && s.getText().contains("1 points")),
@@ -74,7 +74,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
 
         // The old username should no longer appear in the score label
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .noneMatch(s -> s.getText() != null
                                 && s.getText().contains("userB")
                                 && s.getText().contains("1 points")),
@@ -106,7 +106,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
                         + diagnostics("after awardPoint"));
 
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains("CoolPlayer")
                                 && s.getText().contains("1 points")),
@@ -119,7 +119,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
 
         // Should revert to username
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains("userB")
                                 && s.getText().contains("1 points")),
@@ -158,7 +158,7 @@ class MUC03NicknameUpdateTest extends SpringBrowserlessTest {
                 .append("\n");
 
         sb.append("spans on view:\n");
-        $view(Span.class).all().forEach(s -> sb.append("  [")
+        findInView(Span.class).all().forEach(s -> sb.append("  [")
                 .append(s.getText()).append("]\n"));
 
         return sb.toString();

--- a/signals/src/test/java/com/example/muc03/MUC03ViewTest.java
+++ b/signals/src/test/java/com/example/muc03/MUC03ViewTest.java
@@ -27,9 +27,9 @@ class MUC03ViewTest extends SpringBrowserlessTest {
     void viewRendersWithGameControls() {
         navigate(MUC03View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "START ROUND".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Reset Scores".equals(b.getText())));
     }
 
@@ -38,7 +38,7 @@ class MUC03ViewTest extends SpringBrowserlessTest {
         navigate(MUC03View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> "Click START to begin".equals(d.getText())));
     }
 
@@ -48,18 +48,18 @@ class MUC03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Click START ROUND
-        Button startButton = $view(Button.class).all().stream()
+        Button startButton = findInView(Button.class).all().stream()
                 .filter(b -> "START ROUND".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(startButton).click();
         runPendingSignalsTasks();
 
         // Round number should update to 1
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> "Round 1".equals(d.getText())));
 
         // Target button should become visible with clicks remaining
-        assertTrue($view(Button.class).all().stream().anyMatch(
+        assertTrue(findInView(Button.class).all().stream().anyMatch(
                 b -> b.getText() != null && b.getText().contains("CLICK ME!")));
     }
 
@@ -81,12 +81,12 @@ class MUC03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Clicks remaining should be 4
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Targets remaining: 4")));
 
         // User B's score should appear in leaderboard
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> s.getText() != null && s.getText().contains("1 points")));
     }
 
@@ -102,14 +102,14 @@ class MUC03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Reset scores
-        Button resetButton = $view(Button.class).all().stream()
+        Button resetButton = findInView(Button.class).all().stream()
                 .filter(b -> "Reset Scores".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(resetButton).click();
         runPendingSignalsTasks();
 
         // No score spans should remain (leaderboard cleared)
-        assertTrue($view(Span.class).all().stream().noneMatch(
+        assertTrue(findInView(Span.class).all().stream().noneMatch(
                 s -> s.getText() != null && s.getText().contains("points")));
     }
 
@@ -124,14 +124,14 @@ class MUC03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Target button should be visible — click it via the UI
-        Button targetButton = $view(Button.class).all().stream().filter(
+        Button targetButton = findInView(Button.class).all().stream().filter(
                 b -> b.getText() != null && b.getText().contains("CLICK ME!"))
                 .findFirst().orElseThrow();
         test(targetButton).click();
         runPendingSignalsTasks();
 
         // After click, clicks remaining should be 4
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains("Targets remaining: 4")));
     }

--- a/signals/src/test/java/com/example/muc04/MUC04ViewTest.java
+++ b/signals/src/test/java/com/example/muc04/MUC04ViewTest.java
@@ -29,7 +29,7 @@ class MUC04ViewTest extends SpringBrowserlessTest {
     private MUC04Signals muc04Signals;
 
     private TextField getFieldByLabel(String label) {
-        return $view(TextField.class).all().stream()
+        return findInView(TextField.class).all().stream()
                 .filter(f -> label.equals(f.getLabel())).findFirst()
                 .orElseThrow();
     }
@@ -38,8 +38,8 @@ class MUC04ViewTest extends SpringBrowserlessTest {
     void viewRendersWithThreeEditableFields() {
         navigate(MUC04View.class);
 
-        assertEquals(3, $view(TextField.class).all().size());
-        assertTrue($view(Button.class).all().stream()
+        assertEquals(3, findInView(TextField.class).all().size());
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Save Changes".equals(b.getText())));
     }
 
@@ -48,7 +48,7 @@ class MUC04ViewTest extends SpringBrowserlessTest {
         navigate(MUC04View.class);
         runPendingSignalsTasks();
 
-        $view(TextField.class).all().forEach(f -> assertTrue(f.isEnabled(),
+        findInView(TextField.class).all().forEach(f -> assertTrue(f.isEnabled(),
                 "Field '" + f.getLabel() + "' should be enabled"));
     }
 
@@ -71,7 +71,7 @@ class MUC04ViewTest extends SpringBrowserlessTest {
         navigate(MUC04View.class);
         runPendingSignalsTasks();
 
-        Checkbox lockingCheckbox = $view(Checkbox.class).first();
+        Checkbox lockingCheckbox = findInView(Checkbox.class).first();
         test(lockingCheckbox).click();
         runPendingSignalsTasks();
 
@@ -89,7 +89,7 @@ class MUC04ViewTest extends SpringBrowserlessTest {
         navigate(MUC04View.class);
         runPendingSignalsTasks();
 
-        Checkbox lockingCheckbox = $view(Checkbox.class).first();
+        Checkbox lockingCheckbox = findInView(Checkbox.class).first();
         test(lockingCheckbox).click();
         muc04Signals.startEditing("companyName", OTHER_USER);
         runPendingSignalsTasks();

--- a/signals/src/test/java/com/example/muc06/MUC06ViewTest.java
+++ b/signals/src/test/java/com/example/muc06/MUC06ViewTest.java
@@ -30,7 +30,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
     private MUC06Signals muc06Signals;
 
     private String getStatText(String prefix) {
-        return $view(Span.class).all().stream()
+        return findInView(Span.class).all().stream()
                 .filter(s -> s.getText() != null
                         && s.getText().startsWith(prefix))
                 .map(Span::getText).findFirst().orElse("");
@@ -50,7 +50,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
         navigate(MUC06View.class);
         runPendingSignalsTasks();
 
-        Button addButton = $view(Button.class).all().stream()
+        Button addButton = findInView(Button.class).all().stream()
                 .filter(b -> "Add Task".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addButton).click();
@@ -83,7 +83,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // User A adds a task via the UI
-        Button addButton = $view(Button.class).all().stream()
+        Button addButton = findInView(Button.class).all().stream()
                 .filter(b -> "Add Task".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addButton).click();
@@ -132,7 +132,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
 
         // Find the first unchecked checkbox (corresponds to first incomplete
         // task)
-        Checkbox firstCheckbox = $view(Checkbox.class).all().stream()
+        Checkbox firstCheckbox = findInView(Checkbox.class).all().stream()
                 .filter(cb -> !cb.getValue()).findFirst().orElseThrow();
         assertFalse(firstCheckbox.getValue(),
                 "Checkbox should initially be unchecked");
@@ -161,7 +161,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Get the first text field (first task's title)
-        TextField firstTitle = $view(TextField.class).first();
+        TextField firstTitle = findInView(TextField.class).first();
         String originalTitle = firstTitle.getValue();
 
         // Simulate User B renaming the first task via the shared signal
@@ -183,7 +183,7 @@ class MUC06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Get the first date picker
-        DatePicker firstDatePicker = $view(DatePicker.class).first();
+        DatePicker firstDatePicker = findInView(DatePicker.class).first();
         LocalDate newDate = LocalDate.of(2030, 12, 25);
 
         // Simulate User B changing the due date via the shared signal

--- a/signals/src/test/java/com/example/usecase01/UseCase01ViewTest.java
+++ b/signals/src/test/java/com/example/usecase01/UseCase01ViewTest.java
@@ -23,20 +23,20 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void formRendersWithAllComponents() {
         navigate(UseCase01View.class);
 
-        assertEquals(1, $view(EmailField.class).all().size());
-        assertEquals(2, $view(PasswordField.class).all().size());
-        assertEquals(1, $view(Button.class).all().size());
+        assertEquals(1, findInView(EmailField.class).all().size());
+        assertEquals(2, findInView(PasswordField.class).all().size());
+        assertEquals(1, findInView(Button.class).all().size());
     }
 
     @Test
     void submitButtonDisabledWhenFormIsEmpty() {
         navigate(UseCase01View.class);
-        test($view(EmailField.class).single()).setValue("");
-        test($view(PasswordField.class).atIndex(1)).setValue("");
-        test($view(PasswordField.class).atIndex(2)).setValue("");
+        test(findInView(EmailField.class).single()).setValue("");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertFalse(submitButton.isEnabled());
     }
 
@@ -44,12 +44,12 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void submitButtonDisabledWithInvalidEmail() {
         navigate(UseCase01View.class);
 
-        test($view(EmailField.class).single()).setValue("notanemail");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("password123");
+        test(findInView(EmailField.class).single()).setValue("notanemail");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("password123");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertFalse(submitButton.isEnabled());
     }
 
@@ -57,12 +57,12 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void submitButtonDisabledWithShortPassword() {
         navigate(UseCase01View.class);
 
-        test($view(EmailField.class).single()).setValue("user@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("short");
-        test($view(PasswordField.class).atIndex(2)).setValue("short");
+        test(findInView(EmailField.class).single()).setValue("user@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("short");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("short");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertFalse(submitButton.isEnabled());
     }
 
@@ -70,12 +70,12 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void submitButtonDisabledWhenPasswordsDontMatch() {
         navigate(UseCase01View.class);
 
-        test($view(EmailField.class).single()).setValue("user@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("different123");
+        test(findInView(EmailField.class).single()).setValue("user@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("different123");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertFalse(submitButton.isEnabled());
     }
 
@@ -83,12 +83,12 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void submitButtonEnabledWhenFormIsValid() {
         navigate(UseCase01View.class);
 
-        test($view(EmailField.class).single()).setValue("user@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("password123");
+        test(findInView(EmailField.class).single()).setValue("user@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("password123");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertTrue(submitButton.isEnabled());
     }
 
@@ -97,7 +97,7 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
         navigate(UseCase01View.class);
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertEquals("Create Account", submitButton.getText());
     }
 
@@ -105,12 +105,12 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
     void clickingSubmitChangesButtonTextAndDisablesButton() {
         navigate(UseCase01View.class);
 
-        test($view(EmailField.class).single()).setValue("user@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("password123");
+        test(findInView(EmailField.class).single()).setValue("user@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("password123");
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         test(submitButton).click();
         runPendingSignalsTasks();
 
@@ -123,20 +123,20 @@ class UseCase01ViewTest extends SpringBrowserlessTest {
         navigate(UseCase01View.class);
 
         // Fill valid form
-        test($view(EmailField.class).single()).setValue("user@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("password123");
+        test(findInView(EmailField.class).single()).setValue("user@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("password123");
         runPendingSignalsTasks();
-        assertTrue($view(Button.class).single().isEnabled());
+        assertTrue(findInView(Button.class).single().isEnabled());
 
         // Break form (clear email)
-        test($view(EmailField.class).single()).setValue("");
+        test(findInView(EmailField.class).single()).setValue("");
         runPendingSignalsTasks();
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
 
         // Fix form again
-        test($view(EmailField.class).single()).setValue("other@example.com");
+        test(findInView(EmailField.class).single()).setValue("other@example.com");
         runPendingSignalsTasks();
-        assertTrue($view(Button.class).single().isEnabled());
+        assertTrue(findInView(Button.class).single().isEnabled());
     }
 }

--- a/signals/src/test/java/com/example/usecase02/UseCase02ViewTest.java
+++ b/signals/src/test/java/com/example/usecase02/UseCase02ViewTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @WithMockUser
 class UseCase02ViewTest extends SpringBrowserlessTest {
 
-    // $view() only returns VISIBLE components. Hidden sections' children
+    // findInView() only returns VISIBLE components. Hidden sections' children
     // are not found. We test visibility by checking component presence.
 
     @Test
@@ -29,8 +29,8 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
 
         // Only needsVisa checkbox visible; visa type ComboBox is in hidden
         // section
-        assertEquals(1, $view(Checkbox.class).all().size());
-        assertFalse($view(ComboBox.class).all().stream()
+        assertEquals(1, findInView(Checkbox.class).all().size());
+        assertFalse(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "Visa Type".equals(c.getLabel())));
     }
 
@@ -38,26 +38,26 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
     void checkingVisaShowsVisaSection() {
         navigate(UseCase02View.class);
 
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
         // Visa type ComboBox now visible (in visaSection)
-        assertTrue($view(ComboBox.class).all().stream()
+        assertTrue(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "Visa Type".equals(c.getLabel())));
         // H1B section also visible (default type is H1B)
         // -> hasH1BPreviouslyCheckbox visible
-        assertEquals(2, $view(Checkbox.class).all().size());
+        assertEquals(2, findInView(Checkbox.class).all().size());
     }
 
     @Test
     void h1bFieldsVisibleWhenVisaCheckedAndH1BSelected() {
         navigate(UseCase02View.class);
 
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
         // H1B is default -> "Specialty Occupation" field should be visible
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Specialty Occupation".equals(f.getLabel())));
     }
 
@@ -65,11 +65,11 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
     void previousH1BFieldsHiddenByDefault() {
         navigate(UseCase02View.class);
 
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
         // hasH1BPreviously is false -> previous employer fields hidden
-        assertFalse($view(TextField.class).all().stream()
+        assertFalse(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Previous Employer".equals(f.getLabel())));
     }
 
@@ -78,20 +78,20 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
         navigate(UseCase02View.class);
 
         // Check needsVisa
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
         // Check hasH1BPreviously
-        Checkbox hasH1BPreviously = $view(Checkbox.class).all().stream()
+        Checkbox hasH1BPreviously = findInView(Checkbox.class).all().stream()
                 .filter(c -> c.getLabel().contains("H1-B")).findFirst()
                 .orElseThrow();
         test(hasH1BPreviously).click();
         runPendingSignalsTasks();
 
         // Previous employer fields now visible
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Previous Employer".equals(f.getLabel())));
-        assertTrue($view(TextField.class).all().stream().anyMatch(
+        assertTrue(findInView(TextField.class).all().stream().anyMatch(
                 f -> "Previous Petition Number".equals(f.getLabel())));
     }
 
@@ -100,11 +100,11 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
     void l1FieldsVisibleWhenL1Selected() {
         navigate(UseCase02View.class);
 
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
         // Change visa type to L1
-        ComboBox<VisaType> visaTypeSelect = (ComboBox<VisaType>) $view(
+        ComboBox<VisaType> visaTypeSelect = (ComboBox<VisaType>) findInView(
                 ComboBox.class).all().stream()
                 .filter(c -> "Visa Type".equals(c.getLabel())).findFirst()
                 .orElseThrow();
@@ -112,9 +112,9 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // L1 fields visible, H1B fields hidden
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Parent Company Name".equals(f.getLabel())));
-        assertFalse($view(TextField.class).all().stream()
+        assertFalse(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Specialty Occupation".equals(f.getLabel())));
     }
 
@@ -123,17 +123,17 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
     void o1FieldsVisibleWhenO1Selected() {
         navigate(UseCase02View.class);
 
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
 
-        ComboBox<VisaType> visaTypeSelect = (ComboBox<VisaType>) $view(
+        ComboBox<VisaType> visaTypeSelect = (ComboBox<VisaType>) findInView(
                 ComboBox.class).all().stream()
                 .filter(c -> "Visa Type".equals(c.getLabel())).findFirst()
                 .orElseThrow();
         test(visaTypeSelect).selectItem("O1");
         runPendingSignalsTasks();
 
-        assertTrue($view(TextField.class).all().stream().anyMatch(
+        assertTrue(findInView(TextField.class).all().stream().anyMatch(
                 f -> "Field of Extraordinary Ability".equals(f.getLabel())));
     }
 
@@ -142,21 +142,21 @@ class UseCase02ViewTest extends SpringBrowserlessTest {
         navigate(UseCase02View.class);
 
         // Check visa
-        test($view(Checkbox.class).single()).click();
+        test(findInView(Checkbox.class).single()).click();
         runPendingSignalsTasks();
-        assertTrue($view(ComboBox.class).all().size() > 0);
+        assertTrue(findInView(ComboBox.class).all().size() > 0);
 
         // Uncheck visa
-        Checkbox needsVisa = $view(Checkbox.class).all().stream()
+        Checkbox needsVisa = findInView(Checkbox.class).all().stream()
                 .filter(c -> c.getLabel().contains("visa sponsorship"))
                 .findFirst().orElseThrow();
         test(needsVisa).click();
         runPendingSignalsTasks();
 
         // No ComboBoxes visible (visa type is hidden)
-        assertFalse($view(ComboBox.class).all().stream()
+        assertFalse(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "Visa Type".equals(c.getLabel())));
         // Only 1 checkbox remains visible
-        assertEquals(1, $view(Checkbox.class).all().size());
+        assertEquals(1, findInView(Checkbox.class).all().size());
     }
 }

--- a/signals/src/test/java/com/example/usecase03/UseCase03ViewTest.java
+++ b/signals/src/test/java/com/example/usecase03/UseCase03ViewTest.java
@@ -23,7 +23,7 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
     @Test
     void viewRendersWithTabs() {
         navigate(UseCase03View.class);
-        assertEquals(1, $view(Tabs.class).all().size());
+        assertEquals(1, findInView(Tabs.class).all().size());
     }
 
     @Test
@@ -32,14 +32,14 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Rectangle tab is shown by default with its sliders
-        assertTrue($view(IntegerSlider.class).all().size() >= 5);
+        assertTrue(findInView(IntegerSlider.class).all().size() >= 5);
     }
 
     @Test
     void viewRendersWithResetButton() {
         navigate(UseCase03View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Reset to Defaults".equals(b.getText())));
     }
 
@@ -49,7 +49,7 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Rectangle controls: Fill and Stroke ComboBoxes
-        assertTrue($view(ComboBox.class).all().size() >= 2);
+        assertTrue(findInView(ComboBox.class).all().size() >= 2);
     }
 
     @Test
@@ -59,17 +59,17 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
 
         // Rectangle tab (index 0) is selected by default
         // Rectangle controls should have a "Width" slider visible
-        assertTrue($view(IntegerSlider.class).all().stream()
+        assertTrue(findInView(IntegerSlider.class).all().stream()
                 .anyMatch(s -> "Width".equals(s.getLabel())));
 
         // Switch to Star tab (index 1)
-        Tabs tabs = $view(Tabs.class).single();
+        Tabs tabs = findInView(Tabs.class).single();
         Tab starTab = (Tab) tabs.getComponentAt(1);
         tabs.setSelectedTab(starTab);
         runPendingSignalsTasks();
 
         // Star controls should now show "Points" slider
-        assertTrue($view(IntegerSlider.class).all().stream()
+        assertTrue(findInView(IntegerSlider.class).all().stream()
                 .anyMatch(s -> "Points".equals(s.getLabel())));
     }
 
@@ -79,7 +79,7 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Find the Width slider and change its value (default is 150)
-        IntegerSlider widthSlider = $view(IntegerSlider.class).all().stream()
+        IntegerSlider widthSlider = findInView(IntegerSlider.class).all().stream()
                 .filter(s -> "Width".equals(s.getLabel())).findFirst()
                 .orElseThrow();
         widthSlider.setValue(200);
@@ -87,7 +87,7 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         assertEquals(200, widthSlider.getValue());
 
         // Click Reset to Defaults
-        Button resetButton = $view(Button.class).all().stream()
+        Button resetButton = findInView(Button.class).all().stream()
                 .filter(b -> "Reset to Defaults".equals(b.getText()))
                 .findFirst().orElseThrow();
         test(resetButton).click();
@@ -103,7 +103,7 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Find the X position slider and set a value
-        IntegerSlider xSlider = $view(IntegerSlider.class).all().stream()
+        IntegerSlider xSlider = findInView(IntegerSlider.class).all().stream()
                 .filter(s -> "X".equals(s.getLabel())).findFirst()
                 .orElseThrow();
         xSlider.setValue(250);
@@ -118,9 +118,9 @@ class UseCase03ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Rectangle-specific sliders should be present
-        assertTrue($view(IntegerSlider.class).all().stream()
+        assertTrue(findInView(IntegerSlider.class).all().stream()
                 .anyMatch(s -> "Corner Radius".equals(s.getLabel())));
-        assertTrue($view(IntegerSlider.class).all().stream()
+        assertTrue(findInView(IntegerSlider.class).all().stream()
                 .anyMatch(s -> "Height".equals(s.getLabel())));
     }
 }

--- a/signals/src/test/java/com/example/usecase04/UseCase04ViewTest.java
+++ b/signals/src/test/java/com/example/usecase04/UseCase04ViewTest.java
@@ -22,10 +22,10 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
     void viewRendersWithFilterAndGrid() {
         navigate(UseCase04View.class);
 
-        assertEquals(1, $view(ComboBox.class).all().size());
-        assertEquals(1, $view(TextField.class).all().size());
-        assertEquals(1, $view(Checkbox.class).all().size());
-        assertEquals(1, $view(Grid.class).all().size());
+        assertEquals(1, findInView(ComboBox.class).all().size());
+        assertEquals(1, findInView(TextField.class).all().size());
+        assertEquals(1, findInView(Checkbox.class).all().size());
+        assertEquals(1, findInView(Grid.class).all().size());
     }
 
     @SuppressWarnings("unchecked")
@@ -34,7 +34,7 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        Grid<Product> grid = $view(Grid.class).single();
+        Grid<Product> grid = findInView(Grid.class).single();
         assertEquals(10, test(grid).size());
     }
 
@@ -44,11 +44,11 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> categoryFilter = $view(ComboBox.class).single();
+        ComboBox<String> categoryFilter = findInView(ComboBox.class).single();
         test(categoryFilter).selectItem("Electronics");
         runPendingSignalsTasks();
 
-        Grid<Product> grid = $view(Grid.class).single();
+        Grid<Product> grid = findInView(Grid.class).single();
         assertEquals(3, test(grid).size());
     }
 
@@ -58,11 +58,11 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        TextField searchField = $view(TextField.class).single();
+        TextField searchField = findInView(TextField.class).single();
         test(searchField).setValue("laptop");
         runPendingSignalsTasks();
 
-        Grid<Product> grid = $view(Grid.class).single();
+        Grid<Product> grid = findInView(Grid.class).single();
         assertEquals(1, test(grid).size());
     }
 
@@ -72,11 +72,11 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        Checkbox inStockCheckbox = $view(Checkbox.class).single();
+        Checkbox inStockCheckbox = findInView(Checkbox.class).single();
         test(inStockCheckbox).click();
         runPendingSignalsTasks();
 
-        Grid<Product> grid = $view(Grid.class).single();
+        Grid<Product> grid = findInView(Grid.class).single();
         // P003 (stock=0) and P005 (stock=0) excluded -> 8 items
         assertEquals(8, test(grid).size());
     }
@@ -87,14 +87,14 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> categoryFilter = $view(ComboBox.class).single();
+        ComboBox<String> categoryFilter = findInView(ComboBox.class).single();
         test(categoryFilter).selectItem("Electronics");
 
-        Checkbox inStockCheckbox = $view(Checkbox.class).single();
+        Checkbox inStockCheckbox = findInView(Checkbox.class).single();
         test(inStockCheckbox).click();
         runPendingSignalsTasks();
 
-        Grid<Product> grid = $view(Grid.class).single();
+        Grid<Product> grid = findInView(Grid.class).single();
         // Electronics: Laptop(15), Mouse(0), Keyboard(8) -> in-stock: 2
         assertEquals(2, test(grid).size());
     }
@@ -105,15 +105,15 @@ class UseCase04ViewTest extends SpringBrowserlessTest {
         navigate(UseCase04View.class);
         runPendingSignalsTasks();
 
-        TextField searchField = $view(TextField.class).single();
+        TextField searchField = findInView(TextField.class).single();
         test(searchField).setValue("laptop");
         runPendingSignalsTasks();
         assertEquals(1,
-                test((Grid<Product>) $view(Grid.class).single()).size());
+                test((Grid<Product>) findInView(Grid.class).single()).size());
 
         test(searchField).setValue("");
         runPendingSignalsTasks();
         assertEquals(10,
-                test((Grid<Product>) $view(Grid.class).single()).size());
+                test((Grid<Product>) findInView(Grid.class).single()).size());
     }
 }

--- a/signals/src/test/java/com/example/usecase05/UseCase05ViewTest.java
+++ b/signals/src/test/java/com/example/usecase05/UseCase05ViewTest.java
@@ -20,7 +20,7 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
     @Test
     void viewRendersThreeComboBoxes() {
         navigate(UseCase05View.class);
-        assertEquals(3, $view(ComboBox.class).all().size());
+        assertEquals(3, findInView(ComboBox.class).all().size());
     }
 
     @SuppressWarnings("unchecked")
@@ -29,7 +29,7 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
         navigate(UseCase05View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> countrySelect = $view(ComboBox.class).atIndex(1);
+        ComboBox<String> countrySelect = findInView(ComboBox.class).atIndex(1);
         assertEquals("United States", countrySelect.getValue());
     }
 
@@ -39,7 +39,7 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
         navigate(UseCase05View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> stateSelect = $view(ComboBox.class).atIndex(2);
+        ComboBox<String> stateSelect = findInView(ComboBox.class).atIndex(2);
         assertTrue(stateSelect.isEnabled());
     }
 
@@ -49,7 +49,7 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
         navigate(UseCase05View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> citySelect = $view(ComboBox.class).atIndex(3);
+        ComboBox<String> citySelect = findInView(ComboBox.class).atIndex(3);
         assertFalse(citySelect.isEnabled());
     }
 
@@ -59,11 +59,11 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
         navigate(UseCase05View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> stateSelect = $view(ComboBox.class).atIndex(2);
+        ComboBox<String> stateSelect = findInView(ComboBox.class).atIndex(2);
         test(stateSelect).selectItem("California");
         runPendingSignalsTasks();
 
-        ComboBox<String> citySelect = $view(ComboBox.class).atIndex(3);
+        ComboBox<String> citySelect = findInView(ComboBox.class).atIndex(3);
         assertTrue(citySelect.isEnabled());
     }
 
@@ -74,12 +74,12 @@ class UseCase05ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Select a state first
-        ComboBox<String> stateSelect = $view(ComboBox.class).atIndex(2);
+        ComboBox<String> stateSelect = findInView(ComboBox.class).atIndex(2);
         test(stateSelect).selectItem("California");
         runPendingSignalsTasks();
 
         // Change country
-        ComboBox<String> countrySelect = $view(ComboBox.class).atIndex(1);
+        ComboBox<String> countrySelect = findInView(ComboBox.class).atIndex(1);
         test(countrySelect).selectItem("Canada");
         runPendingSignalsTasks();
 

--- a/signals/src/test/java/com/example/usecase06/UseCase06ViewTest.java
+++ b/signals/src/test/java/com/example/usecase06/UseCase06ViewTest.java
@@ -24,7 +24,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         navigate(UseCase06View.class);
 
         // 4 "Add" buttons for products + "Empty cart" button
-        long addButtons = $view(Button.class).all().stream()
+        long addButtons = findInView(Button.class).all().stream()
                 .filter(b -> "Add".equals(b.getText())).count();
         assertEquals(4, addButtons);
     }
@@ -33,7 +33,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
     void emptyCartButtonPresent() {
         navigate(UseCase06View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Empty cart".equals(b.getText())));
     }
 
@@ -42,7 +42,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         navigate(UseCase06View.class);
         runPendingSignalsTasks();
 
-        Span subtotalLabel = $view(Span.class).all().stream().filter(
+        Span subtotalLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Subtotal:"))
                 .findFirst().orElseThrow();
         assertEquals("Subtotal: $0.00", subtotalLabel.getText());
@@ -54,13 +54,13 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Click first "Add" button (Laptop - $999.99)
-        Button addLaptop = $view(Button.class).all().stream()
+        Button addLaptop = findInView(Button.class).all().stream()
                 .filter(b -> "Add".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addLaptop).click();
         runPendingSignalsTasks();
 
-        Span subtotalLabel = $view(Span.class).all().stream().filter(
+        Span subtotalLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Subtotal:"))
                 .findFirst().orElseThrow();
         assertEquals("Subtotal: $999.99", subtotalLabel.getText());
@@ -70,7 +70,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
     void shippingSelectPresent() {
         navigate(UseCase06View.class);
 
-        assertTrue($view(ComboBox.class).all().stream()
+        assertTrue(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "Shipping Method".equals(c.getLabel())));
     }
 
@@ -78,7 +78,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
     void discountCodeFieldPresent() {
         navigate(UseCase06View.class);
 
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Discount Code".equals(f.getLabel())));
     }
 
@@ -87,7 +87,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         navigate(UseCase06View.class);
         runPendingSignalsTasks();
 
-        Span shippingLabel = $view(Span.class).all().stream().filter(
+        Span shippingLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Shipping:"))
                 .findFirst().orElseThrow();
         assertEquals("Shipping: $5.99", shippingLabel.getText());
@@ -98,7 +98,7 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         navigate(UseCase06View.class);
         runPendingSignalsTasks();
 
-        Span totalLabel = $view(Span.class).all().stream().filter(
+        Span totalLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Total:"))
                 .findFirst().orElseThrow();
         // Subtotal $0 - discount $0 + shipping $5.99 + tax 8% of $0 = $5.99
@@ -111,21 +111,21 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Add Laptop ($999.99)
-        Button addLaptop = $view(Button.class).all().stream()
+        Button addLaptop = findInView(Button.class).all().stream()
                 .filter(b -> "Add".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addLaptop).click();
         runPendingSignalsTasks();
 
         // Enter discount code
-        TextField discountField = $view(TextField.class).all().stream()
+        TextField discountField = findInView(TextField.class).all().stream()
                 .filter(f -> "Discount Code".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(discountField).setValue("SAVE10");
         runPendingSignalsTasks();
 
         // Discount label should be visible (> $0)
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().startsWith("Discount:")));
     }
@@ -136,13 +136,13 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Add Laptop ($999.99) once
-        Button addLaptop = $view(Button.class).all().stream()
+        Button addLaptop = findInView(Button.class).all().stream()
                 .filter(b -> "Add".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addLaptop).click();
         runPendingSignalsTasks();
 
-        Span subtotalLabel = $view(Span.class).all().stream().filter(
+        Span subtotalLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Subtotal:"))
                 .findFirst().orElseThrow();
         assertEquals("Subtotal: $999.99", subtotalLabel.getText());
@@ -160,20 +160,20 @@ class UseCase06ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Add a product
-        Button addLaptop = $view(Button.class).all().stream()
+        Button addLaptop = findInView(Button.class).all().stream()
                 .filter(b -> "Add".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addLaptop).click();
         runPendingSignalsTasks();
 
         // Click "Empty cart"
-        Button emptyCartButton = $view(Button.class).all().stream()
+        Button emptyCartButton = findInView(Button.class).all().stream()
                 .filter(b -> "Empty cart".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(emptyCartButton).click();
         runPendingSignalsTasks();
 
-        Span subtotalLabel = $view(Span.class).all().stream().filter(
+        Span subtotalLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Subtotal:"))
                 .findFirst().orElseThrow();
         assertEquals("Subtotal: $0.00", subtotalLabel.getText());

--- a/signals/src/test/java/com/example/usecase08/UseCase08ViewTest.java
+++ b/signals/src/test/java/com/example/usecase08/UseCase08ViewTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @WithMockUser
 class UseCase08ViewTest extends SpringBrowserlessTest {
 
-    // $view() only returns VISIBLE components. Hidden step layouts
+    // findInView() only returns VISIBLE components. Hidden step layouts
     // and hidden buttons (Previous, Submit) are not found.
 
     @Test
@@ -30,12 +30,12 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Step 1 fields visible
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "First Name".equals(f.getLabel())));
-        assertEquals(1, $view(EmailField.class).all().size());
+        assertEquals(1, findInView(EmailField.class).all().size());
 
         // Step 2 fields NOT visible
-        assertFalse($view(TextField.class).all().stream()
+        assertFalse(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Company Name".equals(f.getLabel())));
     }
 
@@ -44,7 +44,7 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         navigate(UseCase08View.class);
         runPendingSignalsTasks();
 
-        Span progress = $view(Span.class).all().stream()
+        Span progress = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().contains("Step")).findFirst()
                 .orElseThrow();
         assertEquals("Step 1 of 4", progress.getText());
@@ -56,7 +56,7 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // On step 1: only "Next" button is visible (Previous/Submit are hidden)
-        Button nextButton = $view(Button.class).all().stream()
+        Button nextButton = findInView(Button.class).all().stream()
                 .filter(b -> "Next".equals(b.getText())).findFirst()
                 .orElseThrow();
         assertFalse(nextButton.isEnabled());
@@ -68,8 +68,8 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Previous button has bindVisible(step != PERSONAL_INFO),
-        // so it's hidden on step 1 and NOT found by $view()
-        assertFalse($view(Button.class).all().stream()
+        // so it's hidden on step 1 and NOT found by findInView()
+        assertFalse(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Previous".equals(b.getText())));
     }
 
@@ -78,7 +78,7 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         navigate(UseCase08View.class);
         fillStep1();
 
-        Button nextButton = $view(Button.class).all().stream()
+        Button nextButton = findInView(Button.class).all().stream()
                 .filter(b -> "Next".equals(b.getText())).findFirst()
                 .orElseThrow();
         assertTrue(nextButton.isEnabled());
@@ -91,13 +91,13 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         clickNext();
 
         // Step 2 fields visible
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Company Name".equals(f.getLabel())));
         // Step 1 fields hidden
-        assertFalse($view(TextField.class).all().stream()
+        assertFalse(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "First Name".equals(f.getLabel())));
         // Previous button now visible
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Previous".equals(b.getText())));
     }
 
@@ -107,14 +107,14 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         fillStep1();
         clickNext();
 
-        Button previousButton = $view(Button.class).all().stream()
+        Button previousButton = findInView(Button.class).all().stream()
                 .filter(b -> "Previous".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(previousButton).click();
         runPendingSignalsTasks();
 
         // Step 1 fields visible again
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "First Name".equals(f.getLabel())));
     }
 
@@ -129,21 +129,21 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
         clickNext();
 
         // Submit button visible on step 4
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Submit".equals(b.getText())));
         // Next button hidden on step 4
-        assertFalse($view(Button.class).all().stream()
+        assertFalse(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Next".equals(b.getText())));
     }
 
     private void fillStep1() {
-        TextField firstName = $view(TextField.class).all().stream()
+        TextField firstName = findInView(TextField.class).all().stream()
                 .filter(f -> "First Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
-        TextField lastName = $view(TextField.class).all().stream()
+        TextField lastName = findInView(TextField.class).all().stream()
                 .filter(f -> "Last Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
-        EmailField email = $view(EmailField.class).single();
+        EmailField email = findInView(EmailField.class).single();
 
         test(firstName).setValue("John");
         test(lastName).setValue("Doe");
@@ -153,17 +153,17 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
 
     @SuppressWarnings("unchecked")
     private void fillStep2() {
-        TextField companyName = $view(TextField.class).all().stream()
+        TextField companyName = findInView(TextField.class).all().stream()
                 .filter(f -> "Company Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(companyName).setValue("Acme Corp");
 
-        ComboBox<String> companySize = $view(ComboBox.class).all().stream()
+        ComboBox<String> companySize = findInView(ComboBox.class).all().stream()
                 .filter(c -> "Company Size".equals(c.getLabel())).findFirst()
                 .orElseThrow();
         test(companySize).selectItem("11-50");
 
-        ComboBox<String> industry = $view(ComboBox.class).all().stream()
+        ComboBox<String> industry = findInView(ComboBox.class).all().stream()
                 .filter(c -> "Industry".equals(c.getLabel())).findFirst()
                 .orElseThrow();
         test(industry).selectItem("Technology");
@@ -171,7 +171,7 @@ class UseCase08ViewTest extends SpringBrowserlessTest {
     }
 
     private void clickNext() {
-        Button nextButton = $view(Button.class).all().stream()
+        Button nextButton = findInView(Button.class).all().stream()
                 .filter(b -> "Next".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(nextButton).click();

--- a/signals/src/test/java/com/example/usecase09/UseCase09ViewTest.java
+++ b/signals/src/test/java/com/example/usecase09/UseCase09ViewTest.java
@@ -27,12 +27,12 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
     void viewRendersWithAllFormFields() {
         navigate(UseCase09View.class);
 
-        assertEquals(1, $view(TextField.class).all().size());
-        assertEquals(1, $view(EmailField.class).all().size());
-        assertEquals(2, $view(PasswordField.class).all().size());
-        assertEquals(1, $view(ComboBox.class).all().size());
-        assertEquals(1, $view(IntegerField.class).all().size());
-        assertEquals(1, $view(Button.class).all().size());
+        assertEquals(1, findInView(TextField.class).all().size());
+        assertEquals(1, findInView(EmailField.class).all().size());
+        assertEquals(2, findInView(PasswordField.class).all().size());
+        assertEquals(1, findInView(ComboBox.class).all().size());
+        assertEquals(1, findInView(IntegerField.class).all().size());
+        assertEquals(1, findInView(Button.class).all().size());
     }
 
     @Test
@@ -40,7 +40,7 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         runPendingSignalsTasks();
 
-        Button submitButton = $view(Button.class).single();
+        Button submitButton = findInView(Button.class).single();
         assertFalse(submitButton.isEnabled());
     }
 
@@ -50,10 +50,10 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         fillValidForm();
 
         // Override username with short value
-        test($view(TextField.class).single()).setValue("ab");
+        test(findInView(TextField.class).single()).setValue("ab");
         runPendingSignalsTasks();
 
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
     }
 
     @Test
@@ -61,10 +61,10 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         fillValidForm();
 
-        test($view(EmailField.class).single()).setValue("notanemail");
+        test(findInView(EmailField.class).single()).setValue("notanemail");
         runPendingSignalsTasks();
 
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
     }
 
     @Test
@@ -72,11 +72,11 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         fillValidForm();
 
-        test($view(PasswordField.class).atIndex(1)).setValue("short");
-        test($view(PasswordField.class).atIndex(2)).setValue("short");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("short");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("short");
         runPendingSignalsTasks();
 
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
     }
 
     @Test
@@ -84,10 +84,10 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         fillValidForm();
 
-        test($view(PasswordField.class).atIndex(2)).setValue("different1");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("different1");
         runPendingSignalsTasks();
 
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
     }
 
     @SuppressWarnings("unchecked")
@@ -97,13 +97,13 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         fillValidForm();
 
         // Switch to BUSINESS account
-        ComboBox<AccountType> accountType = $view(ComboBox.class).single();
+        ComboBox<AccountType> accountType = findInView(ComboBox.class).single();
         test(accountType).selectItem("BUSINESS");
         // Age 15 is valid for PERSONAL but not BUSINESS
-        test($view(IntegerField.class).single()).setValue(15);
+        test(findInView(IntegerField.class).single()).setValue(15);
         runPendingSignalsTasks();
 
-        assertFalse($view(Button.class).single().isEnabled());
+        assertFalse(findInView(Button.class).single().isEnabled());
     }
 
     @Test
@@ -111,7 +111,7 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         fillValidForm();
 
-        assertTrue($view(Button.class).single().isEnabled());
+        assertTrue(findInView(Button.class).single().isEnabled());
     }
 
     @Test
@@ -119,7 +119,7 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         fillValidForm();
 
-        Span statusLabel = $view(Span.class).all().stream()
+        Span statusLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().contains("Form is valid")
                         || s.getText().contains("Please complete"))
                 .findFirst().orElseThrow();
@@ -131,7 +131,7 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
         navigate(UseCase09View.class);
         runPendingSignalsTasks();
 
-        Span statusLabel = $view(Span.class).all().stream()
+        Span statusLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().contains("Form is valid")
                         || s.getText().contains("Please complete"))
                 .findFirst().orElseThrow();
@@ -141,13 +141,13 @@ class UseCase09ViewTest extends SpringBrowserlessTest {
 
     @SuppressWarnings("unchecked")
     private void fillValidForm() {
-        test($view(TextField.class).single()).setValue("johndoe");
-        test($view(EmailField.class).single()).setValue("john@example.com");
-        test($view(PasswordField.class).atIndex(1)).setValue("password123");
-        test($view(PasswordField.class).atIndex(2)).setValue("password123");
-        ComboBox<AccountType> accountType = $view(ComboBox.class).single();
+        test(findInView(TextField.class).single()).setValue("johndoe");
+        test(findInView(EmailField.class).single()).setValue("john@example.com");
+        test(findInView(PasswordField.class).atIndex(1)).setValue("password123");
+        test(findInView(PasswordField.class).atIndex(2)).setValue("password123");
+        ComboBox<AccountType> accountType = findInView(ComboBox.class).single();
         test(accountType).selectItem("PERSONAL");
-        test($view(IntegerField.class).single()).setValue(25);
+        test(findInView(IntegerField.class).single()).setValue(25);
         runPendingSignalsTasks();
     }
 }

--- a/signals/src/test/java/com/example/usecase10/UseCase10ViewTest.java
+++ b/signals/src/test/java/com/example/usecase10/UseCase10ViewTest.java
@@ -22,7 +22,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
     void viewRendersWithUploadComponent() {
         navigate(UseCase10View.class);
 
-        assertEquals(1, $view(Upload.class).all().size());
+        assertEquals(1, findInView(Upload.class).all().size());
     }
 
     @Test
@@ -30,7 +30,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         navigate(UseCase10View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Paragraph.class).all().stream()
+        assertTrue(findInView(Paragraph.class).all().stream()
                 .anyMatch(p -> p.getText() != null && p.getText()
                         .contains("Idle — no upload in progress")));
     }
@@ -40,7 +40,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         navigate(UseCase10View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "None pressed yet".equals(s.getText())));
     }
 
@@ -50,7 +50,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Initially light mode
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Light Mode".equals(s.getText())));
 
         // Simulate OS dark mode change via @ClientCallable
@@ -58,7 +58,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         view.onDarkModeChange(true);
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Dark Mode".equals(s.getText())));
     }
 
@@ -70,12 +70,12 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         UseCase10View view = (UseCase10View) getCurrentView();
         view.onDarkModeChange(true);
         runPendingSignalsTasks();
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Dark Mode".equals(s.getText())));
 
         view.onDarkModeChange(false);
         runPendingSignalsTasks();
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Light Mode".equals(s.getText())));
     }
 
@@ -85,7 +85,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Default summary should contain "Theme: light"
-        assertTrue($view(Paragraph.class).all().stream()
+        assertTrue(findInView(Paragraph.class).all().stream()
                 .anyMatch(p -> p.getText() != null
                         && p.getText().contains("Theme: light")));
 
@@ -94,7 +94,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         view.onDarkModeChange(true);
         runPendingSignalsTasks();
 
-        assertTrue($view(Paragraph.class).all().stream()
+        assertTrue(findInView(Paragraph.class).all().stream()
                 .anyMatch(p -> p.getText() != null
                         && p.getText().contains("Theme: dark")));
     }
@@ -104,7 +104,7 @@ class UseCase10ViewTest extends SpringBrowserlessTest {
         navigate(UseCase10View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Paragraph.class).all().stream()
+        assertTrue(findInView(Paragraph.class).all().stream()
                 .anyMatch(p -> p.getText() != null
                         && p.getText().contains("Upload:")
                         && p.getText().contains("Shortcut:")

--- a/signals/src/test/java/com/example/usecase11/UseCase11ViewTest.java
+++ b/signals/src/test/java/com/example/usecase11/UseCase11ViewTest.java
@@ -21,7 +21,7 @@ class UseCase11ViewTest extends SpringBrowserlessTest {
     @Test
     void viewRendersWithSplitLayout() {
         navigate(UseCase11View.class);
-        assertEquals(1, $view(SplitLayout.class).all().size());
+        assertEquals(1, findInView(SplitLayout.class).all().size());
     }
 
     @Test
@@ -32,13 +32,13 @@ class UseCase11ViewTest extends SpringBrowserlessTest {
         // Initial size from sizeSignal is (0, 0) which is small (< 400px)
         // until the ResizeObserver reports the actual size from the browser
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("Small Width Layout")));
         assertFalse(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("Medium Width Layout")));
         assertFalse(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("Large Width Layout")));
     }
 }

--- a/signals/src/test/java/com/example/usecase13/UseCase13ViewTest.java
+++ b/signals/src/test/java/com/example/usecase13/UseCase13ViewTest.java
@@ -31,7 +31,7 @@ class UseCase13ViewTest extends SpringBrowserlessTest {
 
         // The counter box should show "Currently Online" text
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("Currently Online")));
     }
 
@@ -41,7 +41,7 @@ class UseCase13ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // The mock user's own session is already registered by the framework
-        int initialCount = $view(Card.class).all().size();
+        int initialCount = findInView(Card.class).all().size();
 
         // Register 2 additional fake users
         userSessionRegistry.registerUser("alice", "session-a");
@@ -49,7 +49,7 @@ class UseCase13ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Should have 2 more cards than initial
-        assertEquals(initialCount + 2, $view(Card.class).all().size());
+        assertEquals(initialCount + 2, findInView(Card.class).all().size());
     }
 
     @Test
@@ -65,7 +65,7 @@ class UseCase13ViewTest extends SpringBrowserlessTest {
 
         int expectedCount = initialCount + 2;
         // Counter should show the expected count
-        assertTrue($view(H3.class).all().stream()
+        assertTrue(findInView(H3.class).all().stream()
                 .anyMatch(h -> h.getText() != null && h.getText()
                         .contains(String.valueOf(expectedCount))));
     }

--- a/signals/src/test/java/com/example/usecase14/UseCase14ViewTest.java
+++ b/signals/src/test/java/com/example/usecase14/UseCase14ViewTest.java
@@ -23,7 +23,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
     void viewRendersWithLoadButton() {
         navigate(UseCase14View.class);
 
-        assertTrue($view(Button.class).all().stream().anyMatch(
+        assertTrue(findInView(Button.class).all().stream().anyMatch(
                 b -> "Generate Analytics Report".equals(b.getText())));
     }
 
@@ -31,7 +31,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
     void viewRendersWithErrorToggle() {
         navigate(UseCase14View.class);
 
-        assertTrue($view(Checkbox.class).all().stream()
+        assertTrue(findInView(Checkbox.class).all().stream()
                 .anyMatch(c -> "Simulate Error".equals(c.getLabel())));
     }
 
@@ -40,7 +40,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
         navigate(UseCase14View.class);
         runPendingSignalsTasks();
 
-        Button loadButton = $view(Button.class).all().stream()
+        Button loadButton = findInView(Button.class).all().stream()
                 .filter(b -> "Generate Analytics Report".equals(b.getText()))
                 .findFirst().orElseThrow();
         assertTrue(loadButton.isEnabled());
@@ -52,7 +52,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Idle message should be visible
-        assertTrue($view(Paragraph.class).all().stream()
+        assertTrue(findInView(Paragraph.class).all().stream()
                 .anyMatch(p -> p.getText() != null
                         && p.getText().contains("Generate Analytics Report")));
     }
@@ -62,7 +62,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
         navigate(UseCase14View.class);
         runPendingSignalsTasks();
 
-        Button loadButton = $view(Button.class).all().stream()
+        Button loadButton = findInView(Button.class).all().stream()
                 .filter(b -> "Generate Analytics Report".equals(b.getText()))
                 .findFirst().orElseThrow();
         test(loadButton).click();
@@ -72,7 +72,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
         assertFalse(loadButton.isEnabled());
 
         // Loading ProgressBar should be visible
-        assertTrue($view(ProgressBar.class).all().stream()
+        assertTrue(findInView(ProgressBar.class).all().stream()
                 .anyMatch(ProgressBar::isIndeterminate));
     }
 
@@ -81,7 +81,7 @@ class UseCase14ViewTest extends SpringBrowserlessTest {
         navigate(UseCase14View.class);
         runPendingSignalsTasks();
 
-        Checkbox errorCheckbox = $view(Checkbox.class).all().stream()
+        Checkbox errorCheckbox = findInView(Checkbox.class).all().stream()
                 .filter(c -> "Simulate Error".equals(c.getLabel())).findFirst()
                 .orElseThrow();
 

--- a/signals/src/test/java/com/example/usecase15/UseCase15ViewTest.java
+++ b/signals/src/test/java/com/example/usecase15/UseCase15ViewTest.java
@@ -21,7 +21,7 @@ class UseCase15ViewTest extends SpringBrowserlessTest {
     void viewRendersWithSearchField() {
         navigate(UseCase15View.class);
 
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Search Products".equals(f.getLabel())));
     }
 
@@ -29,7 +29,7 @@ class UseCase15ViewTest extends SpringBrowserlessTest {
     void searchFieldPlaceholderPresent() {
         navigate(UseCase15View.class);
 
-        TextField searchField = $view(TextField.class).all().stream()
+        TextField searchField = findInView(TextField.class).all().stream()
                 .filter(f -> "Search Products".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         assertEquals("Type to search...", searchField.getPlaceholder());
@@ -41,14 +41,14 @@ class UseCase15ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Type into the search field
-        TextField searchField = $view(TextField.class).all().stream()
+        TextField searchField = findInView(TextField.class).all().stream()
                 .filter(f -> "Search Products".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(searchField).setValue("laptop");
         runPendingSignalsTasks();
 
         // The instant value Span should show the typed text
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains("\"laptop\"")));
     }
@@ -59,18 +59,18 @@ class UseCase15ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Initially keystroke count should be 0
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "0".equals(s.getText())));
 
         // Type a value
-        TextField searchField = $view(TextField.class).all().stream()
+        TextField searchField = findInView(TextField.class).all().stream()
                 .filter(f -> "Search Products".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(searchField).setValue("a");
         runPendingSignalsTasks();
 
         // Keystroke count should now be 1
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "1".equals(s.getText())));
     }
 }

--- a/signals/src/test/java/com/example/usecase16/UseCase16ViewTest.java
+++ b/signals/src/test/java/com/example/usecase16/UseCase16ViewTest.java
@@ -22,8 +22,8 @@ class UseCase16ViewTest extends SpringBrowserlessTest {
     void viewRendersWithSearchAndCategory() {
         navigate(UseCase16View.class);
 
-        assertEquals(1, $view(TextField.class).all().size());
-        assertEquals(1, $view(Select.class).all().size());
+        assertEquals(1, findInView(TextField.class).all().size());
+        assertEquals(1, findInView(Select.class).all().size());
     }
 
     @Test
@@ -32,7 +32,7 @@ class UseCase16ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("10 articles")));
     }
 
@@ -41,13 +41,13 @@ class UseCase16ViewTest extends SpringBrowserlessTest {
         navigate(UseCase16View.class);
         runPendingSignalsTasks();
 
-        TextField searchField = $view(TextField.class).single();
+        TextField searchField = findInView(TextField.class).single();
         test(searchField).setValue("signal");
         runPendingSignalsTasks();
 
         // Multiple articles mention "signal" in title or content
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("articles found")));
     }
 
@@ -57,13 +57,13 @@ class UseCase16ViewTest extends SpringBrowserlessTest {
         navigate(UseCase16View.class);
         runPendingSignalsTasks();
 
-        Select<String> categorySelect = $view(Select.class).single();
+        Select<String> categorySelect = findInView(Select.class).single();
         test(categorySelect).selectItem("Tutorial");
         runPendingSignalsTasks();
 
         // 4 Tutorial articles
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("4 articles")));
     }
 
@@ -73,16 +73,16 @@ class UseCase16ViewTest extends SpringBrowserlessTest {
         navigate(UseCase16View.class);
         runPendingSignalsTasks();
 
-        TextField searchField = $view(TextField.class).single();
+        TextField searchField = findInView(TextField.class).single();
         test(searchField).setValue("signal");
 
-        Select<String> categorySelect = $view(Select.class).single();
+        Select<String> categorySelect = findInView(Select.class).single();
         test(categorySelect).selectItem("Tutorial");
         runPendingSignalsTasks();
 
         // Articles matching "signal" in Tutorial category
         assertTrue(
-                $view(H3.class).all().stream().anyMatch(h -> h.getText() != null
+                findInView(H3.class).all().stream().anyMatch(h -> h.getText() != null
                         && h.getText().contains("articles found")));
     }
 }

--- a/signals/src/test/java/com/example/usecase17/UseCase17ViewTest.java
+++ b/signals/src/test/java/com/example/usecase17/UseCase17ViewTest.java
@@ -23,7 +23,7 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
 
         // CPU, Motherboard, RAM, GPU, Primary Storage, Secondary Storage,
         // PSU, Case, CPU Cooler = 9
-        assertEquals(9, $view(ComboBox.class).all().size());
+        assertEquals(9, findInView(ComboBox.class).all().size());
     }
 
     @Test
@@ -32,7 +32,7 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Total price formatted as "$0" (using %.0f format)
-        Span totalLabel = $view(Span.class).all().stream()
+        Span totalLabel = findInView(Span.class).all().stream()
                 .filter(s -> "$0".equals(s.getText())).findFirst()
                 .orElseThrow();
         assertEquals("$0", totalLabel.getText());
@@ -44,14 +44,14 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
         navigate(UseCase17View.class);
         runPendingSignalsTasks();
 
-        ComboBox<CPU> cpuSelect = (ComboBox<CPU>) $view(ComboBox.class).all()
+        ComboBox<CPU> cpuSelect = (ComboBox<CPU>) findInView(ComboBox.class).all()
                 .stream().filter(c -> "CPU".equals(c.getLabel())).findFirst()
                 .orElseThrow();
         test(cpuSelect).selectItem("Intel Core i5-14600K");
         runPendingSignalsTasks();
 
         // Total price should now be $319 (i5-14600K price)
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "$319".equals(s.getText())));
     }
 
@@ -62,13 +62,13 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Select Intel CPU (LGA1700)
-        ComboBox<CPU> cpuSelect = (ComboBox<CPU>) $view(ComboBox.class).all()
+        ComboBox<CPU> cpuSelect = (ComboBox<CPU>) findInView(ComboBox.class).all()
                 .stream().filter(c -> "CPU".equals(c.getLabel())).findFirst()
                 .orElseThrow();
         test(cpuSelect).selectItem("Intel Core i5-14600K");
 
         // Select AMD motherboard (AM5 socket) - socket mismatch
-        ComboBox<Motherboard> mbSelect = (ComboBox<Motherboard>) $view(
+        ComboBox<Motherboard> mbSelect = (ComboBox<Motherboard>) findInView(
                 ComboBox.class).all().stream()
                 .filter(c -> "Motherboard".equals(c.getLabel())).findFirst()
                 .orElseThrow();
@@ -77,7 +77,7 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
 
         // Compatibility count should drop below 13 - find the checks passing
         // span
-        assertTrue($view(Span.class).all().stream().anyMatch(s -> {
+        assertTrue(findInView(Span.class).all().stream().anyMatch(s -> {
             String text = s.getText();
             return text != null && text.contains("checks passing")
                     && !text.contains("13/13");
@@ -89,7 +89,7 @@ class UseCase17ViewTest extends SpringBrowserlessTest {
         navigate(UseCase17View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "Power Consumption".equals(s.getText())));
     }
 }

--- a/signals/src/test/java/com/example/usecase18/UseCase18ViewTest.java
+++ b/signals/src/test/java/com/example/usecase18/UseCase18ViewTest.java
@@ -23,8 +23,8 @@ class UseCase18ViewTest extends SpringBrowserlessTest {
         navigate(UseCase18View.class);
         runPendingSignalsTasks();
 
-        assertEquals(1, $view(MessageList.class).all().size());
-        assertEquals(1, $view(MessageInput.class).all().size());
+        assertEquals(1, findInView(MessageList.class).all().size());
+        assertEquals(1, findInView(MessageInput.class).all().size());
     }
 
     @SuppressWarnings("unchecked")
@@ -33,7 +33,7 @@ class UseCase18ViewTest extends SpringBrowserlessTest {
         navigate(UseCase18View.class);
         runPendingSignalsTasks();
 
-        Grid<Task> grid = $view(Grid.class).single();
+        Grid<Task> grid = findInView(Grid.class).single();
         assertEquals(3, test(grid).size());
     }
 
@@ -64,7 +64,7 @@ class UseCase18ViewTest extends SpringBrowserlessTest {
         assertEquals(Task.TaskStatus.DONE, unitTestSignal.peek().status());
 
         // Verify the grid reflects the change
-        Grid<Task> grid = $view(Grid.class).single();
+        Grid<Task> grid = findInView(Grid.class).single();
         boolean found = false;
         for (int i = 0; i < test(grid).size(); i++) {
             Task task = test(grid).getRow(i);

--- a/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
+++ b/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
@@ -25,14 +25,14 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         navigate(UseCase19View.class);
         runPendingSignalsTasks();
 
-        assertEquals(6, $view(Card.class).all().size());
+        assertEquals(6, findInView(Card.class).all().size());
     }
 
     @Test
     void loadButtonPresent() {
         navigate(UseCase19View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Load All Items".equals(b.getText())));
     }
 
@@ -40,7 +40,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
     void errorCheckboxPresent() {
         navigate(UseCase19View.class);
 
-        assertTrue($view(Checkbox.class).all().stream()
+        assertTrue(findInView(Checkbox.class).all().stream()
                 .anyMatch(c -> "Simulate Random Errors".equals(c.getLabel())));
     }
 
@@ -50,7 +50,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Click "Load All Items"
-        Button loadButton = $view(Button.class).all().stream()
+        Button loadButton = findInView(Button.class).all().stream()
                 .filter(b -> "Load All Items".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(loadButton).click();
@@ -58,7 +58,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
 
         // All 6 cards should transition to LOADING — ProgressBars become
         // visible
-        assertTrue($view(ProgressBar.class).all().stream()
+        assertTrue(findInView(ProgressBar.class).all().stream()
                 .anyMatch(ProgressBar::isIndeterminate));
     }
 
@@ -67,7 +67,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         navigate(UseCase19View.class);
         runPendingSignalsTasks();
 
-        Card card = $view(Card.class).all().getFirst();
+        Card card = findInView(Card.class).all().getFirst();
 
         // IDLE state should carry the state-idle class (rendered via CSS)
         assertTrue(card.getClassNames().contains("state-idle"),
@@ -81,14 +81,14 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Click Load All to transition items to LOADING
-        Button loadButton = $view(Button.class).all().stream()
+        Button loadButton = findInView(Button.class).all().stream()
                 .filter(b -> "Load All Items".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(loadButton).click();
         runPendingSignalsTasks();
 
         // Cards in LOADING state should carry the state-loading class
-        Card card = $view(Card.class).all().getFirst();
+        Card card = findInView(Card.class).all().getFirst();
         assertTrue(card.getClassNames().contains("state-loading"),
                 "LOADING card should have state-loading class but was: "
                         + card.getClassNames());
@@ -99,7 +99,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         navigate(UseCase19View.class);
         runPendingSignalsTasks();
 
-        Checkbox errorCheckbox = $view(Checkbox.class).all().stream()
+        Checkbox errorCheckbox = findInView(Checkbox.class).all().stream()
                 .filter(c -> "Simulate Random Errors".equals(c.getLabel()))
                 .findFirst().orElseThrow();
 

--- a/signals/src/test/java/com/example/usecase20/UseCase20ViewTest.java
+++ b/signals/src/test/java/com/example/usecase20/UseCase20ViewTest.java
@@ -19,7 +19,7 @@ class UseCase20ViewTest extends SpringBrowserlessTest {
     void viewRendersWithRadioButtonGroup() {
         navigate(UseCase20View.class);
 
-        assertEquals(1, $view(RadioButtonGroup.class).all().size());
+        assertEquals(1, findInView(RadioButtonGroup.class).all().size());
     }
 
     @SuppressWarnings("unchecked")
@@ -28,7 +28,7 @@ class UseCase20ViewTest extends SpringBrowserlessTest {
         navigate(UseCase20View.class);
         runPendingSignalsTasks();
 
-        RadioButtonGroup<String> colorPicker = $view(RadioButtonGroup.class)
+        RadioButtonGroup<String> colorPicker = findInView(RadioButtonGroup.class)
                 .single();
         assertEquals("var(--aura-background-color)", colorPicker.getValue());
     }
@@ -38,7 +38,7 @@ class UseCase20ViewTest extends SpringBrowserlessTest {
     void selectingColorUpdatesValue() {
         navigate(UseCase20View.class);
 
-        RadioButtonGroup<String> colorPicker = $view(RadioButtonGroup.class)
+        RadioButtonGroup<String> colorPicker = findInView(RadioButtonGroup.class)
                 .single();
         test(colorPicker).selectItem("#ffd54f");
         runPendingSignalsTasks();

--- a/signals/src/test/java/com/example/usecase21/UseCase21ViewTest.java
+++ b/signals/src/test/java/com/example/usecase21/UseCase21ViewTest.java
@@ -22,8 +22,8 @@ class UseCase21ViewTest extends SpringBrowserlessTest {
     void viewRendersWithFormFields() {
         navigate(UseCase21View.class);
 
-        assertEquals(1, $view(TextField.class).all().size());
-        assertEquals(1, $view(EmailField.class).all().size());
+        assertEquals(1, findInView(TextField.class).all().size());
+        assertEquals(1, findInView(EmailField.class).all().size());
     }
 
     @Test
@@ -32,7 +32,7 @@ class UseCase21ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Submit and Cancel buttons (text from i18n signals)
-        assertEquals(2, $view(Button.class).all().size());
+        assertEquals(2, findInView(Button.class).all().size());
     }
 
     @Test
@@ -40,9 +40,9 @@ class UseCase21ViewTest extends SpringBrowserlessTest {
         navigate(UseCase21View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Submit".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Cancel".equals(b.getText())));
     }
 
@@ -51,10 +51,10 @@ class UseCase21ViewTest extends SpringBrowserlessTest {
         navigate(UseCase21View.class);
         runPendingSignalsTasks();
 
-        TextField nameField = $view(TextField.class).single();
+        TextField nameField = findInView(TextField.class).single();
         assertEquals("Name", nameField.getLabel());
 
-        EmailField emailField = $view(EmailField.class).single();
+        EmailField emailField = findInView(EmailField.class).single();
         assertEquals("Email", emailField.getLabel());
     }
 
@@ -63,10 +63,10 @@ class UseCase21ViewTest extends SpringBrowserlessTest {
         navigate(UseCase21View.class);
         runPendingSignalsTasks();
 
-        TextField nameField = $view(TextField.class).single();
+        TextField nameField = findInView(TextField.class).single();
         assertEquals("Enter your name", nameField.getPlaceholder());
 
-        EmailField emailField = $view(EmailField.class).single();
+        EmailField emailField = findInView(EmailField.class).single();
         assertEquals("Enter your email address", emailField.getPlaceholder());
     }
 }

--- a/signals/src/test/java/com/example/usecase22/UseCase22ViewTest.java
+++ b/signals/src/test/java/com/example/usecase22/UseCase22ViewTest.java
@@ -25,8 +25,8 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
 
         // Personal: First Name, Last Name, Email + Address: Street, City, ZIP,
         // Country = 7
-        assertTrue($view(TextField.class).all().size() >= 7);
-        assertEquals(1, $view(IntegerField.class).all().size());
+        assertTrue(findInView(TextField.class).all().size() >= 7);
+        assertEquals(1, findInView(IntegerField.class).all().size());
     }
 
     @Test
@@ -34,10 +34,10 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
         navigate(UseCase22View.class);
         runPendingSignalsTasks();
 
-        TextField firstNameField = $view(TextField.class).all().stream()
+        TextField firstNameField = findInView(TextField.class).all().stream()
                 .filter(f -> "First Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
-        TextField lastNameField = $view(TextField.class).all().stream()
+        TextField lastNameField = findInView(TextField.class).all().stream()
                 .filter(f -> "Last Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
 
@@ -49,13 +49,13 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
     void changingFirstNameUpdatesFullName() {
         navigate(UseCase22View.class);
 
-        TextField firstNameField = $view(TextField.class).all().stream()
+        TextField firstNameField = findInView(TextField.class).all().stream()
                 .filter(f -> "First Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(firstNameField).setValue("Jane");
         runPendingSignalsTasks();
 
-        Span fullNameLabel = $view(Span.class).all().stream()
+        Span fullNameLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().startsWith("Full name:")).findFirst()
                 .orElseThrow();
         assertEquals("Full name: Jane Doe", fullNameLabel.getText());
@@ -65,13 +65,13 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
     void changingLastNameUpdatesFullName() {
         navigate(UseCase22View.class);
 
-        TextField lastNameField = $view(TextField.class).all().stream()
+        TextField lastNameField = findInView(TextField.class).all().stream()
                 .filter(f -> "Last Name".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(lastNameField).setValue("Smith");
         runPendingSignalsTasks();
 
-        Span fullNameLabel = $view(Span.class).all().stream()
+        Span fullNameLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().startsWith("Full name:")).findFirst()
                 .orElseThrow();
         assertEquals("Full name: John Smith", fullNameLabel.getText());
@@ -81,13 +81,13 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
     void changingCityUpdatesFormattedAddress() {
         navigate(UseCase22View.class);
 
-        TextField cityField = $view(TextField.class).all().stream()
+        TextField cityField = findInView(TextField.class).all().stream()
                 .filter(f -> "City".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(cityField).setValue("Portland");
         runPendingSignalsTasks();
 
-        Span addressLabel = $view(Span.class).all().stream()
+        Span addressLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().startsWith("Formatted:")).findFirst()
                 .orElseThrow();
         assertTrue(addressLabel.getText().contains("Portland"));
@@ -97,13 +97,13 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
     void changingStreetUpdatesFormattedAddress() {
         navigate(UseCase22View.class);
 
-        TextField streetField = $view(TextField.class).all().stream()
+        TextField streetField = findInView(TextField.class).all().stream()
                 .filter(f -> "Street".equals(f.getLabel())).findFirst()
                 .orElseThrow();
         test(streetField).setValue("456 Oak Ave");
         runPendingSignalsTasks();
 
-        Span addressLabel = $view(Span.class).all().stream()
+        Span addressLabel = findInView(Span.class).all().stream()
                 .filter(s -> s.getText().startsWith("Formatted:")).findFirst()
                 .orElseThrow();
         assertTrue(addressLabel.getText().contains("456 Oak Ave"));
@@ -113,11 +113,11 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
     void ageFieldUpdatesState() {
         navigate(UseCase22View.class);
 
-        IntegerField ageField = $view(IntegerField.class).single();
+        IntegerField ageField = findInView(IntegerField.class).single();
         test(ageField).setValue(25);
         runPendingSignalsTasks();
 
-        Pre stateDisplay = $view(Pre.class).atIndex(1);
+        Pre stateDisplay = findInView(Pre.class).atIndex(1);
         assertTrue(stateDisplay.getText().contains("\"age\": 25"));
     }
 
@@ -126,7 +126,7 @@ class UseCase22ViewTest extends SpringBrowserlessTest {
         navigate(UseCase22View.class);
         runPendingSignalsTasks();
 
-        Pre stateDisplay = $view(Pre.class).atIndex(1);
+        Pre stateDisplay = findInView(Pre.class).atIndex(1);
         String text = stateDisplay.getText();
         assertTrue(text.contains("\"firstName\": \"John\""));
         assertTrue(text.contains("\"lastName\": \"Doe\""));

--- a/signals/src/test/java/com/example/usecase23/UseCase23ViewTest.java
+++ b/signals/src/test/java/com/example/usecase23/UseCase23ViewTest.java
@@ -26,7 +26,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
     void viewRendersWithBoard() {
         navigate(UseCase23View.class);
 
-        assertEquals(1, $view(Board.class).all().size());
+        assertEquals(1, findInView(Board.class).all().size());
     }
 
     @Test
@@ -36,9 +36,9 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
 
         // 4 highlight cards with H2 titles: "Current users", "View events",
         // "Conversion rate", "Custom metric"
-        assertTrue($view(H2.class).all().stream()
+        assertTrue(findInView(H2.class).all().stream()
                 .anyMatch(h -> "Current users".equals(h.getText())));
-        assertTrue($view(H2.class).all().stream()
+        assertTrue(findInView(H2.class).all().stream()
                 .anyMatch(h -> "View events".equals(h.getText())));
     }
 
@@ -48,7 +48,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Grid for service health should be present
-        assertTrue($view(Grid.class).all().size() >= 1);
+        assertTrue(findInView(Grid.class).all().size() >= 1);
     }
 
     @Test
@@ -56,7 +56,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
         navigate(UseCase23View.class);
         runPendingSignalsTasks();
 
-        UseCase23View view = $view(UseCase23View.class).first();
+        UseCase23View view = findInView(UseCase23View.class).first();
 
         // Push data update with known values
         view.onDataUpdate(createTestData(42, 1500, 3.5, 99));
@@ -64,7 +64,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
 
         // "Current users" card should show "42"
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> "42".equals(s.getText())),
                 "Expected a Span with text '42' for current users");
     }
@@ -74,7 +74,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
         navigate(UseCase23View.class);
         runPendingSignalsTasks();
 
-        UseCase23View view = $view(UseCase23View.class).first();
+        UseCase23View view = findInView(UseCase23View.class).first();
 
         // First update: baseline
         view.onDataUpdate(createTestData(100, 1000, 2.0, 50));
@@ -86,7 +86,7 @@ class UseCase23ViewTest extends SpringBrowserlessTest {
 
         // Should show "+100.0" in the percentage badge
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains("+100.0")),
                 "Expected percentage badge showing +100.0");

--- a/signals/src/test/java/com/example/usecase24/UseCase24ViewTest.java
+++ b/signals/src/test/java/com/example/usecase24/UseCase24ViewTest.java
@@ -29,16 +29,16 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         navigate(UseCase24View.class);
 
         // Type filter and Status filter
-        assertEquals(2, $view(ComboBox.class).all().size());
+        assertEquals(2, findInView(ComboBox.class).all().size());
     }
 
     @Test
     void viewRendersWithActionButtons() {
         navigate(UseCase24View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Mark All Read".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Clear All".equals(b.getText())));
     }
 
@@ -46,13 +46,13 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
     void viewRendersWithAddButtons() {
         navigate(UseCase24View.class);
 
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Add Info".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Add Warning".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Add Error".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Add Success".equals(b.getText())));
     }
 
@@ -62,7 +62,7 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // 8 seed notifications, 5 unread
-        Span countLabel = $view(Span.class).all().stream().filter(
+        Span countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("8 notification"));
@@ -74,7 +74,7 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         navigate(UseCase24View.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> s.getText() != null && s.getText().contains("unread")));
     }
 
@@ -83,13 +83,13 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         navigate(UseCase24View.class);
         runPendingSignalsTasks();
 
-        Button addInfo = $view(Button.class).all().stream()
+        Button addInfo = findInView(Button.class).all().stream()
                 .filter(b -> "Add Info".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(addInfo).click();
         runPendingSignalsTasks();
 
-        Span countLabel = $view(Span.class).all().stream().filter(
+        Span countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("9 notification"));
@@ -100,13 +100,13 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         navigate(UseCase24View.class);
         runPendingSignalsTasks();
 
-        Button clearAll = $view(Button.class).all().stream()
+        Button clearAll = findInView(Button.class).all().stream()
                 .filter(b -> "Clear All".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(clearAll).click();
         runPendingSignalsTasks();
 
-        Span countLabel = $view(Span.class).all().stream().filter(
+        Span countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("0 notification"));
@@ -118,20 +118,20 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Verify we start with 5 unread
-        Span countLabel = $view(Span.class).all().stream().filter(
+        Span countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("5 unread"));
 
         // Click Mark All Read
-        Button markAllRead = $view(Button.class).all().stream()
+        Button markAllRead = findInView(Button.class).all().stream()
                 .filter(b -> "Mark All Read".equals(b.getText())).findFirst()
                 .orElseThrow();
         test(markAllRead).click();
         runPendingSignalsTasks();
 
         // Verify 0 unread
-        countLabel = $view(Span.class).all().stream().filter(
+        countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("0 unread"),
@@ -152,7 +152,7 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         // Render a card and attach it to the view so test framework can click
         // Before the fix, the click handler used get() outside a reactive
         // context which throws IllegalStateException
-        UseCase24View view = $view(UseCase24View.class).first();
+        UseCase24View view = findInView(UseCase24View.class).first();
         Div card = view.createNotificationCard(unread, signal);
         view.add(card);
 
@@ -179,7 +179,7 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         // Render a card and attach it to the view so test framework can click
         // Before the fix, the click handler used get() outside a reactive
         // context which throws IllegalStateException
-        UseCase24View view = $view(UseCase24View.class).first();
+        UseCase24View view = findInView(UseCase24View.class).first();
         Div card = view.createNotificationCard(n, signal);
         view.add(card);
 
@@ -209,13 +209,13 @@ class UseCase24ViewTest extends SpringBrowserlessTest {
         navigate(UseCase24View.class);
         runPendingSignalsTasks();
 
-        ComboBox<String> typeFilter = (ComboBox<String>) $view(ComboBox.class)
+        ComboBox<String> typeFilter = (ComboBox<String>) findInView(ComboBox.class)
                 .all().stream().filter(c -> "Type".equals(c.getLabel()))
                 .findFirst().orElseThrow();
         test(typeFilter).selectItem("ERROR");
         runPendingSignalsTasks();
 
-        Span countLabel = $view(Span.class).all().stream().filter(
+        Span countLabel = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().contains("Showing"))
                 .findFirst().orElseThrow();
         assertTrue(countLabel.getText().contains("2 notification"));

--- a/signals/src/test/java/com/example/usecase25/UseCase25ViewTest.java
+++ b/signals/src/test/java/com/example/usecase25/UseCase25ViewTest.java
@@ -24,7 +24,7 @@ class UseCase25ViewTest extends SpringBrowserlessTest {
         for (String symbol : new String[] { "AAPL", "GOOGL", "MSFT", "AMZN",
                 "TSLA", "NVDA", "META", "NFLX" }) {
             assertTrue(
-                    $view(Span.class).all().stream()
+                    findInView(Span.class).all().stream()
                             .anyMatch(s -> symbol.equals(s.getText())),
                     "Missing stock symbol: " + symbol);
         }
@@ -36,9 +36,9 @@ class UseCase25ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Verify some initial prices are displayed
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> s.getText() != null && s.getText().contains("$189.84")));
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> s.getText() != null && s.getText().contains("$141.80")));
     }
 
@@ -48,7 +48,7 @@ class UseCase25ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // All initial change values should be +0.00
-        long zeroChanges = $view(Span.class).all().stream()
+        long zeroChanges = findInView(Span.class).all().stream()
                 .filter(s -> "+0.00".equals(s.getText())).count();
         // 8 stocks × 1 change column = 8 spans with "+0.00"
         assertTrue(zeroChanges >= 8,
@@ -70,13 +70,13 @@ class UseCase25ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // At least some change values should no longer be +0.00
-        long zeroChanges = $view(Span.class).all().stream()
+        long zeroChanges = findInView(Span.class).all().stream()
                 .filter(s -> "+0.00".equals(s.getText())).count();
         assertTrue(zeroChanges < 8,
                 "Expected some stocks to have non-zero changes after update");
 
         // At least some percentage changes should no longer be +0.00%
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null && s.getText().endsWith("%")
                         && !"+0.00%".equals(s.getText())),
                 "Expected some non-zero percentage changes after update");

--- a/signals/src/test/java/com/example/usecase26/UseCase26ViewTest.java
+++ b/signals/src/test/java/com/example/usecase26/UseCase26ViewTest.java
@@ -21,7 +21,7 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
 
     @SuppressWarnings("unchecked")
     private ComboBox<Country> countryCombo() {
-        return (ComboBox<Country>) $view(ComboBox.class).all().stream()
+        return (ComboBox<Country>) findInView(ComboBox.class).all().stream()
                 .filter(c -> "Country".equals(c.getLabel())).findFirst()
                 .orElseThrow();
     }
@@ -37,8 +37,8 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Only the country ComboBox should be visible, no address TextFields
-        assertEquals(1, $view(ComboBox.class).all().size());
-        assertEquals(0, $view(TextField.class).all().size());
+        assertEquals(1, findInView(ComboBox.class).all().size());
+        assertEquals(0, findInView(TextField.class).all().size());
     }
 
     @Test
@@ -49,12 +49,12 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         selectCountry("US");
 
         // US fields should appear
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Street".equals(f.getLabel())));
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "ZIP".equals(f.getLabel())));
         // State ComboBox should appear
-        assertTrue($view(ComboBox.class).all().stream()
+        assertTrue(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "State".equals(c.getLabel())));
     }
 
@@ -65,9 +65,9 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
 
         selectCountry("JAPAN");
 
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Postal Code".equals(f.getLabel())));
-        assertTrue($view(ComboBox.class).all().stream()
+        assertTrue(findInView(ComboBox.class).all().stream()
                 .anyMatch(c -> "Prefecture".equals(c.getLabel())));
     }
 
@@ -77,15 +77,15 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         selectCountry("US");
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Street".equals(f.getLabel())));
 
         selectCountry("JAPAN");
         // US fields hidden
-        assertFalse($view(TextField.class).all().stream()
+        assertFalse(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Street".equals(f.getLabel())));
         // Japan fields visible
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Postal Code".equals(f.getLabel())));
     }
 
@@ -100,7 +100,7 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         selectCountry("US");
 
         // Only 1 "Created US" log entry (create-once pattern)
-        long usCreationCount = $view(Span.class).all().stream()
+        long usCreationCount = findInView(Span.class).all().stream()
                 .filter(s -> "Created US address form".equals(s.getText()))
                 .count();
         assertEquals(1, usCreationCount);
@@ -117,12 +117,12 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         selectCountry("JAPAN");
 
         // 2 creation events + 1 destroy event for Japan
-        long jpCreationCount = $view(Span.class).all().stream()
+        long jpCreationCount = findInView(Span.class).all().stream()
                 .filter(s -> "Created Japan address form".equals(s.getText()))
                 .count();
         assertEquals(2, jpCreationCount);
 
-        long jpDestroyCount = $view(Span.class).all().stream()
+        long jpDestroyCount = findInView(Span.class).all().stream()
                 .filter(s -> "Destroyed Japan address form".equals(s.getText()))
                 .count();
         assertEquals(1, jpDestroyCount);
@@ -134,7 +134,7 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Log starts empty
-        long logEntries = $view(Span.class).all().stream().filter(
+        long logEntries = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Created"))
                 .count();
         assertEquals(0, logEntries);
@@ -142,7 +142,7 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         // Select a country -> log gains an entry
         selectCountry("US");
 
-        logEntries = $view(Span.class).all().stream().filter(
+        logEntries = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Created"))
                 .count();
         assertEquals(1, logEntries);
@@ -160,7 +160,7 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         selectCountry("US");
 
         // No spurious destroy messages when switching away from US
-        long destroyCount = $view(Span.class).all().stream().filter(
+        long destroyCount = findInView(Span.class).all().stream().filter(
                 s -> s.getText() != null && s.getText().startsWith("Destroyed"))
                 .count();
         // Japan was switched away from twice
@@ -178,19 +178,19 @@ class UseCase26ViewTest extends SpringBrowserlessTest {
         selectCountry("US");
 
         // Japan created twice, destroyed twice
-        long jpCreated = $view(Span.class).all().stream()
+        long jpCreated = findInView(Span.class).all().stream()
                 .filter(s -> "Created Japan address form".equals(s.getText()))
                 .count();
         assertEquals(2, jpCreated);
 
-        long jpDestroyed = $view(Span.class).all().stream()
+        long jpDestroyed = findInView(Span.class).all().stream()
                 .filter(s -> "Destroyed Japan address form".equals(s.getText()))
                 .count();
         assertEquals(2, jpDestroyed);
 
         // Create-once US: created exactly once
         assertEquals(1,
-                $view(Span.class).all().stream().filter(
+                findInView(Span.class).all().stream().filter(
                         s -> "Created US address form".equals(s.getText()))
                         .count());
     }

--- a/signals/src/test/java/com/example/usecase27/UseCase27ViewTest.java
+++ b/signals/src/test/java/com/example/usecase27/UseCase27ViewTest.java
@@ -88,11 +88,11 @@ class UseCase27ViewTest extends SpringBrowserlessTest {
     void parentLayoutInstanceIsReusedAcrossSiblingNavigations() {
         navigate(UseCase27View.class);
         runPendingSignalsTasks();
-        UseCase27Layout firstLayout = $(UseCase27Layout.class).single();
+        UseCase27Layout firstLayout = find(UseCase27Layout.class).single();
 
         navigate(UseCase27DetailsView.class, Map.of("id", "7"));
         runPendingSignalsTasks();
-        UseCase27Layout secondLayout = $(UseCase27Layout.class).single();
+        UseCase27Layout secondLayout = find(UseCase27Layout.class).single();
 
         assertEquals(firstLayout, secondLayout,
                 "UseCase27Layout must be reused across sibling navigations — "
@@ -101,13 +101,13 @@ class UseCase27ViewTest extends SpringBrowserlessTest {
     }
 
     private String breadcrumbText() {
-        Div breadcrumb = $(Div.class).withId(UseCase27Layout.BREADCRUMB_ID)
+        Div breadcrumb = find(Div.class).withId(UseCase27Layout.BREADCRUMB_ID)
                 .single();
         return breadcrumb.getElement().getTextRecursively();
     }
 
     private int updateCount() {
-        Span badge = $(Span.class).withId(UseCase27Layout.UPDATE_COUNT_ID)
+        Span badge = find(Span.class).withId(UseCase27Layout.UPDATE_COUNT_ID)
                 .single();
         String text = badge.getText();
         int colon = text.lastIndexOf(':');

--- a/text-selection/src/test/java/com/example/uc1/SelectAllOnFocusViewTest.java
+++ b/text-selection/src/test/java/com/example/uc1/SelectAllOnFocusViewTest.java
@@ -19,15 +19,15 @@ class SelectAllOnFocusViewTest extends SpringBrowserlessTest {
     void viewRendersWithExpectedHeadingAndPrefilledQuantity() {
         navigate(SelectAllOnFocusView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC1 — Select all on focus".equals(h.getText())));
-        assertEquals("10", $(TextField.class).single().getValue());
+        assertEquals("10", find(TextField.class).single().getValue());
     }
 
     @Test
     void autoselectIsEnabled() {
         navigate(SelectAllOnFocusView.class);
-        assertTrue($(TextField.class).single().isAutoselect(),
+        assertTrue(find(TextField.class).single().isAutoselect(),
                 "the field should drive selection via setAutoselect(true)");
     }
 }

--- a/text-selection/src/test/java/com/example/uc2/FormatAndSelectViewTest.java
+++ b/text-selection/src/test/java/com/example/uc2/FormatAndSelectViewTest.java
@@ -20,20 +20,20 @@ class FormatAndSelectViewTest extends SpringBrowserlessTest {
     void viewRendersWithDefaultTitle() {
         navigate(FormatAndSelectView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC2 — Post-transform select-all".equals(h.getText())));
         assertEquals("Hello, Awesome World!",
-                $(TextField.class).single().getValue());
+                find(TextField.class).single().getValue());
     }
 
     @Test
     void formatSlugifiesTheValue() {
         navigate(FormatAndSelectView.class);
 
-        TextField title = $(TextField.class).single();
+        TextField title = find(TextField.class).single();
         test(title).setValue("Hello, Awesome World!!!");
 
-        test($(Button.class).withText("Format").single()).click();
+        test(find(Button.class).withText("Format").single()).click();
         runPendingSignalsTasks();
 
         assertEquals("hello-awesome-world", title.getValue());

--- a/text-selection/src/test/java/com/example/uc3/FindAndHighlightViewTest.java
+++ b/text-selection/src/test/java/com/example/uc3/FindAndHighlightViewTest.java
@@ -23,9 +23,9 @@ class FindAndHighlightViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndSampleContent() {
         navigate(FindAndHighlightView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC3 — Find and highlight in textarea")));
-        TextArea content = $(TextArea.class).single();
+        TextArea content = find(TextArea.class).single();
         assertTrue(content.getValue().contains("Lorem ipsum"));
     }
 
@@ -34,9 +34,9 @@ class FindAndHighlightViewTest extends SpringBrowserlessTest {
         navigate(FindAndHighlightView.class);
         runPendingSignalsTasks();
 
-        TextField search = $(TextField.class).single();
-        TextArea content = $(TextArea.class).single();
-        Button findNext = $(Button.class).withText("Find next").single();
+        TextField search = find(TextField.class).single();
+        TextArea content = find(TextArea.class).single();
+        Button findNext = find(Button.class).withText("Find next").single();
 
         test(search).setValue("dolor");
 
@@ -56,7 +56,7 @@ class FindAndHighlightViewTest extends SpringBrowserlessTest {
     }
 
     private int readMatchOffset() {
-        String status = $view(Span.class).all().stream().map(Span::getText)
+        String status = findInView(Span.class).all().stream().map(Span::getText)
                 .filter(t -> t != null && t.contains("Match at ")).findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "Expected a 'Match at N' status span"));
@@ -70,15 +70,15 @@ class FindAndHighlightViewTest extends SpringBrowserlessTest {
         navigate(FindAndHighlightView.class);
         // Simulate the user clicking around in the textarea so a non-empty
         // selection signal value exists from a prior interaction.
-        TextArea content = $(TextArea.class).single();
+        TextArea content = find(TextArea.class).single();
         TextSelectionTestSupport.setSelection(content, 0, 0);
         runPendingSignalsTasks();
 
-        Button findNext = $(Button.class).withText("Find next").single();
+        Button findNext = find(Button.class).withText("Find next").single();
         test(findNext).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> "Enter a search term first".equals(s.getText())));
     }
 }

--- a/text-selection/src/test/java/com/example/uc4/ValidationJumpViewTest.java
+++ b/text-selection/src/test/java/com/example/uc4/ValidationJumpViewTest.java
@@ -20,7 +20,7 @@ class ValidationJumpViewTest extends SpringBrowserlessTest {
     void viewRendersHeading() {
         navigate(ValidationJumpView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC4 — Jump to validation error".equals(h.getText())));
     }
 
@@ -29,8 +29,8 @@ class ValidationJumpViewTest extends SpringBrowserlessTest {
         navigate(ValidationJumpView.class);
         runPendingSignalsTasks();
 
-        TextField username = $(TextField.class).single();
-        Button submit = $(Button.class).withText("Submit").single();
+        TextField username = find(TextField.class).single();
+        Button submit = find(Button.class).withText("Submit").single();
 
         // Default value "My Cool User" — first invalid run is "M".
         test(submit).click();
@@ -38,7 +38,7 @@ class ValidationJumpViewTest extends SpringBrowserlessTest {
 
         // Status text reports the offending range; that range, applied to the
         // current value, must contain at least one non-[a-z0-9_] character.
-        String status = $view(Span.class).all().stream().map(Span::getText)
+        String status = findInView(Span.class).all().stream().map(Span::getText)
                 .filter(t -> t != null
                         && t.startsWith("Invalid characters at "))
                 .findFirst().orElseThrow(() -> new AssertionError(
@@ -60,14 +60,14 @@ class ValidationJumpViewTest extends SpringBrowserlessTest {
     @Test
     void shortValueShowsTheLengthError() {
         navigate(ValidationJumpView.class);
-        TextField username = $(TextField.class).single();
+        TextField username = find(TextField.class).single();
         username.setValue("ab");
 
-        Button submit = $(Button.class).withText("Submit").single();
+        Button submit = find(Button.class).withText("Submit").single();
         test(submit).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains("at least 3 characters")));
     }
@@ -75,15 +75,15 @@ class ValidationJumpViewTest extends SpringBrowserlessTest {
     @Test
     void validValueShowsSuccess() {
         navigate(ValidationJumpView.class);
-        TextField username = $(TextField.class).single();
+        TextField username = find(TextField.class).single();
         username.setValue("good_name_42");
         runPendingSignalsTasks();
 
-        Button submit = $(Button.class).withText("Submit").single();
+        Button submit = find(Button.class).withText("Submit").single();
         test(submit).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Span.class).all().stream().anyMatch(
+        assertTrue(findInView(Span.class).all().stream().anyMatch(
                 s -> s.getText() != null && s.getText().contains("is valid")));
     }
 }

--- a/text-selection/src/test/java/com/example/uc5/InsertTemplateViewTest.java
+++ b/text-selection/src/test/java/com/example/uc5/InsertTemplateViewTest.java
@@ -21,20 +21,20 @@ class InsertTemplateViewTest extends SpringBrowserlessTest {
     void viewRenders() {
         navigate(InsertTemplateView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC5 — Insert template at cursor".equals(h.getText())));
     }
 
     @Test
     void greetingInsertsAtCurrentCursor() {
         navigate(InsertTemplateView.class);
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
         // Position the cursor at offset 4 ("Hi,\n" + here)
         TextSelectionTestSupport.setSelection(editor, 4, 4);
         runPendingSignalsTasks();
 
         String original = editor.getValue();
-        Button greeting = $(Button.class).withText("Greeting").single();
+        Button greeting = find(Button.class).withText("Greeting").single();
         test(greeting).click();
         runPendingSignalsTasks();
 
@@ -46,13 +46,13 @@ class InsertTemplateViewTest extends SpringBrowserlessTest {
     @Test
     void snippetReplacesNonEmptySelection() {
         navigate(InsertTemplateView.class);
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
         // Default value is "Hi,\n\n\n\nThanks,\n". Select "Hi," (offsets 0..3).
         TextSelectionTestSupport.setSelection(editor, 0, 3);
         runPendingSignalsTasks();
 
         String original = editor.getValue();
-        Button greeting = $(Button.class).withText("Greeting").single();
+        Button greeting = find(Button.class).withText("Greeting").single();
         test(greeting).click();
         runPendingSignalsTasks();
 
@@ -63,12 +63,12 @@ class InsertTemplateViewTest extends SpringBrowserlessTest {
     @Test
     void signatureInsertsAtStart() {
         navigate(InsertTemplateView.class);
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
         TextSelectionTestSupport.setSelection(editor, 0, 0);
         runPendingSignalsTasks();
 
         String original = editor.getValue();
-        Button signature = $(Button.class).withText("Signature").single();
+        Button signature = find(Button.class).withText("Signature").single();
         test(signature).click();
         runPendingSignalsTasks();
 

--- a/text-selection/src/test/java/com/example/uc6/LiveSelectionInfoViewTest.java
+++ b/text-selection/src/test/java/com/example/uc6/LiveSelectionInfoViewTest.java
@@ -20,7 +20,7 @@ class LiveSelectionInfoViewTest extends SpringBrowserlessTest {
     void viewRenders() {
         navigate(LiveSelectionInfoView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC6 — Live selection info".equals(h.getText())));
     }
 
@@ -30,26 +30,26 @@ class LiveSelectionInfoViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Initially nothing selected
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "0 chars".equals(s.getText())));
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "0 words".equals(s.getText())));
 
-        TextArea text = $(TextArea.class).single();
+        TextArea text = find(TextArea.class).single();
         // "The quick brown fox" — 19 chars, 4 words
         TextSelectionTestSupport.setSelection(text, 0, 19);
         runPendingSignalsTasks();
 
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> "19 chars".equals(s.getText())),
                 "expected selection length to update");
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> "4 words".equals(s.getText())),
                 "expected word count to update");
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> "0 – 19".equals(s.getText())),
                 "expected range to update");
     }

--- a/text-selection/src/test/java/com/example/uc7/SelectionToolbarViewTest.java
+++ b/text-selection/src/test/java/com/example/uc7/SelectionToolbarViewTest.java
@@ -21,7 +21,7 @@ class SelectionToolbarViewTest extends SpringBrowserlessTest {
     void viewRenders() {
         navigate(SelectionToolbarView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(h -> h.getText()
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h -> h.getText()
                 .equals("UC7 — Selection-driven transform toolbar")));
     }
 
@@ -30,13 +30,13 @@ class SelectionToolbarViewTest extends SpringBrowserlessTest {
         navigate(SelectionToolbarView.class);
         runPendingSignalsTasks();
 
-        Button upper = $(Button.class).withText("UPPERCASE").single();
-        Button lower = $(Button.class).withText("lowercase").single();
+        Button upper = find(Button.class).withText("UPPERCASE").single();
+        Button lower = find(Button.class).withText("lowercase").single();
         assertFalse(upper.isEnabled(),
                 "no selection: button should be disabled");
         assertFalse(lower.isEnabled());
 
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
         TextSelectionTestSupport.setSelection(editor, 0, 5);
         runPendingSignalsTasks();
 
@@ -48,13 +48,13 @@ class SelectionToolbarViewTest extends SpringBrowserlessTest {
     @Test
     void uppercaseTransformsTheSelection() {
         navigate(SelectionToolbarView.class);
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
 
         // Select "Click" (first 5 chars)
         TextSelectionTestSupport.setSelection(editor, 0, 5);
         runPendingSignalsTasks();
 
-        Button upper = $(Button.class).withText("UPPERCASE").single();
+        Button upper = find(Button.class).withText("UPPERCASE").single();
         test(upper).click();
         runPendingSignalsTasks();
 
@@ -65,11 +65,11 @@ class SelectionToolbarViewTest extends SpringBrowserlessTest {
     @Test
     void quoteTransformWrapsTheSelection() {
         navigate(SelectionToolbarView.class);
-        TextArea editor = $(TextArea.class).single();
+        TextArea editor = find(TextArea.class).single();
         TextSelectionTestSupport.setSelection(editor, 0, 5);
         runPendingSignalsTasks();
 
-        test($(Button.class).withText("\"Quote\"").single()).click();
+        test(find(Button.class).withText("\"Quote\"").single()).click();
         runPendingSignalsTasks();
 
         assertTrue(editor.getValue().startsWith("\"Click\""),

--- a/triggers/src/test/java/com/example/uc1/CopyFieldValueViewTest.java
+++ b/triggers/src/test/java/com/example/uc1/CopyFieldValueViewTest.java
@@ -27,18 +27,18 @@ class CopyFieldValueViewTest extends SpringBrowserlessTest {
     void viewRendersWithExpectedComponents() {
         navigate(CopyFieldValueView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Copy field value on click"
                         .equals(h.getText())));
-        assertNotNull($view(TextField.class).id("source"));
-        assertNotNull($view(Button.class).id("copy"));
+        assertNotNull(findInView(TextField.class).id("source"));
+        assertNotNull(findInView(Button.class).id("copy"));
     }
 
     @Test
     void clickTriggerIsWiredToClipboardCopyActionReadingFieldValue() {
         navigate(CopyFieldValueView.class);
 
-        Button copy = $view(Button.class).id("copy");
+        Button copy = findInView(Button.class).id("copy");
         ObjectNode snapshot = TriggerSupport.on(copy).snapshotForTest();
 
         JsonNode triggers = snapshot.get("triggers");

--- a/triggers/src/test/java/com/example/uc2/CopyCodeSnippetViewTest.java
+++ b/triggers/src/test/java/com/example/uc2/CopyCodeSnippetViewTest.java
@@ -27,17 +27,17 @@ class CopyCodeSnippetViewTest extends SpringBrowserlessTest {
     void viewRendersWithSnippetAndCopyButton() {
         navigate(CopyCodeSnippetView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC2 — Copy a code snippet".equals(h.getText())));
-        assertNotNull($view(Pre.class).id("snippet"));
-        assertNotNull($view(Button.class).id("copy"));
+        assertNotNull(findInView(Pre.class).id("snippet"));
+        assertNotNull(findInView(Button.class).id("copy"));
     }
 
     @Test
     void outputReadsTextContentOfPreElement() {
         navigate(CopyCodeSnippetView.class);
 
-        Button copy = $view(Button.class).id("copy");
+        Button copy = findInView(Button.class).id("copy");
         ObjectNode snapshot = TriggerSupport.on(copy).snapshotForTest();
 
         JsonNode actionEntry = snapshot.get("actions").get("0");

--- a/triggers/src/test/java/com/example/uc3/CopySelectValueViewTest.java
+++ b/triggers/src/test/java/com/example/uc3/CopySelectValueViewTest.java
@@ -26,17 +26,17 @@ class CopySelectValueViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndCopyButton() {
         navigate(CopySelectValueView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC3 — Copy the currently selected option"
                         .equals(h.getText())));
-        assertNotNull($view(Button.class).id("copy"));
+        assertNotNull(findInView(Button.class).id("copy"));
     }
 
     @Test
     void outputReadsValueOfNativeSelect() {
         navigate(CopySelectValueView.class);
 
-        Button copy = $view(Button.class).id("copy");
+        Button copy = findInView(Button.class).id("copy");
         ObjectNode snapshot = TriggerSupport.on(copy).snapshotForTest();
 
         JsonNode action = snapshot.get("actions").get("0");

--- a/triggers/src/test/java/com/example/uc4/ShareUrlViewTest.java
+++ b/triggers/src/test/java/com/example/uc4/ShareUrlViewTest.java
@@ -26,10 +26,10 @@ class ShareUrlViewTest extends SpringBrowserlessTest {
     void viewRendersWithServerGeneratedUrl() {
         navigate(ShareUrlView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC4 — Share URL widget".equals(h.getText())));
 
-        TextField field = $view(TextField.class).id("share-url");
+        TextField field = findInView(TextField.class).id("share-url");
         assertTrue(field.getValue().startsWith("https://example.com/share/"),
                 "server should render the share URL into the field");
         assertTrue(field.isReadOnly(), "share URL is read-only");
@@ -39,7 +39,7 @@ class ShareUrlViewTest extends SpringBrowserlessTest {
     void copyButtonIsWiredToReadFieldValue() {
         navigate(ShareUrlView.class);
 
-        Button copy = $view(Button.class).id("copy");
+        Button copy = findInView(Button.class).id("copy");
         ObjectNode snapshot = TriggerSupport.on(copy).snapshotForTest();
 
         assertEquals(ClickTrigger.TYPE_ID,
@@ -59,13 +59,13 @@ class ShareUrlViewTest extends SpringBrowserlessTest {
     @Test
     void twoSessionsGetDifferentShareUrls() {
         ShareUrlView first = navigate(ShareUrlView.class);
-        String firstUrl = $view(TextField.class).id("share-url").getValue();
+        String firstUrl = findInView(TextField.class).id("share-url").getValue();
 
         cleanVaadinEnvironment();
         initVaadinEnvironment();
 
         ShareUrlView second = navigate(ShareUrlView.class);
-        String secondUrl = $view(TextField.class).id("share-url").getValue();
+        String secondUrl = findInView(TextField.class).id("share-url").getValue();
 
         assertTrue(!firstUrl.equals(secondUrl),
                 "each session should generate its own share URL");

--- a/triggers/src/test/java/com/example/uc5/CustomActionViewTest.java
+++ b/triggers/src/test/java/com/example/uc5/CustomActionViewTest.java
@@ -25,18 +25,18 @@ class CustomActionViewTest extends SpringBrowserlessTest {
     void viewRendersTargetAndTriggerButton() {
         navigate(CustomActionView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC5 — Custom action via @JsModule"
                         .equals(h.getText())));
-        assertNotNull($view(Div.class).id("target"));
-        assertNotNull($view(Button.class).id("trigger"));
+        assertNotNull(findInView(Div.class).id("target"));
+        assertNotNull(findInView(Button.class).id("trigger"));
     }
 
     @Test
     void clickIsBoundToCustomActionTypeId() {
         navigate(CustomActionView.class);
 
-        Button trigger = $view(Button.class).id("trigger");
+        Button trigger = findInView(Button.class).id("trigger");
         ObjectNode snapshot = TriggerSupport.on(trigger).snapshotForTest();
 
         assertEquals(ClickTrigger.TYPE_ID,

--- a/wake-lock/src/test/java/com/example/uc1/ManualToggleViewTest.java
+++ b/wake-lock/src/test/java/com/example/uc1/ManualToggleViewTest.java
@@ -21,12 +21,12 @@ class ManualToggleViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndToggleButton() {
         navigate(ManualToggleView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Manual keep-awake toggle"
                         .equals(h.getText())),
                 "Heading should render");
         // The toggle button starts as "Keep screen awake".
-        assertEquals(1, $view(Button.class).withText("Keep screen awake").all()
+        assertEquals(1, findInView(Button.class).withText("Keep screen awake").all()
                 .size(), "Toggle button should render with initial label");
     }
 
@@ -40,7 +40,7 @@ class ManualToggleViewTest extends SpringBrowserlessTest {
         WakeLockTestSupport.simulateAcquired();
         runPendingSignalsTasks();
         assertBadgeContains("Holding lock");
-        assertTrue($view(Button.class).withText("Allow screen to sleep").all()
+        assertTrue(findInView(Button.class).withText("Allow screen to sleep").all()
                 .size() == 1,
                 "Button label should switch when the lock is held");
 
@@ -54,7 +54,7 @@ class ManualToggleViewTest extends SpringBrowserlessTest {
         navigate(ManualToggleView.class);
         runPendingSignalsTasks();
 
-        Button toggle = $view(Button.class).withText("Keep screen awake")
+        Button toggle = findInView(Button.class).withText("Keep screen awake")
                 .single();
         test(toggle).click();
         // Click triggers request() (executeJs to the client); confirm via the
@@ -63,7 +63,7 @@ class ManualToggleViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
         assertBadgeContains("Holding lock");
 
-        Button release = $view(Button.class).withText("Allow screen to sleep")
+        Button release = findInView(Button.class).withText("Allow screen to sleep")
                 .single();
         test(release).click();
         WakeLockTestSupport.simulateReleased();
@@ -72,7 +72,7 @@ class ManualToggleViewTest extends SpringBrowserlessTest {
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains(fragment)),
                 "expected status badge to contain \"" + fragment + "\"");

--- a/wake-lock/src/test/java/com/example/uc2/RecipeViewTest.java
+++ b/wake-lock/src/test/java/com/example/uc2/RecipeViewTest.java
@@ -22,12 +22,12 @@ class RecipeViewTest extends SpringBrowserlessTest {
         navigate(RecipeView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> h.getText() != null
                         && h.getText().contains("Leek tart")),
                 "view should render the recipe heading");
 
-        long stepCount = $view(Div.class).all().stream()
+        long stepCount = findInView(Div.class).all().stream()
                 .filter(d -> d.getElement().getClassList().contains(
                         "recipe-step"))
                 .count();
@@ -41,7 +41,7 @@ class RecipeViewTest extends SpringBrowserlessTest {
         navigate(RecipeView.class);
         runPendingSignalsTasks();
 
-        Div firstStep = $view(Div.class).all().stream()
+        Div firstStep = findInView(Div.class).all().stream()
                 .filter(d -> d.getElement().getClassList().contains(
                         "recipe-step"))
                 .findFirst().orElseThrow();
@@ -54,11 +54,11 @@ class RecipeViewTest extends SpringBrowserlessTest {
         navigate(RecipeView.class);
         runPendingSignalsTasks();
 
-        Button next = $(Button.class).withText("Next step").single();
+        Button next = find(Button.class).withText("Next step").single();
         test(next).click();
         runPendingSignalsTasks();
 
-        var steps = $view(Div.class).all().stream()
+        var steps = findInView(Div.class).all().stream()
                 .filter(d -> d.getElement().getClassList().contains(
                         "recipe-step"))
                 .toList();
@@ -82,7 +82,7 @@ class RecipeViewTest extends SpringBrowserlessTest {
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().toLowerCase().contains(
                                 fragment.toLowerCase())),

--- a/wake-lock/src/test/java/com/example/uc3/SlideshowViewTest.java
+++ b/wake-lock/src/test/java/com/example/uc3/SlideshowViewTest.java
@@ -23,15 +23,15 @@ class SlideshowViewTest extends SpringBrowserlessTest {
         navigate(SlideshowView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC3 — Presentation slideshow"
                         .equals(h.getText())),
                 "view should render heading");
 
-        Button start = $view(Button.class).withText("Start presentation")
+        Button start = findInView(Button.class).withText("Start presentation")
                 .single();
-        Button next = $view(Button.class).withText("Next slide").single();
-        Button stop = $view(Button.class).withText("Stop").single();
+        Button next = findInView(Button.class).withText("Next slide").single();
+        Button stop = findInView(Button.class).withText("Stop").single();
         assertTrue(start.isEnabled(),
                 "Start should be enabled before presenting");
         assertFalse(next.isEnabled(),
@@ -45,13 +45,13 @@ class SlideshowViewTest extends SpringBrowserlessTest {
         navigate(SlideshowView.class);
         runPendingSignalsTasks();
 
-        test($view(Button.class).withText("Start presentation").single())
+        test(findInView(Button.class).withText("Start presentation").single())
                 .click();
         runPendingSignalsTasks();
 
         assertSlideBodyContains("quick tour");
 
-        test($view(Button.class).withText("Next slide").single()).click();
+        test(findInView(Button.class).withText("Next slide").single()).click();
         runPendingSignalsTasks();
         assertSlideBodyContains("Wake Lock API prevents");
     }
@@ -61,19 +61,19 @@ class SlideshowViewTest extends SpringBrowserlessTest {
         navigate(SlideshowView.class);
         runPendingSignalsTasks();
 
-        Button start = $view(Button.class).withText("Start presentation")
+        Button start = findInView(Button.class).withText("Start presentation")
                 .single();
         test(start).click();
         runPendingSignalsTasks();
 
-        Button next = $view(Button.class).withText("Next slide").single();
+        Button next = findInView(Button.class).withText("Next slide").single();
         // 5 slides → click Next 5 times to fall off the end.
         for (int i = 0; i < 5; i++) {
             test(next).click();
             runPendingSignalsTasks();
         }
         // After advancing past the last slide, the presentation should stop.
-        Button stop = $view(Button.class).withText("Stop").single();
+        Button stop = findInView(Button.class).withText("Stop").single();
         assertFalse(stop.isEnabled(),
                 "Stop should be disabled once the deck ends");
         assertTrue(start.isEnabled(),
@@ -87,7 +87,7 @@ class SlideshowViewTest extends SpringBrowserlessTest {
 
         assertBadgeContains("Released");
 
-        test($view(Button.class).withText("Start presentation").single())
+        test(findInView(Button.class).withText("Start presentation").single())
                 .click();
         runPendingSignalsTasks();
         // Server has called request(); the browser hasn't confirmed yet.
@@ -95,7 +95,7 @@ class SlideshowViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
         assertBadgeContains("Holding");
 
-        test($view(Button.class).withText("Stop").single()).click();
+        test(findInView(Button.class).withText("Stop").single()).click();
         runPendingSignalsTasks();
         // Server has called release(); the browser confirms.
         WakeLockTestSupport.simulateReleased();
@@ -104,14 +104,14 @@ class SlideshowViewTest extends SpringBrowserlessTest {
     }
 
     private void assertSlideBodyContains(String fragment) {
-        assertTrue($view(Div.class).all().stream()
+        assertTrue(findInView(Div.class).all().stream()
                 .anyMatch(d -> d.getText() != null
                         && d.getText().contains(fragment)),
                 "expected a slide body div containing \"" + fragment + "\"");
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains(fragment)),
                 "expected status badge to contain \"" + fragment + "\"");

--- a/wake-lock/src/test/java/com/example/uc4/WorkoutTimerViewTest.java
+++ b/wake-lock/src/test/java/com/example/uc4/WorkoutTimerViewTest.java
@@ -21,13 +21,13 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
         navigate(WorkoutTimerView.class);
         runPendingSignalsTasks();
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> h.getText() != null
                         && h.getText().contains("Workout interval timer")),
                 "view should render heading");
-        assertTrue($view(Button.class).withText("Start").all().size() == 1,
+        assertTrue(findInView(Button.class).withText("Start").all().size() == 1,
                 "Start button should render initially");
-        assertTrue($view(Button.class).withText("Reset").all().size() == 1,
+        assertTrue(findInView(Button.class).withText("Reset").all().size() == 1,
                 "Reset button should render initially");
     }
 
@@ -36,10 +36,10 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
         navigate(WorkoutTimerView.class);
         runPendingSignalsTasks();
 
-        test($view(Button.class).withText("Start").single()).click();
+        test(findInView(Button.class).withText("Start").single()).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Button.class).withText("Pause").all().size() == 1,
+        assertTrue(findInView(Button.class).withText("Pause").all().size() == 1,
                 "Start should become Pause once running");
     }
 
@@ -48,12 +48,12 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
         navigate(WorkoutTimerView.class);
         runPendingSignalsTasks();
 
-        test($view(Button.class).withText("Start").single()).click();
+        test(findInView(Button.class).withText("Start").single()).click();
         runPendingSignalsTasks();
-        test($view(Button.class).withText("Reset").single()).click();
+        test(findInView(Button.class).withText("Reset").single()).click();
         runPendingSignalsTasks();
 
-        assertTrue($view(Button.class).withText("Start").all().size() == 1,
+        assertTrue(findInView(Button.class).withText("Start").all().size() == 1,
                 "Reset should put the button back to Start");
         assertClockShows("00:30");
         assertPhaseShows("WORK");
@@ -67,7 +67,7 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
         assertBadgeContains("Released");
 
         // Start the timer — the effect calls request() on the wake lock.
-        test($view(Button.class).withText("Start").single()).click();
+        test(findInView(Button.class).withText("Start").single()).click();
         runPendingSignalsTasks();
 
         // The browser confirms.
@@ -76,7 +76,7 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
         assertBadgeContains("Holding");
 
         // Pause — the effect calls release(); the browser confirms.
-        test($view(Button.class).withText("Pause").single()).click();
+        test(findInView(Button.class).withText("Pause").single()).click();
         runPendingSignalsTasks();
         WakeLockTestSupport.simulateReleased();
         runPendingSignalsTasks();
@@ -84,20 +84,20 @@ class WorkoutTimerViewTest extends SpringBrowserlessTest {
     }
 
     private void assertBadgeContains(String fragment) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> s.getText() != null
                         && s.getText().contains(fragment)),
                 "expected status badge to contain \"" + fragment + "\"");
     }
 
     private void assertClockShows(String text) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> text.equals(s.getText())),
                 "expected clock to show \"" + text + "\"");
     }
 
     private void assertPhaseShows(String text) {
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> text.equals(s.getText())),
                 "expected phase label to show \"" + text + "\"");
     }

--- a/web-share/src/test/java/com/example/uc1/ShareThisPageViewTest.java
+++ b/web-share/src/test/java/com/example/uc1/ShareThisPageViewTest.java
@@ -21,9 +21,9 @@ class ShareThisPageViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndButton() {
         navigate(ShareThisPageView.class);
 
-        assertTrue($view(H1.class).all().stream()
+        assertTrue(findInView(H1.class).all().stream()
                 .anyMatch(h -> "UC1 — Share this page".equals(h.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Share this page".equals(b.getText())));
     }
 
@@ -48,7 +48,7 @@ class ShareThisPageViewTest extends SpringBrowserlessTest {
 
     private void assertBadgeContains(String fragment) {
         assertTrue(
-                $view(Span.class).all().stream()
+                findInView(Span.class).all().stream()
                         .anyMatch(s -> s.getText() != null
                                 && s.getText().contains(fragment)),
                 "expected status badge to contain \"" + fragment + "\"");
@@ -56,7 +56,7 @@ class ShareThisPageViewTest extends SpringBrowserlessTest {
 
     private void assertButtonEnabled(boolean expected) {
         assertTrue(
-                $view(Button.class).all().stream()
+                findInView(Button.class).all().stream()
                         .filter(b -> "Share this page".equals(b.getText()))
                         .anyMatch(b -> b.isEnabled() == expected),
                 "expected Share button enabled=" + expected);

--- a/web-share/src/test/java/com/example/uc2/CopyLinkFallbackViewTest.java
+++ b/web-share/src/test/java/com/example/uc2/CopyLinkFallbackViewTest.java
@@ -20,7 +20,7 @@ class CopyLinkFallbackViewTest extends SpringBrowserlessTest {
     void viewRendersHeading() {
         navigate(CopyLinkFallbackView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC2 — Share with copy-link fallback".equals(h.getText())));
     }
 
@@ -43,14 +43,14 @@ class CopyLinkFallbackViewTest extends SpringBrowserlessTest {
 
     private void assertButtonExists(String text) {
         assertTrue(
-                $view(Button.class).all().stream()
+                findInView(Button.class).all().stream()
                         .anyMatch(b -> text.equals(b.getText())),
                 "expected a button labelled \"" + text + "\"");
     }
 
     private void assertButtonAbsent(String text) {
         assertTrue(
-                $view(Button.class).all().stream()
+                findInView(Button.class).all().stream()
                         .noneMatch(b -> text.equals(b.getText())),
                 "expected no button labelled \"" + text + "\"");
     }

--- a/web-share/src/test/java/com/example/uc3/CustomMessageViewTest.java
+++ b/web-share/src/test/java/com/example/uc3/CustomMessageViewTest.java
@@ -24,15 +24,15 @@ class CustomMessageViewTest extends SpringBrowserlessTest {
     void viewRendersWithFormAndButton() {
         navigate(CustomMessageView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC3 — Share a custom message".equals(h.getText())));
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "Title".equals(f.getLabel())));
-        assertTrue($view(TextArea.class).all().stream()
+        assertTrue(findInView(TextArea.class).all().stream()
                 .anyMatch(f -> "Text".equals(f.getLabel())));
-        assertTrue($view(TextField.class).all().stream()
+        assertTrue(findInView(TextField.class).all().stream()
                 .anyMatch(f -> "URL".equals(f.getLabel())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Share".equals(b.getText())));
     }
 
@@ -80,25 +80,25 @@ class CustomMessageViewTest extends SpringBrowserlessTest {
     }
 
     private TextField findTextField(String label) {
-        return $view(TextField.class).all().stream()
+        return findInView(TextField.class).all().stream()
                 .filter(f -> label.equals(f.getLabel())).findFirst()
                 .orElseThrow();
     }
 
     private TextArea findTextArea(String label) {
-        return $view(TextArea.class).all().stream()
+        return findInView(TextArea.class).all().stream()
                 .filter(f -> label.equals(f.getLabel())).findFirst()
                 .orElseThrow();
     }
 
     private Div findPreview() {
-        return $view(Div.class).all().stream()
+        return findInView(Div.class).all().stream()
                 .filter(d -> d.getClassNames().contains("share-preview"))
                 .findFirst().orElseThrow();
     }
 
     private Button findButton() {
-        return $view(Button.class).all().stream()
+        return findInView(Button.class).all().stream()
                 .filter(b -> "Share".equals(b.getText())).findFirst()
                 .orElseThrow();
     }

--- a/web-share/src/test/java/com/example/uc4/ShareListItemsViewTest.java
+++ b/web-share/src/test/java/com/example/uc4/ShareListItemsViewTest.java
@@ -22,10 +22,10 @@ class ShareListItemsViewTest extends SpringBrowserlessTest {
     void viewRendersOneRowPerArticle() {
         navigate(ShareListItemsView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC4 — Share each item in a list".equals(h.getText())));
 
-        long rowCount = $view(Div.class).all().stream().filter(
+        long rowCount = findInView(Div.class).all().stream().filter(
                 d -> d.getClassNames().contains("share-list-item")).count();
         // The view ships with three articles.
         assertEquals(3, rowCount);
@@ -36,7 +36,7 @@ class ShareListItemsViewTest extends SpringBrowserlessTest {
         navigate(ShareListItemsView.class);
         runPendingSignalsTasks();
 
-        long shareButtons = $view(Button.class).all().stream()
+        long shareButtons = findInView(Button.class).all().stream()
                 .filter(b -> b.getElement().getAttribute("aria-label") != null
                         && b.getElement().getAttribute("aria-label")
                                 .startsWith("Share \""))
@@ -61,7 +61,7 @@ class ShareListItemsViewTest extends SpringBrowserlessTest {
     }
 
     private void assertAllShareButtonsEnabled(boolean expected) {
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .filter(b -> b.getElement().getAttribute("aria-label") != null
                         && b.getElement().getAttribute("aria-label")
                                 .startsWith("Share \""))

--- a/web-share/src/test/java/com/example/uc5/ShareFeedbackViewTest.java
+++ b/web-share/src/test/java/com/example/uc5/ShareFeedbackViewTest.java
@@ -19,12 +19,12 @@ class ShareFeedbackViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndButtons() {
         navigate(ShareFeedbackView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC5 — Share with completion feedback"
                         .equals(h.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Share with feedback".equals(b.getText())));
-        assertTrue($view(Button.class).all().stream()
+        assertTrue(findInView(Button.class).all().stream()
                 .anyMatch(b -> "Simulate success".equals(b.getText())));
     }
 
@@ -44,7 +44,7 @@ class ShareFeedbackViewTest extends SpringBrowserlessTest {
 
     private void assertLogContains(String fragment) {
         assertTrue(
-                $view(Div.class).all().stream()
+                findInView(Div.class).all().stream()
                         .anyMatch(d -> d.getText() != null
                                 && d.getText().contains(fragment)),
                 "expected outcome log to contain \"" + fragment + "\"");

--- a/web-share/src/test/java/com/example/uc6/ShareInviteLinkViewTest.java
+++ b/web-share/src/test/java/com/example/uc6/ShareInviteLinkViewTest.java
@@ -25,9 +25,9 @@ class ShareInviteLinkViewTest extends SpringBrowserlessTest {
     void viewRendersHeadingAndPlaceholders() {
         navigate(ShareInviteLinkView.class);
 
-        assertTrue($view(H1.class).all().stream().anyMatch(
+        assertTrue(findInView(H1.class).all().stream().anyMatch(
                 h -> "UC6 — Share an invite link".equals(h.getText())));
-        assertTrue($view(Span.class).all().stream()
+        assertTrue(findInView(Span.class).all().stream()
                 .anyMatch(s -> "—".equals(s.getText())));
     }
 
@@ -81,14 +81,14 @@ class ShareInviteLinkViewTest extends SpringBrowserlessTest {
     }
 
     private void clickGenerate() {
-        Button generate = $view(Button.class).all().stream()
+        Button generate = findInView(Button.class).all().stream()
                 .filter(b -> "Generate invite".equals(b.getText())).findFirst()
                 .orElseThrow();
         generate.click();
     }
 
     private void assertShareButtonEnabled(boolean expected) {
-        Button share = $view(Button.class).all().stream()
+        Button share = findInView(Button.class).all().stream()
                 .filter(b -> "Share invite".equals(b.getText())).findFirst()
                 .orElseThrow();
         if (expected) {


### PR DESCRIPTION
vaadin/browserless-test#63 renamed the component-query DSL; update all test classes to use the new names.
