### PR TITLE
triggers: ShortcutTrigger — listen on window in capture phase

### DIFF
--- a/triggers/src/main/java/com/example/ShortcutTrigger.java
+++ b/triggers/src/main/java/com/example/ShortcutTrigger.java
@@ -21,14 +21,22 @@ import com.vaadin.flow.shared.Registration;
  * instead.
  *
  * <p>
- * Listens for {@code keydown} on the host, filters by an exact modifier match
- * (required modifiers must be pressed, all others must NOT be pressed — so
- * {@code Ctrl+S} doesn't also fire on {@code Ctrl+Shift+S}, leaving that combo
- * free to bind separately), matches the key against both {@code event.key} and
- * {@code event.code} so a single binding handles {@link Key#KEY_S} regardless
- * of which representation the browser sends, and calls {@code preventDefault()}
- * and {@code stopPropagation()} so the browser's default action and any
- * ancestor handler do not double-fire.
+ * Listens for {@code keydown} on {@code window} in capture phase — that's
+ * the only reliable way to beat the browser's built-in shortcut handling
+ * (e.g. {@code Ctrl+S} opens the Save Page dialog before any element-scoped
+ * listener can see the event). The listener is installed when the host
+ * element attaches and removed when it detaches, so the shortcut is "active
+ * while the view is mounted" — not "active only when focus is in the host's
+ * subtree".
+ * <p>
+ * Filters by an exact modifier match (required modifiers must be pressed,
+ * all others must NOT be pressed — so {@code Ctrl+S} doesn't also fire on
+ * {@code Ctrl+Shift+S}, leaving that combo free to bind separately), matches
+ * the key against both {@code event.key} and {@code event.code} so a single
+ * binding handles {@link Key#KEY_S} regardless of which representation the
+ * browser sends, and calls {@code preventDefault()} and
+ * {@code stopPropagation()} so the browser's default action and any other
+ * handler do not double-fire.
  *
  * <p>
  * Example:
@@ -110,8 +118,12 @@ public class ShortcutTrigger extends Trigger {
                 "if(!allowed.includes(e.key)&&!allowed.includes(e.code))return;");
         js.append("e.preventDefault();e.stopPropagation();$0(e);");
         js.append("};");
-        js.append("this.addEventListener('keydown',listener);");
-        js.append("return ()=>this.removeEventListener('keydown',listener);");
+        // Window + capture: beats the browser's built-in shortcut handler
+        // (e.g. Ctrl+S Save Page) and any descendant handler that might
+        // stopPropagation before the event reaches the host's bubble phase.
+        js.append("window.addEventListener('keydown',listener,true);");
+        js.append(
+                "return ()=>window.removeEventListener('keydown',listener,true);");
         return getHost().addJsInitializer(js.toString(), action);
     }
 }


### PR DESCRIPTION
Listening on the host element in bubble phase loses races against the
browser's built-in shortcut handler. Ctrl+S would still pop the Save
Page dialog because the keydown reached the host's bubble after the
browser had already committed to its default action; preventDefault
arrived too late.

Switching the install JS to attach the keydown listener on window in
capture phase fixes this — capture runs from window down to the focused
element before bubble, so our listener sees and preventDefault's the
event before anything else processes it. Same fix every shortcut
library converges on.

The contract widens slightly: the shortcut is now "active while the
host is mounted" instead of "active only when focus is in the host's
subtree". For save/find/quick-action shortcuts that's the expected
behaviour; for narrowly-scoped shortcuts apps can still add their own
filter inside the action. UC7's Enter shortcut is unaffected — the
Enter check still only matches Enter keystrokes regardless of focus.
