### PR TITLE
triggers: Add UC11–UC20 — custom Triggers, Actions, Inputs and the responsive grid

### DIFF
--- a/triggers/API-GAPS.md
+++ b/triggers/API-GAPS.md
@@ -18,6 +18,8 @@ shapes will keep evolving.
 | Client-side test simulator | Open — no introspection at all in the new architecture | — |
 | Server-side feature detection | Open | — |
 | `PropertyInput` doesn't accept raw `Element` | Open — only `Component` accepted; native elements need a wrapper | UC3 |
+| `Action.Input#toJs` not reachable from outside `internal` | Open — application Actions can't consume Inputs they didn't declare statically | UC19 |
+| `HandlerInput` not public | Open — custom Triggers can't reuse the canonical handler-scoped input class | UC11, UC13 |
 | Public introspection of trigger wiring | Open — `addJsInitializer` exposes no inspect surface | All tests |
 
 ## [Closed in mainline] Server callback after copy
@@ -132,3 +134,40 @@ augment a trigger's bindings after the fact has no API. The old
 the new architecture has nothing.
 **Suggested API:** A read-only view on `Element#getJsInitializers()` (or a
 similar accessor) that returns the install expressions and their captures.
+
+## `Action.Input#toJs` is package-private
+
+**Where it bit us:** UC19 wanted a `FilterListAction` that took an
+`Action.Input<String>` as the query source — the natural shape mirroring
+`SetPropertyAction(target, name, source)`. But
+`Action.Input#toJs(Trigger)` has `protected` visibility, and the surrounding
+`Action` class lives in
+`com.vaadin.flow.component.trigger.internal`, so application code in any
+other package can't call it.
+**Symptom:** `source.toJs(trigger)` from a custom Action outside the
+`internal` package fails to compile with "toJs has protected access in
+Input".
+**Workaround used:** Drop the Input parameter entirely. UC19's
+`FilterListAction` is hard-wired to read its query from
+`event.target.value` and only works when bound to a `DomEventTrigger` on
+the relevant search field. A more general shape isn't expressible.
+**Suggested API:** Promote `Input#toJs` to `public` (it is already public
+by intent — every `Action` calls it). Or give Input a public render method
+that wraps `toJs` for external callers.
+
+## `HandlerInput` is not public
+
+**Where it bit us:** UC11 (IdleTrigger), UC13 (BroadcastChannelTrigger).
+Both expose event-scoped state through static `Action.Input` fields and
+would naturally use `HandlerInput<>("event.detail.idle",
+IdleTrigger.class)` — the exact pattern the built-in triggers use (see
+`SizeTrigger.EventData`, `MouseEventTrigger.EventData`).
+**Symptom:** `HandlerInput` is in the `internal` package and
+package-private. Custom Triggers in any other package fall back to
+declaring an anonymous `Action.Input<T>` per field with an inline trigger
+type check.
+**Workaround used:** Anonymous classes (see `IdleTrigger.EventData.idle`,
+`BroadcastChannelTrigger.EventData.data`). Each is ~10 lines instead of
+one.
+**Suggested API:** Make `HandlerInput` `public` so add-on triggers can
+reuse the canonical implementation.

--- a/triggers/src/main/java/com/example/home/HomeView.java
+++ b/triggers/src/main/java/com/example/home/HomeView.java
@@ -3,7 +3,17 @@ package com.example.home;
 import com.example.common.BaseHomeView;
 import com.example.uc1.CopyFieldValueView;
 import com.example.uc10.CopyAndCountView;
+import com.example.uc11.IdleWarningView;
+import com.example.uc12.NetworkStatusView;
+import com.example.uc13.CrossTabBroadcastView;
+import com.example.uc14.LongPressDeleteView;
+import com.example.uc15.ScrollIntoViewView;
+import com.example.uc16.HighlightView;
+import com.example.uc17.RightClickCoordsView;
+import com.example.uc18.AccessibleSaveView;
+import com.example.uc19.ClientFilterView;
 import com.example.uc2.CopyCodeSnippetView;
+import com.example.uc20.ResponsiveCardsView;
 import com.example.uc3.CopySelectValueView;
 import com.example.uc4.ShareUrlView;
 import com.example.uc5.CustomActionView;
@@ -26,13 +36,13 @@ public class HomeView extends BaseHomeView {
                 "Each card below exercises one use case of the "
                         + "com.vaadin.flow.component.trigger.internal API. A "
                         + "Trigger fires on the client (a click, a keyboard "
-                        + "shortcut, a double-click, …), reads zero or more Inputs "
-                        + "(DOM properties, server-side Signals, JS expressions, "
-                        + "literals), and runs one or more Actions — all inside "
-                        + "the original user-gesture handler so gesture-gated "
-                        + "browser APIs (clipboard, fullscreen, share) work "
-                        + "without a server round-trip. Server-side mirrors and "
-                        + "callbacks land afterwards over the regular Flow channel.");
+                        + "shortcut, a resize, an idle timeout, a cross-tab "
+                        + "broadcast, …), reads zero or more Inputs, and runs "
+                        + "one or more Actions — all inside the original "
+                        + "browser handler. The later UCs demonstrate the "
+                        + "extension SPI: custom Triggers, custom Actions, and "
+                        + "custom Inputs you write against the public abstract "
+                        + "classes.");
 
         Div cards = new Div();
         cards.addClassName("home-cards");
