### PR TITLE
route-hierarchy: Drive breadcrumbs reactively via UI.routerStateSignal()

### DIFF
--- a/route-hierarchy/API-GAPS.md
+++ b/route-hierarchy/API-GAPS.md
@@ -70,24 +70,26 @@ has no static title left for any *other* consumer that walks to it as an
 ancestor (it would fall back to a humanised class name). A walker-side title
 hook (gap 1) would side-step this by not depending on `@PageTitle` at all.
 
-## 4. No reactive "current navigation" signal — layout breadcrumbs need a listener
+## 4. ~~No reactive "current navigation" signal~~ — closed by `UI.routerStateSignal()`
 
-**Where it bit us:** uc6 / `TeamLayout.java`
-**Symptom:** for a single breadcrumb bar hosted in a parent layout and shared by
-all child views, there is no `Signal<NavigationState>` to subscribe to. You must
-implement `AfterNavigationObserver`, rebuild the trail in `afterNavigation`,
-pull the leaf instance out of `AfterNavigationEvent#getActiveChain()` and the
-parameters out of `getRouteParameters()`, and remember to seed the first render.
-**Workaround used:** `TeamLayout implements AfterNavigationObserver` and rebuilds
-on every event; a counter badge confirms the rebuild fires once per navigation.
-**Suggested API:** the `Signal<NavigationState>` proposed in the breadcrumbs
-flow-spec ("Reuse and Proposed Adjustments → a `Signal<NavigationState>` for the
-current route"). With it the layout collapses to a single
-`Signal.effect(this, () -> breadcrumbs.show(state.viewInstance(), state.routeParameters()))`
-that auto-seeds and auto-unsubscribes. (Note: a sibling snapshot already ships
-`UI.routerStateSignal()` in the `signals` module — this PR's snapshot does not
-include it, so the listener pattern is the only option here.) Ref: flow#24451 and
-the breadcrumbs flow-spec.
+**Status:** closed. This module's snapshot now carries the
+`UI.routerStateSignal()` from the breadcrumbs flow-spec
+("Reuse and Proposed Adjustments → a `Signal<NavigationState>` for the current
+route"), exposing a read-only `Signal<RouterState>` with `navigationTarget()`,
+`location()`, `routeParameters()`, `currentView()` and `activeChain()`.
+**How it landed in the demo:** every breadcrumb is signal-bound. `BreadcrumbBar`
+subscribes in its constructor via a single `Signal.effect(this, () -> { var
+state = UI.getCurrent().routerStateSignal().get(); rebuild(state); })` — the
+effect seeds the first render, auto-fires on every navigation (including
+same-class navigations with new `RouteParameters`) and auto-unsubscribes on
+detach. Views just `add(new BreadcrumbBar())`; no `BeforeEnterObserver`, no
+`AfterNavigationObserver`, no manual seed step. UC6's `TeamLayout` follows the
+same pattern for its rebuild counter. `UpLink` (UC5) is wired identically.
+**Note:** gaps 1, 2, 3 and 5 remain — the signal hands you the leaf instance and
+the current `RouteParameters`, but `RouteHierarchy.resolveAncestors` still
+returns bare classes, so label resolution, per-ancestor parameter filtering,
+dynamic-leaf labels and dynamic-ancestor labels stay an application
+responsibility.
 
 ## 5. Ancestor labels cannot be dynamic
 

--- a/route-hierarchy/README.md
+++ b/route-hierarchy/README.md
@@ -10,7 +10,11 @@ repository stays on the baseline `25.2-SNAPSHOT`.
 The PR does **not** ship a `Breadcrumbs` component — that lives in
 flow-components and consumes this API. Every view here therefore builds its
 breadcrumb by hand as a `HorizontalLayout` of `RouterLink`s
-(`BreadcrumbBar`), driven entirely by `RouteHierarchy`. See
+(`BreadcrumbBar`), driven by `RouteHierarchy`. The bar wires itself to
+`UI.routerStateSignal()` via a single `Signal.effect` from its own constructor,
+so views never call a `show(...)` method — they just `add(new
+BreadcrumbBar())` and the bar rebuilds reactively on every navigation. The same
+applies to UC5's `UpLink` and UC6's `TeamLayout`. See
 [`API-GAPS.md`](API-GAPS.md) for what was awkward.
 
 | # | View | What it shows |
@@ -20,7 +24,7 @@ breadcrumb by hand as a `HorizontalLayout` of `RouterLink`s
 | UC3 | Dynamic leaf label | A profile at `uc3/:userId` implementing `HasDynamicTitle`; the current crumb shows the resolved person name, not the static `@PageTitle`. |
 | UC4 | Parameter-preserving links | A four-level parameterised hierarchy where each ancestor link keeps the live `:projectId` (and only the parameters its own template needs). |
 | UC5 | Up-one-level button | A single "↑ Up to <parent>" control built from `resolveParent(...)`, hidden at the hierarchy root. |
-| UC6 | Layout-wide auto breadcrumbs | One breadcrumb bar in a parent layout, rebuilt on every navigation via `AfterNavigationObserver` (no reactive navigation signal exists in this snapshot). |
+| UC6 | Layout-wide auto breadcrumbs | One breadcrumb bar in a parent layout, rebuilt on every navigation via a `Signal.effect` subscribed to `UI.routerStateSignal()` — no `AfterNavigationObserver` and no manual seeding. |
 | UC7 | Route-tree sitemap | `resolveAncestors` used as a graph-builder: leaf routes from across the demo are expanded and merged into a nested sitemap tree. |
 
 ## Run

--- a/route-hierarchy/src/main/java/com/example/MissingAPI.java
+++ b/route-hierarchy/src/main/java/com/example/MissingAPI.java
@@ -8,8 +8,8 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.HasDynamicTitle;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.RouteConfiguration;
-import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouteHierarchy;
+import com.vaadin.flow.router.RouteParameters;
 
 /**
  * Static shims for the bits of breadcrumb building that the route-hierarchy API
@@ -20,8 +20,8 @@ import com.vaadin.flow.router.RouteHierarchy;
  * {@code Class<? extends Component>} objects. To render a usable breadcrumb you
  * still have to (a) turn each class into a human label and (b) figure out which
  * route parameters each ancestor's template actually needs so its link resolves
- * to a working URL. Both of those are done here. See {@code API-GAPS.md} for the
- * shape these methods suggest the API should grow.
+ * to a working URL. Both of those are done here. See {@code API-GAPS.md} for
+ * the shape these methods suggest the API should grow.
  */
 public final class MissingAPI {
 
@@ -87,8 +87,7 @@ public final class MissingAPI {
         for (String segment : template.get().split("/")) {
             if (segment.startsWith(":")) {
                 String name = parameterName(segment);
-                available.get(name)
-                        .ifPresent(value -> subset.put(name, value));
+                available.get(name).ifPresent(value -> subset.put(name, value));
             }
         }
         return subset.isEmpty() ? RouteParameters.empty()

--- a/route-hierarchy/src/main/java/com/example/uc1/CatalogView.java
+++ b/route-hierarchy/src/main/java/com/example/uc1/CatalogView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -17,22 +15,24 @@ import com.vaadin.flow.router.RouterLink;
  * UC1 — URL-prefix trail (root).
  * <p>
  * The three views of this use case nest purely by URL: {@code uc1},
- * {@code uc1/electronics}, {@code uc1/electronics/laptops}. None of them carry a
- * {@code @RouteParent} annotation, so {@link com.vaadin.flow.router.RouteHierarchy}
- * discovers the trail entirely through its URL-prefix fallback — it strips the
- * last path segment and looks the shorter URL up in the route registry. This is
- * the zero-configuration case: lay your routes out hierarchically and the
- * breadcrumb just works.
+ * {@code uc1/electronics}, {@code uc1/electronics/laptops}. None of them carry
+ * a {@code @RouteParent} annotation, so
+ * {@link com.vaadin.flow.router.RouteHierarchy} discovers the trail entirely
+ * through its URL-prefix fallback — it strips the last path segment and looks
+ * the shorter URL up in the route registry. This is the zero-configuration
+ * case: lay your routes out hierarchically and the breadcrumb just works.
+ * <p>
+ * The view does no breadcrumb plumbing: the {@link BreadcrumbBar} subscribes to
+ * {@code UI.routerStateSignal()} from its own constructor and rebuilds itself
+ * on every navigation.
  */
 @Route(value = "uc1", layout = MainLayout.class)
 @PageTitle("Catalog")
 @Menu(order = 1, title = "UC1 — URL-prefix trail")
-public class CatalogView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class CatalogView extends VerticalLayout {
 
     public CatalogView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Catalog"));
         add(new Paragraph(
                 "This is the root of a three-level catalog. Each level lives at "
@@ -42,10 +42,5 @@ public class CatalogView extends VerticalLayout implements BeforeEnterObserver {
                         + "by stripping URL segments. Drill in and watch the "
                         + "breadcrumb above grow."));
         add(new RouterLink("Browse Electronics →", CategoryView.class));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc1/CategoryView.java
+++ b/route-hierarchy/src/main/java/com/example/uc1/CategoryView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
@@ -20,13 +18,10 @@ import com.vaadin.flow.router.RouterLink;
  */
 @Route(value = "uc1/electronics", layout = MainLayout.class)
 @PageTitle("Electronics")
-public class CategoryView extends VerticalLayout
-        implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class CategoryView extends VerticalLayout {
 
     public CategoryView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Electronics"));
         add(new Paragraph(
                 "The breadcrumb above now reads Catalog › Electronics. The "
@@ -34,10 +29,5 @@ public class CategoryView extends VerticalLayout
                         + "the uc1 route class; \"Electronics\" is the current "
                         + "page and is not a link."));
         add(new RouterLink("Browse Laptops →", SubcategoryView.class));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc1/SubcategoryView.java
+++ b/route-hierarchy/src/main/java/com/example/uc1/SubcategoryView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
@@ -19,13 +17,10 @@ import com.vaadin.flow.router.Route;
  */
 @Route(value = "uc1/electronics/laptops", layout = MainLayout.class)
 @PageTitle("Laptops")
-public class SubcategoryView extends VerticalLayout
-        implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class SubcategoryView extends VerticalLayout {
 
     public SubcategoryView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Laptops"));
         add(new Paragraph(
                 "The deepest level. The breadcrumb reads Catalog › Electronics "
@@ -33,10 +28,5 @@ public class SubcategoryView extends VerticalLayout
                         + "their route classes, the last is the current page. "
                         + "All of it came from RouteHierarchy.resolveAncestors "
                         + "without a single @RouteParent annotation."));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc2/OrderDetailView.java
+++ b/route-hierarchy/src/main/java/com/example/uc2/OrderDetailView.java
@@ -20,17 +20,21 @@ import com.vaadin.flow.router.RouteParent;
  * lets {@link com.vaadin.flow.router.RouteHierarchy} place it under Orders. The
  * leaf label is supplied dynamically via {@link HasDynamicTitle} so it reflects
  * the actual order id.
+ * <p>
+ * {@code BeforeEnter} captures the order id into a field so
+ * {@link #getPageTitle()} can return a dynamic label; the breadcrumb itself
+ * needs no wiring — it is signal-bound and reads this view back from
+ * {@code UI.routerStateSignal().currentView()} when the navigation completes.
  */
 @Route(value = "order-detail/:orderId", layout = MainLayout.class)
 @RouteParent(OrdersView.class)
 public class OrderDetailView extends VerticalLayout
         implements BeforeEnterObserver, HasDynamicTitle {
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
     private String orderId = "?";
 
     public OrderDetailView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Order detail"));
         add(new Paragraph(
                 "This page's URL is order-detail/:orderId — there is no uc2/ "
@@ -44,7 +48,6 @@ public class OrderDetailView extends VerticalLayout
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         orderId = event.getRouteParameters().get("orderId").orElse("?");
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 
     @Override

--- a/route-hierarchy/src/main/java/com/example/uc2/OrdersView.java
+++ b/route-hierarchy/src/main/java/com/example/uc2/OrdersView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -27,12 +25,10 @@ import com.vaadin.flow.router.RouterLink;
 @Route(value = "uc2", layout = MainLayout.class)
 @PageTitle("Orders")
 @Menu(order = 2, title = "UC2 — @RouteParent override")
-public class OrdersView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class OrdersView extends VerticalLayout {
 
     public OrdersView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Orders"));
         add(new Paragraph(
                 "The order detail page lives at order-detail/:orderId, which "
@@ -45,10 +41,5 @@ public class OrdersView extends VerticalLayout implements BeforeEnterObserver {
                 new RouteParameters("orderId", "1001")));
         add(new RouterLink("Open order #1002", OrderDetailView.class,
                 new RouteParameters("orderId", "1002")));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc3/UserProfileView.java
+++ b/route-hierarchy/src/main/java/com/example/uc3/UserProfileView.java
@@ -15,19 +15,22 @@ import com.vaadin.flow.router.Route;
  * UC3 — Dynamic leaf label (profile, {@code uc3/:userId}).
  * <p>
  * Implements {@link HasDynamicTitle} so the breadcrumb leaf shows the resolved
- * person name rather than the static {@code @PageTitle}. The parent
- * {@code uc3} is still found by stripping the {@code :userId} segment.
+ * person name rather than the static {@code @PageTitle}. The parent {@code uc3}
+ * is still found by stripping the {@code :userId} segment.
+ * <p>
+ * {@code BeforeEnter} captures the resolved name into a field; the breadcrumb
+ * itself is signal-bound and re-reads {@link HasDynamicTitle#getPageTitle()}
+ * when the navigation signal fires.
  */
 @Route(value = "uc3/:userId", layout = MainLayout.class)
 public class UserProfileView extends VerticalLayout
         implements BeforeEnterObserver, HasDynamicTitle {
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
     private final H1 heading = new H1();
     private String userName = "Unknown user";
 
     public UserProfileView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(heading);
         add(new Paragraph(
                 "The breadcrumb leaf above matches this page's H1 — both come "
@@ -43,7 +46,6 @@ public class UserProfileView extends VerticalLayout
         String userId = event.getRouteParameters().get("userId").orElse("?");
         userName = Directory.nameOf(userId);
         heading.setText(userName);
-        breadcrumbs.show(this, event.getRouteParameters());
     }
 
     @Override

--- a/route-hierarchy/src/main/java/com/example/uc3/UsersView.java
+++ b/route-hierarchy/src/main/java/com/example/uc3/UsersView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -27,12 +25,10 @@ import com.vaadin.flow.router.RouterLink;
 @Route(value = "uc3", layout = MainLayout.class)
 @PageTitle("Users")
 @Menu(order = 3, title = "UC3 — Dynamic leaf label")
-public class UsersView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class UsersView extends VerticalLayout {
 
     public UsersView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Users"));
         add(new Paragraph(
                 "Open a profile below. Its breadcrumb leaf is not the static "
@@ -40,13 +36,7 @@ public class UsersView extends VerticalLayout implements BeforeEnterObserver {
                         + "resolved at runtime from the :userId via "
                         + "HasDynamicTitle. The Users crumb is still found by "
                         + "URL-prefix walking."));
-        Directory.USERS.forEach((id, name) -> add(new RouterLink(
-                "View " + name, UserProfileView.class,
-                new RouteParameters("userId", id))));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
+        Directory.USERS.forEach((id, name) -> add(new RouterLink("View " + name,
+                UserProfileView.class, new RouteParameters("userId", id))));
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc4/ProjectView.java
+++ b/route-hierarchy/src/main/java/com/example/uc4/ProjectView.java
@@ -20,12 +20,11 @@ import com.vaadin.flow.router.RouterLink;
 @PageTitle("Project")
 public class ProjectView extends VerticalLayout implements BeforeEnterObserver {
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
     private final H1 heading = new H1();
     private final RouterLink tasksLink = new RouterLink();
 
     public ProjectView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(heading);
         add(new Paragraph(
                 "The Projects crumb above is a parameterless ancestor; this "
@@ -42,6 +41,5 @@ public class ProjectView extends VerticalLayout implements BeforeEnterObserver {
         heading.setText(ProjectData.projectName(projectId));
         tasksLink.setRoute(TasksView.class,
                 new RouteParameters("projectId", projectId));
-        breadcrumbs.show(this, parameters);
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc4/ProjectsView.java
+++ b/route-hierarchy/src/main/java/com/example/uc4/ProjectsView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -30,25 +28,18 @@ import com.vaadin.flow.router.RouterLink;
 @Route(value = "uc4", layout = MainLayout.class)
 @PageTitle("Projects")
 @Menu(order = 4, title = "UC4 — Parameter-preserving links")
-public class ProjectsView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
+public class ProjectsView extends VerticalLayout {
 
     public ProjectsView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Projects"));
         add(new Paragraph(
                 "Open a project, then its tasks, then a single task. On the "
                         + "deepest page the breadcrumb's Project and Tasks "
                         + "links still point at the right project because the "
                         + ":projectId is carried onto each ancestor link."));
-        ProjectData.PROJECTS.forEach((id, name) -> add(new RouterLink(
-                "Open " + name, ProjectView.class,
-                new RouteParameters("projectId", id))));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
+        ProjectData.PROJECTS.forEach((id,
+                name) -> add(new RouterLink("Open " + name, ProjectView.class,
+                        new RouteParameters("projectId", id))));
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc4/TaskDetailView.java
+++ b/route-hierarchy/src/main/java/com/example/uc4/TaskDetailView.java
@@ -25,12 +25,11 @@ import com.vaadin.flow.router.RouteParameters;
 public class TaskDetailView extends VerticalLayout
         implements BeforeEnterObserver, HasDynamicTitle {
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
     private final H1 heading = new H1();
     private String taskId = "?";
 
     public TaskDetailView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(heading);
         add(new Paragraph(
                 "Hover the Project and Tasks crumbs above: both hrefs include "
@@ -45,7 +44,6 @@ public class TaskDetailView extends VerticalLayout
         RouteParameters parameters = event.getRouteParameters();
         taskId = parameters.get("taskId").orElse("?");
         heading.setText(ProjectData.taskName(taskId));
-        breadcrumbs.show(this, parameters);
     }
 
     @Override

--- a/route-hierarchy/src/main/java/com/example/uc4/TasksView.java
+++ b/route-hierarchy/src/main/java/com/example/uc4/TasksView.java
@@ -26,13 +26,12 @@ import com.vaadin.flow.router.RouterLink;
 @PageTitle("Tasks")
 public class TasksView extends VerticalLayout implements BeforeEnterObserver {
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
     private final H1 heading = new H1();
     private final VerticalLayout taskLinks = new VerticalLayout();
 
     public TasksView() {
         setPadding(false);
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(heading);
         add(new Paragraph("Each task link below opens a task page nested two "
                 + "levels under Projects. The breadcrumb there keeps both the "
@@ -50,9 +49,8 @@ public class TasksView extends VerticalLayout implements BeforeEnterObserver {
         taskLinks.removeAll();
         for (String taskId : ProjectData.taskIds()) {
             taskLinks.add(new RouterLink(ProjectData.taskName(taskId),
-                    TaskDetailView.class, new RouteParameters(Map.of(
-                            "projectId", projectId, "taskId", taskId))));
+                    TaskDetailView.class, new RouteParameters(
+                            Map.of("projectId", projectId, "taskId", taskId))));
         }
-        breadcrumbs.show(this, parameters);
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc5/SecurityView.java
+++ b/route-hierarchy/src/main/java/com/example/uc5/SecurityView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
@@ -20,23 +18,14 @@ import com.vaadin.flow.router.RouterLink;
  */
 @Route(value = "uc5/security", layout = MainLayout.class)
 @PageTitle("Security")
-public class SecurityView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
-    private final UpLink upLink = new UpLink();
+public class SecurityView extends VerticalLayout {
 
     public SecurityView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Security"));
         add(new Paragraph("The \"↑ Up\" control points at Settings — the "
                 + "immediate parent resolved by resolveParent(...)."));
-        add(upLink);
+        add(new UpLink());
         add(new RouterLink("Active sessions →", SessionsView.class));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
-        upLink.show(this);
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc5/SessionsView.java
+++ b/route-hierarchy/src/main/java/com/example/uc5/SessionsView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
@@ -19,24 +17,14 @@ import com.vaadin.flow.router.Route;
  */
 @Route(value = "uc5/security/sessions", layout = MainLayout.class)
 @PageTitle("Active sessions")
-public class SessionsView extends VerticalLayout
-        implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
-    private final UpLink upLink = new UpLink();
+public class SessionsView extends VerticalLayout {
 
     public SessionsView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Active sessions"));
         add(new Paragraph("The \"↑ Up\" control resolves to Security — the "
                 + "immediate parent — even though the full breadcrumb above "
                 + "spans three levels."));
-        add(upLink);
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
-        upLink.show(this);
+        add(new UpLink());
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc5/SettingsView.java
+++ b/route-hierarchy/src/main/java/com/example/uc5/SettingsView.java
@@ -6,8 +6,6 @@ import com.example.views.MainLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -17,33 +15,24 @@ import com.vaadin.flow.router.RouterLink;
  * UC5 — Up-one-level button (root, {@code uc5}).
  * <p>
  * Each page in this use case carries a single "↑ Up" control built from
- * {@link com.vaadin.flow.router.RouteHierarchy#resolveParent}. On this root page
- * {@code resolveParent} finds no parent within the use case, so the control
- * shows a "top level" note instead of a link.
+ * {@link com.vaadin.flow.router.RouteHierarchy#resolveParent}. On this root
+ * page {@code resolveParent} finds no parent within the use case, so the
+ * control shows a "top level" note instead of a link.
  */
 @Route(value = "uc5", layout = MainLayout.class)
 @PageTitle("Settings")
 @Menu(order = 5, title = "UC5 — Up-one-level button")
-public class SettingsView extends VerticalLayout implements BeforeEnterObserver {
-
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
-    private final UpLink upLink = new UpLink();
+public class SettingsView extends VerticalLayout {
 
     public SettingsView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Settings"));
         add(new Paragraph(
                 "The \"↑ Up\" control below uses resolveParent(...), which needs "
                         + "only the immediate parent rather than the whole "
                         + "chain. Drill into Security, then Sessions, and use "
                         + "the control to climb back one level at a time."));
-        add(upLink);
+        add(new UpLink());
         add(new RouterLink("Security settings →", SecurityView.class));
-    }
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
-        upLink.show(this);
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc5/UpLink.java
+++ b/route-hierarchy/src/main/java/com/example/uc5/UpLink.java
@@ -5,11 +5,15 @@ import java.util.Optional;
 import com.example.MissingAPI;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteHierarchy;
 import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.router.RouterState;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * A single "↑ Up to &lt;parent&gt;" control — the minimal back-navigation
@@ -20,21 +24,36 @@ import com.vaadin.flow.router.RouterLink;
  * than {@code resolveAncestors}. When the current view is already a hierarchy
  * root, {@code resolveParent} returns {@link Optional#empty()} and the control
  * renders a plain "top level" note instead of a link.
+ * <p>
+ * The control wires itself to {@link UI#routerStateSignal()} via a single
+ * {@link Signal#effect}; the parent is recomputed from the current
+ * {@link RouterState#currentView()} on every navigation. Views just
+ * {@code add(new UpLink())} — no per-view plumbing.
  */
 public class UpLink extends Div {
 
     public UpLink() {
         addClassName("up-link");
+
+        Signal.effect(this, () -> {
+            RouterState state = UI.getCurrent().routerStateSignal().get();
+            rebuild(state);
+        });
     }
 
-    public void show(Component leafView) {
+    private void rebuild(RouterState state) {
         removeAll();
+        HasElement leaf = state.currentView().orElse(null);
+        if (!(leaf instanceof Component leafView)) {
+            return;
+        }
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forSessionScope();
         Optional<Class<? extends Component>> parent = RouteHierarchy
                 .resolveParent(leafView.getClass(), routeConfiguration);
         if (parent.isPresent()) {
-            add(new RouterLink("↑ Up to " + MissingAPI.staticTitle(parent.get()),
+            add(new RouterLink(
+                    "↑ Up to " + MissingAPI.staticTitle(parent.get()),
                     parent.get()));
         } else {
             add(new Span("You are at the top level."));

--- a/route-hierarchy/src/main/java/com/example/uc6/DashboardView.java
+++ b/route-hierarchy/src/main/java/com/example/uc6/DashboardView.java
@@ -12,7 +12,8 @@ import com.vaadin.flow.router.RouterLink;
  * UC6 — Layout-wide auto breadcrumbs (root, {@code uc6}).
  * <p>
  * This view adds no breadcrumb of its own — {@link TeamLayout} owns the single
- * shared trail and rebuilds it after every navigation.
+ * shared trail and rebuilds it reactively on every navigation via
+ * {@code UI.routerStateSignal()}.
  */
 @Route(value = "uc6", layout = TeamLayout.class)
 @PageTitle("Dashboard")
@@ -26,7 +27,7 @@ public class DashboardView extends VerticalLayout {
                         + "parent layout, not in this view. Navigate into the "
                         + "team and a member — the same bar updates and the "
                         + "counter ticks once per navigation, all from a single "
-                        + "AfterNavigationObserver."));
+                        + "Signal.effect subscribed to UI.routerStateSignal()."));
         add(new RouterLink("Open the team →", TeamView.class));
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc6/MemberView.java
+++ b/route-hierarchy/src/main/java/com/example/uc6/MemberView.java
@@ -11,9 +11,11 @@ import com.vaadin.flow.router.Route;
 /**
  * UC6 — Layout-wide auto breadcrumbs (leaf, {@code uc6/team/:member}).
  * <p>
- * Implements {@link HasDynamicTitle}; the layout's shared breadcrumb reads the
- * live instance from {@code AfterNavigationEvent#getActiveChain()}, so the
- * dynamic member name shows up in the trail without this view touching the bar.
+ * Implements {@link HasDynamicTitle}; the layout's shared breadcrumb is
+ * signal-bound, so when {@code UI.routerStateSignal()} fires the breadcrumb
+ * reads {@code state.currentView()} (this instance) and applies
+ * {@link #getPageTitle()} for the leaf label — this view does not touch the
+ * bar.
  */
 @Route(value = "uc6/team/:member", layout = TeamLayout.class)
 public class MemberView extends VerticalLayout
@@ -25,9 +27,9 @@ public class MemberView extends VerticalLayout
     public MemberView() {
         add(heading);
         add(new Paragraph("This view never references the breadcrumb. The "
-                + "parent layout's AfterNavigationObserver read this instance "
-                + "from the active chain and called getPageTitle() for the leaf "
-                + "label."));
+                + "parent layout's Signal.effect reads the current view "
+                + "instance from UI.routerStateSignal() and calls "
+                + "getPageTitle() for the leaf label."));
     }
 
     @Override

--- a/route-hierarchy/src/main/java/com/example/uc6/TeamLayout.java
+++ b/route-hierarchy/src/main/java/com/example/uc6/TeamLayout.java
@@ -1,18 +1,15 @@
 package com.example.uc6;
 
-import java.util.List;
-
 import com.example.views.BreadcrumbBar;
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.router.AfterNavigationEvent;
-import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * UC6 — Layout-wide auto breadcrumbs.
@@ -21,17 +18,16 @@ import com.vaadin.flow.router.RouterLayout;
  * view ({@code uc6}, {@code uc6/team}, {@code uc6/team/:member}). The child
  * views build no breadcrumb of their own.
  * <p>
- * The route-hierarchy PR ships no reactive "current navigation" signal, so the
- * rebuild is driven the classic way: this layout implements
- * {@link AfterNavigationObserver} and rebuilds the trail in
- * {@link #afterNavigation}. {@code AfterNavigationEvent#getActiveChain()} gives
- * the leaf view instance (so {@code HasDynamicTitle} still works) and
- * {@code getRouteParameters()} the live parameters. See {@code API-GAPS.md} for
- * the {@code Signal<NavigationState>} this pattern is crying out for.
+ * The layout subscribes to {@link UI#routerStateSignal()} from its constructor:
+ * a single {@link Signal#effect} runs on the first attach (seeding the initial
+ * trail) and again on every subsequent navigation, without any
+ * {@code AfterNavigationObserver} registration or manual seeding step. The
+ * {@link BreadcrumbBar} itself is also signal-bound, so the only thing this
+ * effect adds is the rebuild counter — kept here to make the per-navigation
+ * fire visible from the tests.
  */
 @ParentLayout(MainLayout.class)
-public class TeamLayout extends Div
-        implements RouterLayout, AfterNavigationObserver {
+public class TeamLayout extends Div implements RouterLayout {
 
     public static final String REBUILD_BADGE_ID = "uc6-rebuilds";
 
@@ -48,6 +44,12 @@ public class TeamLayout extends Div
         header.addClassName("team-header");
         content.addClassName("team-content");
         add(header, content);
+
+        Signal.effect(this, () -> {
+            UI.getCurrent().routerStateSignal().get();
+            rebuilds++;
+            rebuildBadge.setText("breadcrumb rebuilds: " + rebuilds);
+        });
     }
 
     @Override
@@ -56,17 +58,5 @@ public class TeamLayout extends Div
         if (routerLayoutContent != null) {
             content.getElement().appendChild(routerLayoutContent.getElement());
         }
-    }
-
-    @Override
-    public void afterNavigation(AfterNavigationEvent event) {
-        List<HasElement> activeChain = event.getActiveChain();
-        if (activeChain.isEmpty()
-                || !(activeChain.get(0) instanceof Component leaf)) {
-            return;
-        }
-        breadcrumbs.show(leaf, event.getRouteParameters());
-        rebuilds++;
-        rebuildBadge.setText("breadcrumb rebuilds: " + rebuilds);
     }
 }

--- a/route-hierarchy/src/main/java/com/example/uc7/SitemapView.java
+++ b/route-hierarchy/src/main/java/com/example/uc7/SitemapView.java
@@ -20,8 +20,6 @@ import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.UnorderedList;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -42,7 +40,7 @@ import com.vaadin.flow.router.RouterLink;
 @Route(value = "uc7", layout = MainLayout.class)
 @PageTitle("Sitemap")
 @Menu(order = 7, title = "UC7 — Route-tree sitemap")
-public class SitemapView extends VerticalLayout implements BeforeEnterObserver {
+public class SitemapView extends VerticalLayout {
 
     public static final String ROOT_LIST_ID = "sitemap-root";
 
@@ -51,26 +49,18 @@ public class SitemapView extends VerticalLayout implements BeforeEnterObserver {
             SubcategoryView.class, SessionsView.class, TeamView.class,
             OrdersView.class);
 
-    private final BreadcrumbBar breadcrumbs = new BreadcrumbBar();
-    private final VerticalLayout treeHolder = new VerticalLayout();
-
     public SitemapView() {
-        add(breadcrumbs);
+        add(new BreadcrumbBar());
         add(new H1("Sitemap"));
-        add(new Paragraph(
-                "Every node below was produced by calling "
-                        + "RouteHierarchy.resolveAncestors on a handful of leaf "
-                        + "routes and merging the returned chains into one tree. "
-                        + "The walker that draws a breadcrumb draws a sitemap "
-                        + "just as well."));
-        treeHolder.setPadding(false);
-        add(treeHolder);
+        add(new Paragraph("Every node below was produced by calling "
+                + "RouteHierarchy.resolveAncestors on a handful of leaf "
+                + "routes and merging the returned chains into one tree. "
+                + "The walker that draws a breadcrumb draws a sitemap "
+                + "just as well."));
+        add(buildTree());
     }
 
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        breadcrumbs.show(this, event.getRouteParameters());
-
+    private static UnorderedList buildTree() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forSessionScope();
 
@@ -92,8 +82,7 @@ public class SitemapView extends VerticalLayout implements BeforeEnterObserver {
 
         UnorderedList tree = renderLevel(roots, children);
         tree.setId(ROOT_LIST_ID);
-        treeHolder.removeAll();
-        treeHolder.add(tree);
+        return tree;
     }
 
     private static UnorderedList renderLevel(

--- a/route-hierarchy/src/main/java/com/example/views/BreadcrumbBar.java
+++ b/route-hierarchy/src/main/java/com/example/views/BreadcrumbBar.java
@@ -5,12 +5,16 @@ import java.util.List;
 import com.example.MissingAPI;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteHierarchy;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.router.RouterState;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * A reusable breadcrumb trail rendered as a {@link HorizontalLayout} of
@@ -19,13 +23,19 @@ import com.vaadin.flow.router.RouterLink;
  * <p>
  * The trail is built entirely from the Flow-core route-hierarchy API introduced
  * in <a href="https://github.com/vaadin/flow/pull/24451">flow#24451</a>:
- * {@link RouteHierarchy#resolveAncestors(Class, RouteConfiguration)} returns the
- * ancestor chain (root-first, leaf last) by consulting
- * {@code @RouteParent} first and falling back to URL-prefix walking. Each
- * ancestor becomes a {@link RouterLink}; the leaf is rendered as a plain,
- * non-linked {@link Span} marked as the current page. Label resolution and
- * per-ancestor parameter filtering are done by {@link MissingAPI} (see
- * {@code API-GAPS.md}).
+ * {@link RouteHierarchy#resolveAncestors(Class, RouteConfiguration)} returns
+ * the ancestor chain (root-first, leaf last) by consulting {@code @RouteParent}
+ * first and falling back to URL-prefix walking. Each ancestor becomes a
+ * {@link RouterLink}; the leaf is rendered as a plain, non-linked {@link Span}
+ * marked as the current page. Label resolution and per-ancestor parameter
+ * filtering are done by {@link MissingAPI} (see {@code API-GAPS.md}).
+ * <p>
+ * The bar wires itself to {@link UI#routerStateSignal()} from its constructor
+ * via a single {@link Signal#effect}: the effect rebuilds the trail from the
+ * current {@link RouterState} on every navigation (including same-class
+ * navigations with different route parameters) and unsubscribes automatically
+ * when this component is detached. Views just {@code add(new BreadcrumbBar())}
+ * — no {@code BeforeEnterObserver}, no manual seeding.
  */
 public class BreadcrumbBar extends HorizontalLayout {
 
@@ -33,22 +43,19 @@ public class BreadcrumbBar extends HorizontalLayout {
         addClassName("breadcrumb-bar");
         setSpacing(false);
         setPadding(false);
+
+        Signal.effect(this, () -> {
+            RouterState state = UI.getCurrent().routerStateSignal().get();
+            rebuild(state);
+        });
     }
 
-    /**
-     * Rebuilds the trail for {@code leafView} with no route parameters.
-     */
-    public void show(Component leafView) {
-        show(leafView, RouteParameters.empty());
-    }
-
-    /**
-     * Rebuilds the trail for {@code leafView}, carrying the relevant subset of
-     * {@code parameters} onto each ancestor link so parameterised ancestors
-     * resolve to working URLs.
-     */
-    public void show(Component leafView, RouteParameters parameters) {
+    private void rebuild(RouterState state) {
         removeAll();
+        HasElement leaf = state.currentView().orElse(null);
+        if (!(leaf instanceof Component leafView)) {
+            return;
+        }
 
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forSessionScope();
@@ -61,6 +68,7 @@ public class BreadcrumbBar extends HorizontalLayout {
             return;
         }
 
+        RouteParameters parameters = state.routeParameters();
         for (int i = 0; i < chain.size(); i++) {
             if (i > 0) {
                 add(separator());
@@ -76,8 +84,7 @@ public class BreadcrumbBar extends HorizontalLayout {
     }
 
     private static RouterLink ancestorLink(Class<? extends Component> ancestor,
-            RouteParameters parameters,
-            RouteConfiguration routeConfiguration) {
+            RouteParameters parameters, RouteConfiguration routeConfiguration) {
         String title = MissingAPI.staticTitle(ancestor);
         RouteParameters ancestorParameters = MissingAPI.parametersFor(ancestor,
                 parameters, routeConfiguration);

--- a/route-hierarchy/src/test/java/com/example/uc4/ParameterPreservingTrailTest.java
+++ b/route-hierarchy/src/test/java/com/example/uc4/ParameterPreservingTrailTest.java
@@ -50,7 +50,8 @@ class ParameterPreservingTrailTest extends SpringBrowserlessTest {
 
         // Root "uc4" has no parameters at all.
         assertFalse(projectsHref.contains("apollo"),
-                "Projects root link must not carry :projectId: " + projectsHref);
+                "Projects root link must not carry :projectId: "
+                        + projectsHref);
 
         // The two middle links keep :projectId so they stay in this project...
         assertTrue(projectHref.contains("apollo"), projectHref);

--- a/route-hierarchy/src/test/java/com/example/uc5/UpOneLevelTest.java
+++ b/route-hierarchy/src/test/java/com/example/uc5/UpOneLevelTest.java
@@ -2,12 +2,12 @@ package com.example.uc5;
 
 import java.util.List;
 
-import com.vaadin.flow.component.html.Span;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.RouterLink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/route-hierarchy/src/test/java/com/example/uc6/LayoutWideBreadcrumbsTest.java
+++ b/route-hierarchy/src/test/java/com/example/uc6/LayoutWideBreadcrumbsTest.java
@@ -4,12 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import com.example.views.BreadcrumbBar;
-import com.vaadin.flow.component.html.Span;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.RouterLink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,7 +53,7 @@ class LayoutWideBreadcrumbsTest extends SpringBrowserlessTest {
         assertTrue(trail().contains("Team"));
         int afterSecond = rebuildCount();
         assertTrue(afterSecond > afterFirst,
-                "AfterNavigationObserver must rebuild the trail on navigation");
+                "routerStateSignal effect must rebuild the trail on navigation");
 
         navigate(MemberView.class, Map.of("member", "lee"));
         assertTrue(trail().contains("Lee Wong"));
@@ -79,6 +79,7 @@ class LayoutWideBreadcrumbsTest extends SpringBrowserlessTest {
         Span badge = find(Span.class).withId(TeamLayout.REBUILD_BADGE_ID)
                 .single();
         String text = badge.getText();
-        return Integer.parseInt(text.substring(text.lastIndexOf(':') + 1).trim());
+        return Integer
+                .parseInt(text.substring(text.lastIndexOf(':') + 1).trim());
     }
 }

--- a/route-hierarchy/src/test/java/com/example/uc7/SitemapTreeTest.java
+++ b/route-hierarchy/src/test/java/com/example/uc7/SitemapTreeTest.java
@@ -29,9 +29,8 @@ class SitemapTreeTest extends SpringBrowserlessTest {
         long links = findInView(RouterLink.class).all().size();
         assertEquals(9, links, "sitemap must render one link per route node");
 
-        String text = find(UnorderedList.class)
-                .withId(SitemapView.ROOT_LIST_ID).single().getElement()
-                .getTextRecursively();
+        String text = find(UnorderedList.class).withId(SitemapView.ROOT_LIST_ID)
+                .single().getElement().getTextRecursively();
         for (String title : new String[] { "Catalog", "Electronics", "Laptops",
                 "Settings", "Security", "Active sessions", "Dashboard", "Team",
                 "Orders" }) {


### PR DESCRIPTION
BreadcrumbBar and UpLink now self-subscribe in their constructors via Signal.effect on UI.routerStateSignal(), rebuilding on every navigation and auto-unsubscribing on detach. UC6's TeamLayout drops AfterNavigationObserver for the same pattern; views drop their breadcrumbs.show() / upLink.show() calls and the BeforeEnterObserver implementations that did nothing else. API-GAPS gap #4 (no reactive navigation signal) is now closed.
