### PR TITLE
signals: Cache /root/.npm and /root/.vaadin in Docker build

### DIFF
--- a/signals/Dockerfile
+++ b/signals/Dockerfile
@@ -19,6 +19,8 @@ COPY . $HOME
 #   $ docker build --secret id=offlineKey,src=$HOME/.vaadin/offlineKey .
 
 RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/root/.vaadin \
     --mount=type=secret,id=proKey \
     --mount=type=secret,id=offlineKey \
     sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey 2>/dev/null || cat /run/secrets/proKey 2>/dev/null || echo "") && \


### PR DESCRIPTION
Adds BuildKit cache mounts so Vaadin's node distribution and npm's package tarball cache survive across builds on the same builder, saving the node download/unpack/install (~125s) and a portion of npm install on warm builds.