@@ -49,7 +59,7 @@ public class HomeView extends BaseHomeView {
                 "Server-side ValueSignal copied via SignalInput — no round-trip.",
                 ShareUrlView.class));
         cards.add(homeCard("UC5", "Custom action",
-                "Subclass Action and emit JS via appendStatement — no @JsModule.",
+                "Subclass Action and emit JS via toJs — no @JsModule.",
                 CustomActionView.class));
         cards.add(homeCard("UC6", "Shortcut copy",
                 "Ctrl/Cmd-C fires a (local) ShortcutTrigger that copies a field value.",
@@ -66,6 +76,36 @@ public class HomeView extends BaseHomeView {
         cards.add(homeCard("UC10", "Server callback",
                 "Click copies AND runs a server callback via WriteToClipboardAction's onCopied.",
                 CopyAndCountView.class));
+        cards.add(homeCard("UC11", "Idle warning",
+                "Custom IdleTrigger fires after 5s of no activity; SetSignalAction toggles a state badge.",
+                IdleWarningView.class));
+        cards.add(homeCard("UC12", "Network status",
+                "Custom NetworkStatusTrigger + client-side action that reads navigator.onLine.",
+                NetworkStatusView.class));
+        cards.add(homeCard("UC13", "Cross-tab broadcast",
+                "Custom BroadcastChannelTrigger forwards messages from other tabs into a signal.",
+                CrossTabBroadcastView.class));
+        cards.add(homeCard("UC14", "Long-press to delete",
+                "Custom LongPressTrigger composes pointer events with a timer.",
+                LongPressDeleteView.class));
+        cards.add(homeCard("UC15", "Scroll into view",
+                "Smallest custom Action — captures a target, calls scrollIntoView.",
+                ScrollIntoViewView.class));
+        cards.add(homeCard("UC16", "Highlight",
+                "Custom Action with constructor-time colour and duration as JS captures.",
+                HighlightView.class));
+        cards.add(homeCard("UC17", "Right-click coords",
+                "Custom PointInput returns {x,y}; Jackson decodes into a Point record server-side.",
+                RightClickCoordsView.class));
+        cards.add(homeCard("UC18", "Accessibility announce",
+                "Custom AnnounceAction writes into an aria-live region for screen readers.",
+                AccessibleSaveView.class));
+        cards.add(homeCard("UC19", "Client-side filter",
+                "Server renders the full list once; a custom action filters rows in JS.",
+                ClientFilterView.class));
+        cards.add(homeCard("UC20", "Responsive cards",
+                "SizeTrigger + custom ClassByWidthAction swap a card grid between 1, 2, 3 columns.",
+                ResponsiveCardsView.class));
         add(cards);
     }
 }

--- a/triggers/src/main/java/com/example/uc11/IdleTrigger.java
+++ b/triggers/src/main/java/com/example/uc11/IdleTrigger.java
@@ -1,0 +1,83 @@
+package com.example.uc11;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Custom {@link Trigger} that fires when the user has been inactive for at
+ * least {@code inactivityMs} milliseconds, and again when activity resumes
+ * after an idle period. The trigger keeps a {@code setTimeout} timer that any
+ * keyboard/pointer/scroll event on {@code window} resets.
+ * <p>
+ * The handler receives a synthetic {@code CustomEvent} with
+ * {@code event.detail.idle === true|false}; the {@link EventData#idle} input
+ * exposes that as a server-decodable {@code Boolean}.
+ * <p>
+ * Demonstrates a Trigger whose state lives entirely in JS — no DOM event maps
+ * to "idle"; the trigger composes setTimeout with regular activity listeners.
+ */
+public class IdleTrigger extends Trigger {
+
+    private final int inactivityMs;
+
+    public IdleTrigger(Component host, int inactivityMs) {
+        super(host);
+        if (inactivityMs < 0) {
+            throw new IllegalArgumentException("inactivityMs must be >= 0");
+        }
+        this.inactivityMs = inactivityMs;
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        // The handler is fired twice per idle cycle: once when the timer
+        // elapses (idle=true) and once on the first activity after that
+        // (idle=false). Initial state is "active"; we don't fire on install.
+        return getHost().addJsInitializer("""
+                const ms = $1;
+                const events = ['mousemove','mousedown','keydown','wheel','touchstart'];
+                let idle = false;
+                let timer = null;
+                const fire = (state) => $0(new CustomEvent('idle', {detail: {idle: state}}));
+                const goIdle = () => { idle = true; fire(true); };
+                const onActivity = () => {
+                    if (idle) { idle = false; fire(false); }
+                    if (timer) clearTimeout(timer);
+                    timer = setTimeout(goIdle, ms);
+                };
+                for (const e of events) window.addEventListener(e, onActivity, {passive: true});
+                onActivity();
+                return () => {
+                    if (timer) clearTimeout(timer);
+                    for (const e of events) window.removeEventListener(e, onActivity);
+                };""", action, inactivityMs);
+    }
+
+    /** Inputs exposed by this trigger's handler scope. */
+    public abstract static class EventData {
+        protected EventData() {
+        }
+
+        /**
+         * {@code event.detail.idle} — {@code true} when the trigger fired
+         * because the user just became idle, {@code false} when activity
+         * resumed.
+         */
+        public static final Action.Input<Boolean> idle = new Action.Input<>() {
+            @Override
+            protected JsFunction toJs(Trigger trigger) {
+                if (!(trigger instanceof IdleTrigger)) {
+                    throw new IllegalArgumentException(
+                            "Input is scoped to IdleTrigger and cannot be used in a "
+                                    + trigger.getClass().getSimpleName()
+                                    + " handler");
+                }
+                return JsFunction.of("return event.detail.idle")
+                        .withArguments("event");
+            }
+        };
+    }
+}

--- a/triggers/src/main/java/com/example/uc11/IdleWarningView.java
+++ b/triggers/src/main/java/com/example/uc11/IdleWarningView.java
@@ -1,0 +1,60 @@
+package com.example.uc11;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.SetSignalAction;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.local.ValueSignal;
+
+/**
+ * UC11 — Idle warning.
+ * <p>
+ * A custom {@link IdleTrigger} fires after a few seconds without keyboard,
+ * pointer, or scroll activity, and again when activity resumes. The trigger's
+ * {@link IdleTrigger.EventData#idle} input is wired through
+ * {@link SetSignalAction} to a server-side {@link ValueSignal Boolean signal}
+ * that the view's badge is bound to.
+ */
+@Route(value = "uc11", layout = MainLayout.class)
+@PageTitle("UC11 — Idle warning")
+@Menu(order = 11, title = "UC11 — Idle warning")
+@StyleSheet("uc11.css")
+public class IdleWarningView extends VerticalLayout {
+
+    public IdleWarningView() {
+        addClassName("uc11-view");
+        add(new H1("UC11 — Idle warning"));
+        add(new Paragraph(
+                "Don't touch your mouse or keyboard for 5 seconds. The status "
+                        + "below flips to \"idle\"; any activity flips it back to "
+                        + "\"active\". The state lives in a server-side ValueSignal, "
+                        + "driven entirely by a custom IdleTrigger that wraps "
+                        + "window-level activity listeners and a setTimeout."));
+
+        ValueSignal<Boolean> idleSignal = new ValueSignal<>(Boolean.FALSE);
+
+        Span badge = new Span();
+        badge.setId("status");
+        badge.addClassName("status-badge");
+        badge.bindText(idleSignal.map(idle -> idle ? "idle" : "active"));
+        badge.getClassNames().bind("idle", idleSignal);
+
+        Button resetButton = new Button("Trigger an event");
+        resetButton.setId("reset");
+        resetButton.addClickListener(e -> {
+            /* the click itself is activity — the JS observer will fire false */ });
+
+        new IdleTrigger(this, 5_000).triggers(new SetSignalAction<>(idleSignal,
+                Boolean.class, IdleTrigger.EventData.idle));
+
+        add(badge, resetButton);
+    }
+}

--- a/triggers/src/main/java/com/example/uc12/ApplyNetworkStatusAction.java
+++ b/triggers/src/main/java/com/example/uc12/ApplyNetworkStatusAction.java
@@ -1,0 +1,37 @@
+package com.example.uc12;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Client-side action that reads {@code navigator.onLine} at fire time and
+ * sets the target's {@code textContent} and {@code className} accordingly.
+ * Stays entirely in the browser — important when the trigger is meant to
+ * react to going offline (a server callback would be the wrong tool).
+ */
+public class ApplyNetworkStatusAction extends Action {
+
+    private final Element target;
+
+    public ApplyNetworkStatusAction(Component target) {
+        this(Objects.requireNonNull(target).getElement());
+    }
+
+    public ApplyNetworkStatusAction(Element target) {
+        this.target = Objects.requireNonNull(target);
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        return JsFunction.of("""
+                const online = navigator.onLine;
+                $0.textContent = online ? 'Online' : 'Offline';
+                $0.className = online ? 'status-badge online' : 'status-badge offline';""",
+                target);
+    }
+}

--- a/triggers/src/main/java/com/example/uc12/NetworkStatusTrigger.java
+++ b/triggers/src/main/java/com/example/uc12/NetworkStatusTrigger.java
@@ -1,0 +1,37 @@
+package com.example.uc12;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Custom {@link Trigger} that fires whenever the browser reports a change in
+ * online/offline status (via the {@code online} and {@code offline} window
+ * events), plus once on install so the initial state is observable.
+ * <p>
+ * Demonstrates a trigger whose event source is {@code window}, not the host
+ * element. The host is still used as the lifecycle owner — uninstall happens
+ * when the host is detached.
+ */
+public class NetworkStatusTrigger extends Trigger {
+
+    public NetworkStatusTrigger(Component host) {
+        super(host);
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        return getHost().addJsInitializer(
+                """
+                        const fire = () => $0(new Event('networkstatus'));
+                        window.addEventListener('online', fire);
+                        window.addEventListener('offline', fire);
+                        queueMicrotask(fire);
+                        return () => {
+                            window.removeEventListener('online', fire);
+                            window.removeEventListener('offline', fire);
+                        };""",
+                action);
+    }
+}

--- a/triggers/src/main/java/com/example/uc12/NetworkStatusView.java
+++ b/triggers/src/main/java/com/example/uc12/NetworkStatusView.java
@@ -1,0 +1,49 @@
+package com.example.uc12;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC12 — Network status badge.
+ * <p>
+ * The status flips between "Online" and "Offline" purely client-side because
+ * a server callback wouldn't be reachable when the network drops. A custom
+ * {@link NetworkStatusTrigger} fires on the browser's {@code online} and
+ * {@code offline} window events; a custom {@link ApplyNetworkStatusAction}
+ * reads {@code navigator.onLine} at fire time and updates the badge's text
+ * and class.
+ * <p>
+ * To test: open DevTools' Network panel and toggle "Offline".
+ */
+@Route(value = "uc12", layout = MainLayout.class)
+@PageTitle("UC12 — Network status")
+@Menu(order = 12, title = "UC12 — Network status")
+@StyleSheet("uc12.css")
+public class NetworkStatusView extends VerticalLayout {
+
+    public NetworkStatusView() {
+        addClassName("uc12-view");
+        add(new H1("UC12 — Network status"));
+        add(new Paragraph(
+                "The badge below tracks the browser's online/offline state. "
+                        + "Toggle \"Offline\" in DevTools' Network panel; the badge "
+                        + "flips with no server round-trip."));
+
+        Span badge = new Span("…");
+        badge.setId("status");
+        badge.addClassName("status-badge");
+
+        new NetworkStatusTrigger(this)
+                .triggers(new ApplyNetworkStatusAction(badge));
+
+        add(badge);
+    }
+}

--- a/triggers/src/main/java/com/example/uc13/BroadcastChannelTrigger.java
+++ b/triggers/src/main/java/com/example/uc13/BroadcastChannelTrigger.java
@@ -1,0 +1,66 @@
+package com.example.uc13;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Custom {@link Trigger} that fires when a message arrives on the given
+ * named {@code BroadcastChannel}. The channel is created when the trigger
+ * installs and closed when it uninstalls.
+ * <p>
+ * Demonstrates a Trigger whose "event source" isn't a DOM event at all — it's
+ * an object the trigger constructs (a {@code BroadcastChannel}) and observes
+ * via its {@code message} handler. The host element is only the lifecycle
+ * owner; messages from other tabs don't go through it.
+ */
+public class BroadcastChannelTrigger extends Trigger {
+
+    private final String channelName;
+
+    public BroadcastChannelTrigger(Component host, String channelName) {
+        super(host);
+        this.channelName = Objects.requireNonNull(channelName, "channelName");
+        if (channelName.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "channelName must not be empty");
+        }
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        return getHost().addJsInitializer("""
+                const channel = new BroadcastChannel($1);
+                channel.onmessage = (e) => $0(e);
+                return () => { channel.close(); };""", action, channelName);
+    }
+
+    /** Inputs exposed by this trigger's handler scope. */
+    public abstract static class EventData {
+        protected EventData() {
+        }
+
+        /**
+         * {@code event.data} — the payload posted on the channel by the
+         * sending tab. Decoded server-side via Jackson when consumed by an
+         * action that decodes its input.
+         */
+        public static final Action.Input<String> data = new Action.Input<>() {
+            @Override
+            protected JsFunction toJs(Trigger trigger) {
+                if (!(trigger instanceof BroadcastChannelTrigger)) {
+                    throw new IllegalArgumentException(
+                            "Input is scoped to BroadcastChannelTrigger and cannot be used in a "
+                                    + trigger.getClass().getSimpleName()
+                                    + " handler");
+                }
+                return JsFunction.of("return event.data")
+                        .withArguments("event");
+            }
+        };
+    }
+}

--- a/triggers/src/main/java/com/example/uc13/CrossTabBroadcastView.java
+++ b/triggers/src/main/java/com/example/uc13/CrossTabBroadcastView.java
@@ -1,0 +1,70 @@
+package com.example.uc13;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.SetSignalAction;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.local.ValueSignal;
+
+/**
+ * UC13 — Cross-tab broadcast.
+ * <p>
+ * Open this view in two browser tabs. Clicking "Broadcast hello" in tab A
+ * posts a message on a {@code BroadcastChannel}; tab B's
+ * {@link BroadcastChannelTrigger} fires, {@link SetSignalAction} pushes the
+ * payload into a server-side signal, and tab B's "Last received" badge
+ * updates. The sender does NOT receive its own broadcast — that's
+ * BroadcastChannel semantics.
+ * <p>
+ * The send button uses {@code Element.executeJs} to post on the same channel
+ * the trigger listens on. A production view would wrap that as a custom
+ * {@code Action} (e.g. {@code BroadcastSendAction}) so the send is also part
+ * of the trigger system.
+ */
+@Route(value = "uc13", layout = MainLayout.class)
+@PageTitle("UC13 — Cross-tab broadcast")
+@Menu(order = 13, title = "UC13 — Cross-tab broadcast")
+@StyleSheet("uc13.css")
+public class CrossTabBroadcastView extends VerticalLayout {
+
+    private static final String CHANNEL = "uc13-demo-channel";
+
+    public CrossTabBroadcastView() {
+        addClassName("uc13-view");
+        add(new H1("UC13 — Cross-tab broadcast"));
+        add(new Paragraph(
+                "Open this view in two browser tabs. Click \"Broadcast hello\" "
+                        + "in one tab; the other tab's badge updates. The "
+                        + "BroadcastChannel API doesn't echo to the sender, so the "
+                        + "tab that clicks won't see its own message."));
+
+        ValueSignal<String> lastMessage = new ValueSignal<>("(none yet)");
+
+        Span badge = new Span();
+        badge.setId("last");
+        badge.addClassName("last-message");
+        badge.bindText(lastMessage);
+
+        Button send = new Button("Broadcast hello");
+        send.setId("send");
+        send.getElement().executeJs(
+                "this.addEventListener('click', () => new BroadcastChannel($0)"
+                        + ".postMessage('hello from ' + Math.floor(Math.random()*1000)));",
+                CHANNEL);
+
+        new BroadcastChannelTrigger(this, CHANNEL)
+                .triggers(new SetSignalAction<>(lastMessage, String.class,
+                        BroadcastChannelTrigger.EventData.data));
+
+        add(new HorizontalLayout(send, badge));
+    }
+}

--- a/triggers/src/main/java/com/example/uc14/LongPressDeleteView.java
+++ b/triggers/src/main/java/com/example/uc14/LongPressDeleteView.java
@@ -1,0 +1,61 @@
+package com.example.uc14;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.CallbackAction;
+import com.vaadin.flow.component.trigger.internal.LiteralInput;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+import com.example.views.MainLayout;
+
+/**
+ * UC14 — Long-press to confirm a destructive action.
+ * <p>
+ * Press and hold the red button for 800ms. The custom
+ * {@link LongPressTrigger} fires once the hold threshold elapses, runs a
+ * {@link CallbackAction} that pretends to delete a row, and updates the
+ * status badge. Releasing early cancels — and a regular short click is also
+ * suppressed so accidental taps never delete anything.
+ */
+@Route(value = "uc14", layout = MainLayout.class)
+@PageTitle("UC14 — Long-press to delete")
+@Menu(order = 14, title = "UC14 — Long-press to delete")
+@StyleSheet("uc14.css")
+public class LongPressDeleteView extends VerticalLayout {
+
+    private int deleteCount = 0;
+
+    public LongPressDeleteView() {
+        addClassName("uc14-view");
+        add(new H1("UC14 — Long-press to delete"));
+        add(new Paragraph(
+                "Press and hold the Delete button for 800ms to confirm. "
+                        + "A regular click does nothing — the trigger suppresses "
+                        + "it. Real-world: touch-friendly destructive actions "
+                        + "without a confirm dialog."));
+
+        Button deleteButton = new Button("Hold to delete");
+        deleteButton.setId("delete");
+        deleteButton.addClassName("delete-button");
+
+        Span status = new Span("0 rows deleted");
+        status.setId("status");
+        status.addClassName("status");
+
+        new LongPressTrigger(deleteButton, 800)
+                .triggers(new CallbackAction<>(String.class, payload -> {
+                    deleteCount++;
+                    status.setText(deleteCount + " row"
+                            + (deleteCount == 1 ? "" : "s") + " deleted");
+                }, new LiteralInput<>("delete")));
+
+        add(new HorizontalLayout(deleteButton, status));
+    }
+}

--- a/triggers/src/main/java/com/example/uc14/LongPressTrigger.java
+++ b/triggers/src/main/java/com/example/uc14/LongPressTrigger.java
@@ -1,0 +1,69 @@
+package com.example.uc14;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Custom {@link Trigger} that fires when the host has been pressed
+ * (pointerdown) for at least {@code holdMs} milliseconds without being
+ * released. Cancels on pointerup, pointercancel, or pointerleave. Suppresses
+ * the synthetic click that follows so the wired actions don't also receive
+ * a click event.
+ * <p>
+ * Demonstrates a Trigger that tracks a time-windowed gesture the browser
+ * doesn't fire as a single event — composing pointer events with
+ * {@code setTimeout}.
+ */
+public class LongPressTrigger extends Trigger {
+
+    private final int holdMs;
+
+    public LongPressTrigger(Component host, int holdMs) {
+        super(host);
+        if (holdMs <= 0) {
+            throw new IllegalArgumentException("holdMs must be > 0");
+        }
+        this.holdMs = holdMs;
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        return getHost().addJsInitializer("""
+                const ms = $1;
+                let timer = null;
+                let triggered = false;
+                const onDown = (e) => {
+                    triggered = false;
+                    if (timer) clearTimeout(timer);
+                    timer = setTimeout(() => {
+                        triggered = true;
+                        $0(e);
+                    }, ms);
+                };
+                const cancel = () => {
+                    if (timer) { clearTimeout(timer); timer = null; }
+                };
+                const onClick = (e) => {
+                    if (triggered) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        triggered = false;
+                    }
+                };
+                this.addEventListener('pointerdown', onDown);
+                this.addEventListener('pointerup', cancel);
+                this.addEventListener('pointercancel', cancel);
+                this.addEventListener('pointerleave', cancel);
+                this.addEventListener('click', onClick, {capture: true});
+                return () => {
+                    cancel();
+                    this.removeEventListener('pointerdown', onDown);
+                    this.removeEventListener('pointerup', cancel);
+                    this.removeEventListener('pointercancel', cancel);
+                    this.removeEventListener('pointerleave', cancel);
+                    this.removeEventListener('click', onClick, {capture: true});
+                };""", action, holdMs);
+    }
+}

--- a/triggers/src/main/java/com/example/uc15/ScrollIntoViewAction.java
+++ b/triggers/src/main/java/com/example/uc15/ScrollIntoViewAction.java
@@ -1,0 +1,42 @@
+package com.example.uc15;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action} that calls {@code target.scrollIntoView} on a target
+ * element when the bound trigger fires. Uses {@code behavior: 'smooth'} and
+ * {@code block: 'center'} so the target settles in the middle of the
+ * viewport.
+ * <p>
+ * The simplest possible custom action: capture the target as {@code $0},
+ * call a method on it. No inputs, no outcome.
+ */
+public class ScrollIntoViewAction extends Action {
+
+    private final Element target;
+
+    public ScrollIntoViewAction(Component target) {
+        this(Objects.requireNonNull(target).getElement());
+    }
+
+    public ScrollIntoViewAction(Element target) {
+        this.target = Objects.requireNonNull(target);
+    }
+
+    public Element getTarget() {
+        return target;
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        return JsFunction.of(
+                "$0.scrollIntoView({behavior:'smooth',block:'center'})",
+                target);
+    }
+}

--- a/triggers/src/main/java/com/example/uc15/ScrollIntoViewView.java
+++ b/triggers/src/main/java/com/example/uc15/ScrollIntoViewView.java
@@ -1,0 +1,67 @@
+package com.example.uc15;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC15 — Scroll a target into view on click.
+ * <p>
+ * Two "Jump to …" buttons each wired to a {@link ScrollIntoViewAction}
+ * pointing at a section far down the page. The simplest possible custom
+ * action that doesn't take inputs or report outcome — just calls a method
+ * on the captured target.
+ */
+@Route(value = "uc15", layout = MainLayout.class)
+@PageTitle("UC15 — Scroll into view")
+@Menu(order = 15, title = "UC15 — Scroll into view")
+@StyleSheet("uc15.css")
+public class ScrollIntoViewView extends VerticalLayout {
+
+    public ScrollIntoViewView() {
+        addClassName("uc15-view");
+        add(new H1("UC15 — Scroll into view"));
+        add(new Paragraph(
+                "Click a button to smoothly scroll the corresponding section "
+                        + "into the centre of the viewport. The custom "
+                        + "ScrollIntoViewAction is 5 effective lines — capture "
+                        + "the target, call scrollIntoView."));
+
+        Div sectionA = new Div("Section A");
+        sectionA.setId("section-a");
+        sectionA.addClassName("section");
+
+        Div sectionB = new Div("Section B");
+        sectionB.setId("section-b");
+        sectionB.addClassName("section");
+
+        Div sectionC = new Div("Section C");
+        sectionC.setId("section-c");
+        sectionC.addClassName("section");
+
+        Button toA = new Button("Jump to A");
+        toA.setId("to-a");
+        new ClickTrigger(toA).triggers(new ScrollIntoViewAction(sectionA));
+
+        Button toB = new Button("Jump to B");
+        toB.setId("to-b");
+        new ClickTrigger(toB).triggers(new ScrollIntoViewAction(sectionB));
+
+        Button toC = new Button("Jump to C");
+        toC.setId("to-c");
+        new ClickTrigger(toC).triggers(new ScrollIntoViewAction(sectionC));
+
+        add(new HorizontalLayout(toA, toB, toC));
+        add(new Div(sectionA, sectionB, sectionC));
+    }
+}

--- a/triggers/src/main/java/com/example/uc16/HighlightAction.java
+++ b/triggers/src/main/java/com/example/uc16/HighlightAction.java
@@ -1,0 +1,51 @@
+package com.example.uc16;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action} that briefly tints the target's background with a
+ * configurable colour for a configurable duration. The colour and duration
+ * are captured as JS arguments — they materialise on the client without any
+ * string concatenation in the body.
+ * <p>
+ * Demonstrates how an action takes <em>server-side configuration</em> at
+ * construction and threads it through captures. Same pattern any reusable
+ * action library would follow.
+ */
+public class HighlightAction extends Action {
+
+    private final Element target;
+    private final String color;
+    private final int durationMs;
+
+    public HighlightAction(Component target, String color, int durationMs) {
+        this(Objects.requireNonNull(target).getElement(), color, durationMs);
+    }
+
+    public HighlightAction(Element target, String color, int durationMs) {
+        this.target = Objects.requireNonNull(target);
+        this.color = Objects.requireNonNull(color);
+        if (durationMs <= 0) {
+            throw new IllegalArgumentException("durationMs must be > 0");
+        }
+        this.durationMs = durationMs;
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        return JsFunction.of(
+                """
+                        const t=$0;
+                        const o=t.style.backgroundColor;
+                        t.style.transition='background-color 200ms';
+                        t.style.backgroundColor=$1;
+                        window.setTimeout(()=>{t.style.backgroundColor=o;},$2);""",
+                target, color, durationMs);
+    }
+}

--- a/triggers/src/main/java/com/example/uc16/HighlightView.java
+++ b/triggers/src/main/java/com/example/uc16/HighlightView.java
@@ -1,0 +1,62 @@
+package com.example.uc16;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC16 — Parameterised highlight action.
+ * <p>
+ * Three buttons each fire a {@link HighlightAction} configured with a
+ * different colour and duration. Demonstrates how an action's constructor
+ * arguments thread through to the rendered JS via captures. The same target
+ * is reused by all three; the configuration is per-instance, not per-target.
+ */
+@Route(value = "uc16", layout = MainLayout.class)
+@PageTitle("UC16 — Highlight")
+@Menu(order = 16, title = "UC16 — Highlight")
+@StyleSheet("uc16.css")
+public class HighlightView extends VerticalLayout {
+
+    public HighlightView() {
+        addClassName("uc16-view");
+        add(new H1("UC16 — Parameterised highlight"));
+        add(new Paragraph(
+                "Each button flashes the same target box with its configured "
+                        + "colour and duration. The action's constructor "
+                        + "arguments end up as JS captures — no string "
+                        + "concatenation, all values are Jackson-encoded."));
+
+        Div target = new Div("Target");
+        target.setId("target");
+        target.addClassName("highlight-target");
+
+        Button yellow = new Button("Brief gold (300ms)");
+        yellow.setId("gold");
+        new ClickTrigger(yellow)
+                .triggers(new HighlightAction(target, "gold", 300));
+
+        Button red = new Button("Long red (1.2s)");
+        red.setId("red");
+        new ClickTrigger(red).triggers(
+                new HighlightAction(target, "tomato", 1200));
+
+        Button blue = new Button("Cyan tap (500ms)");
+        blue.setId("cyan");
+        new ClickTrigger(blue).triggers(
+                new HighlightAction(target, "cyan", 500));
+
+        add(target);
+        add(new HorizontalLayout(yellow, red, blue));
+    }
+}

--- a/triggers/src/main/java/com/example/uc17/Point.java
+++ b/triggers/src/main/java/com/example/uc17/Point.java
@@ -1,0 +1,9 @@
+package com.example.uc17;
+
+/**
+ * Pair of viewport-relative pixel coordinates. Plain record so Jackson can
+ * decode the JSON object literal {@code {x, y}} that the custom
+ * {@link PointInput} returns from the client.
+ */
+public record Point(int x, int y) {
+}

--- a/triggers/src/main/java/com/example/uc17/PointInput.java
+++ b/triggers/src/main/java/com/example/uc17/PointInput.java
@@ -1,0 +1,30 @@
+package com.example.uc17;
+
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.MouseEventTrigger;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action.Input} that returns {@code {x, y}} read from the
+ * surrounding {@link MouseEventTrigger}'s event — Jackson decodes the JSON
+ * literal directly into a {@link Point} on the server.
+ * <p>
+ * Demonstrates two things at once: writing a custom Input, and reading
+ * trigger-scoped handler state (the {@code event} parameter) from one. The
+ * trigger check rejects use in any non-mouse-event handler at install time,
+ * the same protection the built-in handler-scoped inputs apply.
+ */
+public final class PointInput extends Action.Input<Point> {
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        if (!(trigger instanceof MouseEventTrigger)) {
+            throw new IllegalArgumentException(
+                    "PointInput is scoped to MouseEventTrigger and cannot be used in a "
+                            + trigger.getClass().getSimpleName() + " handler");
+        }
+        return JsFunction.of("return {x: event.clientX, y: event.clientY}")
+                .withArguments("event");
+    }
+}

--- a/triggers/src/main/java/com/example/uc17/RightClickCoordsView.java
+++ b/triggers/src/main/java/com/example/uc17/RightClickCoordsView.java
@@ -1,0 +1,60 @@
+package com.example.uc17;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.CallbackAction;
+import com.vaadin.flow.component.trigger.internal.MouseEventTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC17 — Right-click and report pointer coordinates to the server.
+ * <p>
+ * The panel listens for {@code contextmenu} via a
+ * {@link MouseEventTrigger}. A custom {@link PointInput} reads
+ * {@code event.clientX}/{@code event.clientY}, returns them as a JS
+ * {@code {x, y}} object literal, and Jackson decodes that into a
+ * {@link Point} record on the server. A {@link CallbackAction Point} consumes
+ * it.
+ * <p>
+ * Demonstrates a custom Input that produces a structured server-side value.
+ */
+@Route(value = "uc17", layout = MainLayout.class)
+@PageTitle("UC17 — Right-click coords")
+@Menu(order = 17, title = "UC17 — Right-click coords")
+@StyleSheet("uc17.css")
+public class RightClickCoordsView extends VerticalLayout {
+
+    public RightClickCoordsView() {
+        addClassName("uc17-view");
+        add(new H1("UC17 — Right-click coordinates"));
+        add(new Paragraph(
+                "Right-click anywhere in the box below. A custom PointInput "
+                        + "reads event.clientX/clientY in the trigger handler "
+                        + "and the value lands on the server as a Point record."));
+
+        Div panel = new Div("Right-click me");
+        panel.setId("panel");
+        panel.addClassName("panel");
+
+        Span lastClick = new Span("(no right-click yet)");
+        lastClick.setId("last");
+        lastClick.addClassName("coords");
+
+        MouseEventTrigger contextMenu = new MouseEventTrigger(panel,
+                "contextmenu");
+        contextMenu.triggers(new CallbackAction<>(Point.class, point -> {
+            lastClick.setText("Last right-click: x=" + point.x() + " y="
+                    + point.y());
+        }, new PointInput()));
+
+        add(panel, lastClick);
+    }
+}

--- a/triggers/src/main/java/com/example/uc18/AccessibleSaveView.java
+++ b/triggers/src/main/java/com/example/uc18/AccessibleSaveView.java
@@ -1,0 +1,62 @@
+package com.example.uc18;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC18 — Accessibility announcement on save.
+ * <p>
+ * Clicking "Save" updates the visible badge and also fires an
+ * {@link AnnounceAction} that writes into an aria-live region. Screen-reader
+ * users hear "Saved" without focus moving from the button. The aria-live
+ * region is visually hidden via the {@code sr-only} class.
+ */
+@Route(value = "uc18", layout = MainLayout.class)
+@PageTitle("UC18 — Accessibility announce")
+@Menu(order = 18, title = "UC18 — Accessibility announce")
+@StyleSheet("uc18.css")
+public class AccessibleSaveView extends VerticalLayout {
+
+    public AccessibleSaveView() {
+        addClassName("uc18-view");
+        add(new H1("UC18 — Accessibility announce"));
+        add(new Paragraph(
+                "Click Save. Sighted users see the badge update; screen-reader "
+                        + "users hear \"Saved at …\" from a visually hidden "
+                        + "aria-live region — the AnnounceAction writes the "
+                        + "message into the region's textContent."));
+
+        Div liveRegion = new Div();
+        liveRegion.setId("live");
+        liveRegion.addClassName("sr-only");
+        liveRegion.getElement().setAttribute("aria-live", "polite");
+        liveRegion.getElement().setAttribute("aria-atomic", "true");
+
+        Span visibleBadge = new Span("(not saved yet)");
+        visibleBadge.setId("badge");
+        visibleBadge.addClassName("badge");
+
+        Button save = new Button("Save");
+        save.setId("save");
+        save.addClickListener(e -> visibleBadge.setText("Saved at "
+                + java.time.LocalTime.now().withNano(0)));
+
+        new ClickTrigger(save).triggers(
+                new AnnounceAction(liveRegion, "Saved"));
+
+        add(new HorizontalLayout(save, visibleBadge));
+        add(liveRegion);
+    }
+}

--- a/triggers/src/main/java/com/example/uc18/AnnounceAction.java
+++ b/triggers/src/main/java/com/example/uc18/AnnounceAction.java
@@ -1,0 +1,44 @@
+package com.example.uc18;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action} that sets an aria-live region's {@code textContent}
+ * so a screen reader announces the message without moving keyboard focus.
+ * <p>
+ * The message is captured at constructor time as a JS literal. Production
+ * code would accept an {@code Action.Input<String>} as well so dynamic
+ * messages can come from a {@code PropertyInput}.
+ * <p>
+ * The target should be a hidden element with
+ * {@code aria-live="polite"} or {@code "assertive"} — the styling that hides
+ * it visually lives in the view's CSS.
+ */
+public class AnnounceAction extends Action {
+
+    private final Element liveRegion;
+    private final String message;
+
+    public AnnounceAction(Component liveRegion, String message) {
+        this(Objects.requireNonNull(liveRegion).getElement(), message);
+    }
+
+    public AnnounceAction(Element liveRegion, String message) {
+        this.liveRegion = Objects.requireNonNull(liveRegion);
+        this.message = Objects.requireNonNull(message);
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        // Setting textContent to the same value back-to-back doesn't
+        // re-announce; clear-then-set forces the screen reader to read.
+        return JsFunction.of("$0.textContent='';$0.textContent=$1", liveRegion,
+                message);
+    }
+}

--- a/triggers/src/main/java/com/example/uc19/ClientFilterView.java
+++ b/triggers/src/main/java/com/example/uc19/ClientFilterView.java
@@ -1,0 +1,73 @@
+package com.example.uc19;
+
+import java.util.List;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.trigger.internal.DomEventTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC19 — Search field + server-loaded list, filtered client-side.
+ * <p>
+ * The full list comes from the server (loaded once at view construction).
+ * A {@link DomEventTrigger} on the search field's {@code input} event fires
+ * a {@link FilterListAction} that hides non-matching rows entirely in JS.
+ * No server round-trip on each keystroke; the server only sees the data
+ * once.
+ * <p>
+ * Contrast with {@code SetSignalAction} (UC8) — there the keystrokes would
+ * push to a signal and the server would react; here the goal is the
+ * opposite, keep the server out of the loop.
+ */
+@Route(value = "uc19", layout = MainLayout.class)
+@PageTitle("UC19 — Client-side filter")
+@Menu(order = 19, title = "UC19 — Client-side filter")
+@StyleSheet("uc19.css")
+public class ClientFilterView extends VerticalLayout {
+
+    private static final List<String> ITEMS = List.of("Apricot", "Banana",
+            "Blueberry", "Cherry", "Cranberry", "Date", "Elderberry", "Fig",
+            "Grape", "Grapefruit", "Honeydew", "Kiwi", "Lemon", "Lime",
+            "Mango", "Nectarine", "Orange", "Papaya", "Peach", "Pear",
+            "Persimmon", "Pineapple", "Plum", "Pomegranate", "Quince",
+            "Raspberry", "Strawberry", "Tangerine", "Watermelon");
+
+    public ClientFilterView() {
+        addClassName("uc19-view");
+        add(new H1("UC19 — Client-side filter"));
+        add(new Paragraph(
+                "The list below is rendered once from the server. Typing in "
+                        + "the search field fires a custom FilterListAction "
+                        + "that hides non-matching rows purely in JS — no "
+                        + "round-trip on each keystroke."));
+
+        TextField search = new TextField();
+        search.setId("search");
+        search.setPlaceholder("Filter…");
+        search.setClearButtonVisible(true);
+        search.addClassName("search-field");
+
+        Div list = new Div();
+        list.setId("list");
+        list.addClassName("filter-list");
+        for (String item : ITEMS) {
+            Div row = new Div(item);
+            row.addClassName("row");
+            list.add(row);
+        }
+
+        new DomEventTrigger(search, "input")
+                .triggers(new FilterListAction(list));
+
+        add(search, list);
+    }
+}

--- a/triggers/src/main/java/com/example/uc19/FilterListAction.java
+++ b/triggers/src/main/java/com/example/uc19/FilterListAction.java
@@ -1,0 +1,46 @@
+package com.example.uc19;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action} that hides children of a list container whose
+ * {@code textContent} doesn't contain the search value read from
+ * {@code event.target.value}. Filtering is entirely client-side — no server
+ * round-trip per keystroke.
+ * <p>
+ * The action is intentionally specialised: it relies on the surrounding
+ * trigger being a DOM event trigger on the search field, so
+ * {@code event.target} is the field. A more general version would accept an
+ * {@code Action.Input<String>} for the query, but {@code Action.Input#toJs}
+ * is currently package-private — application code can't call it. See
+ * API-GAPS.md.
+ */
+public class FilterListAction extends Action {
+
+    private final Element listContainer;
+
+    public FilterListAction(Component listContainer) {
+        this(Objects.requireNonNull(listContainer).getElement());
+    }
+
+    public FilterListAction(Element listContainer) {
+        this.listContainer = Objects.requireNonNull(listContainer);
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        return JsFunction.of(
+                """
+                        const q = ((event.target && event.target.value) || '').toLowerCase();
+                        for (const row of $0.children) {
+                            row.hidden = q && !row.textContent.toLowerCase().includes(q);
+                        }""",
+                listContainer).withArguments("event");
+    }
+}

--- a/triggers/src/main/java/com/example/uc20/ClassByWidthAction.java
+++ b/triggers/src/main/java/com/example/uc20/ClassByWidthAction.java
@@ -1,0 +1,74 @@
+package com.example.uc20;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.SizeTrigger;
+import com.vaadin.flow.component.trigger.internal.Trigger;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+
+/**
+ * Custom {@link Action} that toggles a CSS class on a target element based
+ * on which width breakpoint the trigger's reported size falls into. Bound to
+ * a {@link SizeTrigger} — the trigger emits a {@code {width, height}} event
+ * each time the host resizes; this action reads {@code event.width} and
+ * applies the breakpoint that includes it.
+ * <p>
+ * Demonstrates the headline "container queries for Flow" pattern from the
+ * Responsive UI Helpers RFC implemented entirely in terms of triggers and
+ * actions — no special API needed.
+ */
+public class ClassByWidthAction extends Action {
+
+    private final Element target;
+    private final int narrowMax;
+    private final int wideMin;
+    private final String narrowClass;
+    private final String mediumClass;
+    private final String wideClass;
+
+    /**
+     * @param target
+     *            the element whose class is toggled
+     * @param narrowMax
+     *            apply {@code narrowClass} when width &lt; this value
+     * @param wideMin
+     *            apply {@code wideClass} when width &ge; this value
+     * @param narrowClass
+     *            class to apply when width &lt; narrowMax
+     * @param mediumClass
+     *            class to apply when narrowMax &le; width &lt; wideMin
+     * @param wideClass
+     *            class to apply when width &ge; wideMin
+     */
+    public ClassByWidthAction(Component target, int narrowMax, int wideMin,
+            String narrowClass, String mediumClass, String wideClass) {
+        this.target = Objects.requireNonNull(target).getElement();
+        if (narrowMax >= wideMin) {
+            throw new IllegalArgumentException(
+                    "narrowMax must be < wideMin");
+        }
+        this.narrowMax = narrowMax;
+        this.wideMin = wideMin;
+        this.narrowClass = Objects.requireNonNull(narrowClass);
+        this.mediumClass = Objects.requireNonNull(mediumClass);
+        this.wideClass = Objects.requireNonNull(wideClass);
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        if (!(trigger instanceof SizeTrigger)) {
+            throw new IllegalArgumentException(
+                    "ClassByWidthAction is only valid in a SizeTrigger handler");
+        }
+        return JsFunction.of("""
+                const w = event.width;
+                const cls = w < $1 ? $3 : w >= $2 ? $5 : $4;
+                $0.classList.remove($3, $4, $5);
+                $0.classList.add(cls);""", target, narrowMax, wideMin,
+                narrowClass, mediumClass, wideClass)
+                .withArguments("event");
+    }
+}

--- a/triggers/src/main/java/com/example/uc20/ResponsiveCardsView.java
+++ b/triggers/src/main/java/com/example/uc20/ResponsiveCardsView.java
@@ -1,0 +1,64 @@
+package com.example.uc20;
+
+import com.example.views.MainLayout;
+
+import com.vaadin.flow.component.card.Card;
+import com.vaadin.flow.component.card.CardVariant;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.SizeTrigger;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+/**
+ * UC20 — Responsive card grid driven by SizeTrigger.
+ * <p>
+ * A grid container holds six {@link Card}s. A {@link SizeTrigger} observes
+ * the container's width via {@code ResizeObserver}; the custom
+ * {@link ClassByWidthAction} reads {@code event.width} at every fire and
+ * applies one of three breakpoint classes ({@code w-narrow},
+ * {@code w-medium}, {@code w-wide}) which CSS turns into a 1, 2, or 3-column
+ * grid. The whole responsive switch happens client-side without a server
+ * round-trip on resize.
+ * <p>
+ * Container-relative, not viewport-relative: the same widget would behave
+ * correctly inside a sidebar that's narrower than the viewport.
+ */
+@Route(value = "uc20", layout = MainLayout.class)
+@PageTitle("UC20 — Responsive cards")
+@Menu(order = 20, title = "UC20 — Responsive cards")
+@StyleSheet("uc20.css")
+public class ResponsiveCardsView extends VerticalLayout {
+
+    public ResponsiveCardsView() {
+        addClassName("uc20-view");
+        add(new H1("UC20 — Responsive card grid"));
+        add(new Paragraph(
+                "Resize the browser. Below ~520px the grid is one column; "
+                        + "between 520 and 900px it's two; above 900px it's "
+                        + "three. SizeTrigger fires on every resize; "
+                        + "ClassByWidthAction picks a breakpoint class; CSS "
+                        + "translates the class into a grid-template-columns "
+                        + "value."));
+
+        Div grid = new Div();
+        grid.setId("grid");
+        grid.addClassName("card-grid");
+        for (int i = 1; i <= 6; i++) {
+            Card card = new Card();
+            card.addThemeVariants(CardVariant.OUTLINED);
+            card.setTitle(new Div("Card " + i));
+            card.add(new Paragraph("Body of card " + i + "."));
+            grid.add(card);
+        }
+
+        new SizeTrigger(grid).triggers(new ClassByWidthAction(grid, 520, 900,
+                "w-narrow", "w-medium", "w-wide"));
+
+        add(grid);
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc11.css
+++ b/triggers/src/main/resources/META-INF/resources/uc11.css
@@ -1,0 +1,19 @@
+.uc11-view {
+    .status-badge {
+        display: inline-block;
+        padding: 0.3rem 0.9rem;
+        border-radius: 999px;
+        font-family: monospace;
+        font-size: 0.95rem;
+        background: color-mix(in srgb, var(--aura-green) 18%, transparent);
+        color: var(--aura-green-text, var(--aura-green));
+        border: 1px solid color-mix(in srgb, var(--aura-green) 35%, transparent);
+        transition: background-color 200ms, color 200ms, border-color 200ms;
+    }
+
+    .status-badge.idle {
+        background: color-mix(in srgb, var(--aura-orange) 18%, transparent);
+        color: var(--aura-orange-text, var(--aura-orange));
+        border-color: color-mix(in srgb, var(--aura-orange) 35%, transparent);
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc12.css
+++ b/triggers/src/main/resources/META-INF/resources/uc12.css
@@ -1,0 +1,24 @@
+.uc12-view {
+    .status-badge {
+        display: inline-block;
+        padding: 0.3rem 0.9rem;
+        border-radius: 999px;
+        font-family: monospace;
+        font-size: 0.95rem;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        transition: background-color 200ms, color 200ms, border-color 200ms;
+    }
+
+    .status-badge.online {
+        background: color-mix(in srgb, var(--aura-green) 18%, transparent);
+        color: var(--aura-green-text, var(--aura-green));
+        border-color: color-mix(in srgb, var(--aura-green) 35%, transparent);
+    }
+
+    .status-badge.offline {
+        background: color-mix(in srgb, var(--aura-red) 18%, transparent);
+        color: var(--aura-red-text, var(--aura-red));
+        border-color: color-mix(in srgb, var(--aura-red) 35%, transparent);
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc13.css
+++ b/triggers/src/main/resources/META-INF/resources/uc13.css
@@ -1,0 +1,13 @@
+.uc13-view {
+    .last-message {
+        display: inline-block;
+        padding: 0.3rem 0.9rem;
+        border-radius: var(--vaadin-radius-m);
+        font-family: monospace;
+        font-size: 0.95rem;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        min-width: 12rem;
+        align-self: center;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc14.css
+++ b/triggers/src/main/resources/META-INF/resources/uc14.css
@@ -1,0 +1,17 @@
+.uc14-view {
+    .delete-button {
+        background: color-mix(in srgb, var(--aura-red) 80%, transparent);
+        color: white;
+        user-select: none;
+    }
+
+    .delete-button:hover {
+        background: color-mix(in srgb, var(--aura-red) 90%, transparent);
+    }
+
+    .status {
+        font-family: monospace;
+        color: var(--vaadin-text-color-secondary);
+        align-self: center;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc15.css
+++ b/triggers/src/main/resources/META-INF/resources/uc15.css
@@ -1,0 +1,15 @@
+.uc15-view {
+    .section {
+        height: 60vh;
+        margin: 8rem 0;
+        padding: 2rem;
+        font-size: 2rem;
+        font-weight: 600;
+        background: var(--vaadin-background-container);
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-l);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc16.css
+++ b/triggers/src/main/resources/META-INF/resources/uc16.css
@@ -1,0 +1,10 @@
+.uc16-view {
+    .highlight-target {
+        padding: 1.5rem 2rem;
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        width: fit-content;
+        font-size: 1.1rem;
+        font-weight: 600;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc17.css
+++ b/triggers/src/main/resources/META-INF/resources/uc17.css
@@ -1,0 +1,19 @@
+.uc17-view {
+    .panel {
+        height: 240px;
+        background: var(--vaadin-background-container);
+        border: 1px dashed var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--vaadin-text-color-secondary);
+        font-style: italic;
+        user-select: none;
+    }
+
+    .coords {
+        font-family: monospace;
+        color: var(--vaadin-text-color-secondary);
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc18.css
+++ b/triggers/src/main/resources/META-INF/resources/uc18.css
@@ -1,0 +1,21 @@
+.uc18-view {
+    /* Visually hidden but reachable by screen readers — the canonical
+       sr-only utility. */
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    .badge {
+        font-family: monospace;
+        color: var(--vaadin-text-color-secondary);
+        align-self: center;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc19.css
+++ b/triggers/src/main/resources/META-INF/resources/uc19.css
@@ -1,0 +1,24 @@
+.uc19-view {
+    .search-field {
+        width: 18rem;
+    }
+
+    .filter-list {
+        max-width: 22rem;
+        margin-top: 0.75rem;
+        border: 1px solid var(--vaadin-border-color);
+        border-radius: var(--vaadin-radius-m);
+        background: var(--vaadin-background-container);
+        max-height: 320px;
+        overflow-y: auto;
+    }
+
+    .filter-list .row {
+        padding: 0.4rem 0.9rem;
+        border-bottom: 1px solid var(--vaadin-border-color);
+    }
+
+    .filter-list .row:last-child {
+        border-bottom: none;
+    }
+}

--- a/triggers/src/main/resources/META-INF/resources/uc20.css
+++ b/triggers/src/main/resources/META-INF/resources/uc20.css
@@ -1,0 +1,22 @@
+.uc20-view {
+    .card-grid {
+        display: grid;
+        gap: 1rem;
+        margin-top: 1rem;
+        /* Default to one column until the trigger applies a breakpoint
+           class — covers the first frame before ResizeObserver fires. */
+        grid-template-columns: 1fr;
+    }
+
+    .card-grid.w-narrow {
+        grid-template-columns: 1fr;
+    }
+
+    .card-grid.w-medium {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .card-grid.w-wide {
+        grid-template-columns: 1fr 1fr 1fr;
+    }
+}

--- a/triggers/src/test/java/com/example/uc11/IdleWarningViewTest.java
+++ b/triggers/src/test/java/com/example/uc11/IdleWarningViewTest.java
@@ -1,0 +1,29 @@
+package com.example.uc11;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = IdleWarningView.class)
+class IdleWarningViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithStatusBadge() {
+        navigate(IdleWarningView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC11 — Idle warning".equals(h.getText())));
+        assertEquals("active", findInView(Span.class).id("status").getText());
+        assertNotNull(findInView(Button.class).id("reset"));
+    }
+}

--- a/triggers/src/test/java/com/example/uc12/NetworkStatusViewTest.java
+++ b/triggers/src/test/java/com/example/uc12/NetworkStatusViewTest.java
@@ -1,0 +1,26 @@
+package com.example.uc12;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = NetworkStatusView.class)
+class NetworkStatusViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithStatusBadge() {
+        navigate(NetworkStatusView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC12 — Network status".equals(h.getText())));
+        assertNotNull(findInView(Span.class).id("status"));
+    }
+}

--- a/triggers/src/test/java/com/example/uc13/CrossTabBroadcastViewTest.java
+++ b/triggers/src/test/java/com/example/uc13/CrossTabBroadcastViewTest.java
@@ -1,0 +1,30 @@
+package com.example.uc13;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = CrossTabBroadcastView.class)
+class CrossTabBroadcastViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithSendButtonAndBadge() {
+        navigate(CrossTabBroadcastView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC13 — Cross-tab broadcast"
+                        .equals(h.getText())));
+        assertNotNull(findInView(Button.class).id("send"));
+        assertEquals("(none yet)", findInView(Span.class).id("last").getText());
+    }
+}

--- a/triggers/src/test/java/com/example/uc14/LongPressDeleteViewTest.java
+++ b/triggers/src/test/java/com/example/uc14/LongPressDeleteViewTest.java
@@ -1,0 +1,31 @@
+package com.example.uc14;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = LongPressDeleteView.class)
+class LongPressDeleteViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithDeleteButtonAndStatus() {
+        navigate(LongPressDeleteView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC14 — Long-press to delete"
+                        .equals(h.getText())));
+        assertNotNull(findInView(Button.class).id("delete"));
+        assertEquals("0 rows deleted",
+                findInView(Span.class).id("status").getText());
+    }
+}

--- a/triggers/src/test/java/com/example/uc15/ScrollIntoViewViewTest.java
+++ b/triggers/src/test/java/com/example/uc15/ScrollIntoViewViewTest.java
@@ -1,0 +1,32 @@
+package com.example.uc15;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = ScrollIntoViewView.class)
+class ScrollIntoViewViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithJumpButtonsAndSections() {
+        navigate(ScrollIntoViewView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC15 — Scroll into view".equals(h.getText())));
+        assertNotNull(findInView(Button.class).id("to-a"));
+        assertNotNull(findInView(Button.class).id("to-b"));
+        assertNotNull(findInView(Button.class).id("to-c"));
+        assertNotNull(findInView(Div.class).id("section-a"));
+        assertNotNull(findInView(Div.class).id("section-b"));
+        assertNotNull(findInView(Div.class).id("section-c"));
+    }
+}

--- a/triggers/src/test/java/com/example/uc16/HighlightViewTest.java
+++ b/triggers/src/test/java/com/example/uc16/HighlightViewTest.java
@@ -1,0 +1,31 @@
+package com.example.uc16;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = HighlightView.class)
+class HighlightViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithTargetAndButtons() {
+        navigate(HighlightView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC16 — Parameterised highlight"
+                        .equals(h.getText())));
+        assertNotNull(findInView(Div.class).id("target"));
+        assertNotNull(findInView(Button.class).id("gold"));
+        assertNotNull(findInView(Button.class).id("red"));
+        assertNotNull(findInView(Button.class).id("cyan"));
+    }
+}

--- a/triggers/src/test/java/com/example/uc17/RightClickCoordsViewTest.java
+++ b/triggers/src/test/java/com/example/uc17/RightClickCoordsViewTest.java
@@ -1,0 +1,31 @@
+package com.example.uc17;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = RightClickCoordsView.class)
+class RightClickCoordsViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithPanelAndCoords() {
+        navigate(RightClickCoordsView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC17 — Right-click coordinates"
+                        .equals(h.getText())));
+        assertNotNull(findInView(Div.class).id("panel"));
+        assertEquals("(no right-click yet)",
+                findInView(Span.class).id("last").getText());
+    }
+}

--- a/triggers/src/test/java/com/example/uc18/AccessibleSaveViewTest.java
+++ b/triggers/src/test/java/com/example/uc18/AccessibleSaveViewTest.java
@@ -1,0 +1,41 @@
+package com.example.uc18;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = AccessibleSaveView.class)
+class AccessibleSaveViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithLiveRegionAndSaveButton() {
+        navigate(AccessibleSaveView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC18 — Accessibility announce"
+                        .equals(h.getText())));
+        Div live = findInView(Div.class).id("live");
+        assertNotNull(live);
+        assertEquals("polite", live.getElement().getAttribute("aria-live"));
+        assertNotNull(findInView(Button.class).id("save"));
+    }
+
+    @Test
+    void clickUpdatesVisibleBadgeServerSide() {
+        navigate(AccessibleSaveView.class);
+        test(findInView(Button.class).id("save")).click();
+        assertTrue(findInView(Span.class).id("badge").getText()
+                .startsWith("Saved at "));
+    }
+}

--- a/triggers/src/test/java/com/example/uc19/ClientFilterViewTest.java
+++ b/triggers/src/test/java/com/example/uc19/ClientFilterViewTest.java
@@ -1,0 +1,32 @@
+package com.example.uc19;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.textfield.TextField;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = ClientFilterView.class)
+class ClientFilterViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithSearchAndFullList() {
+        navigate(ClientFilterView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC19 — Client-side filter"
+                        .equals(h.getText())));
+        assertNotNull(findInView(TextField.class).id("search"));
+        Div list = findInView(Div.class).id("list");
+        assertNotNull(list);
+        assertTrue(list.getChildren().count() > 20,
+                "server-rendered list should hold all items");
+    }
+}

--- a/triggers/src/test/java/com/example/uc20/ResponsiveCardsViewTest.java
+++ b/triggers/src/test/java/com/example/uc20/ResponsiveCardsViewTest.java
@@ -1,0 +1,30 @@
+package com.example.uc20;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vaadin.browserless.SpringBrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.card.Card;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ViewPackages(classes = ResponsiveCardsView.class)
+class ResponsiveCardsViewTest extends SpringBrowserlessTest {
+
+    @Test
+    void viewRendersWithGridAndSixCards() {
+        navigate(ResponsiveCardsView.class);
+
+        assertTrue(findInView(H1.class).all().stream()
+                .anyMatch(h -> "UC20 — Responsive card grid"
+                        .equals(h.getText())));
+        assertNotNull(findInView(Div.class).id("grid"));
+        assertEquals(6, findInView(Card.class).all().size());
+    }
+}


### PR DESCRIPTION
Ten new use cases focused on the trigger/action SPI rather than gesture-gated browser APIs (clipboard/fullscreen/etc are covered by sibling modules).

Custom Triggers:
- UC11 IdleTrigger — fires after N seconds of no activity, again on resume; wraps window-level listeners + setTimeout, exposes event.detail.idle as Action.Input<Boolean>.
- UC12 NetworkStatusTrigger — fires on window's online/offline events plus once on install; paired with a client-side ApplyNetworkStatusAction reading navigator.onLine (no server callback — server is unreachable when offline).
- UC13 BroadcastChannelTrigger — fires on cross-tab messages from a named BroadcastChannel; payload flows into a ValueSignal via SetSignalAction.
- UC14 LongPressTrigger — fires after pointerdown is held for N ms, cancels on pointerup/cancel/leave, suppresses the synthetic click.
- UC20 SizeTrigger responsive grid — built-in SizeTrigger paired with a custom ClassByWidthAction that applies w-narrow/w-medium/w-wide based on the reported width; CSS turns those into a 1/2/3-column grid of Cards. The container-queries-for-Flow pattern from the Responsive UI Helpers RFC, implemented in pure trigger API.

Custom Actions:
- UC15 ScrollIntoViewAction — minimal custom Action; captures the target, calls scrollIntoView on click.
- UC16 HighlightAction — parameterised colour + duration captured as JS arguments; three buttons configure the same target differently.
- UC18 AnnounceAction — writes into an aria-live region for screen readers without moving focus.

Custom Inputs:
- UC17 RightClickCoords — custom PointInput returns {x, y} from a MouseEventTrigger("contextmenu"); Jackson decodes into a Point record on the server via CallbackAction<Point>.

Composition:
- UC19 Client-side filter list — server renders the full list once; a DomEventTrigger("input") + custom FilterListAction hides non-matching rows entirely in JS.

API-GAPS.md grows three entries surfaced by this work:
- Action.Input#toJs is package-private, so custom Actions outside the internal package can't consume Inputs.
- HandlerInput is not public, forcing custom Triggers to declare anonymous Action.Input subclasses instead of reusing the canonical implementation.
- (Previously logged) PropertyInput doesn't accept raw Element.
