### PR TITLE
triggers: UC20 — track view width, pin grid to full container width

### DIFF
--- a/triggers/src/main/java/com/example/uc20/ResponsiveCardsView.java
+++ b/triggers/src/main/java/com/example/uc20/ResponsiveCardsView.java
@@ -56,7 +56,12 @@ public class ResponsiveCardsView extends VerticalLayout {
             grid.add(card);
         }
 
-        new SizeTrigger(grid).triggers(new ClassByWidthAction(grid, 520, 900,
+        // Track the view's width — the column the view is rendered in —
+        // and apply the breakpoint class to the grid inside. Tracking the
+        // grid itself would observe its post-layout width, which depends
+        // on the breakpoint class we're about to set; tracking the view
+        // observes the "space we have to work with".
+        new SizeTrigger(this).triggers(new ClassByWidthAction(grid, 520, 900,
                 "w-narrow", "w-medium", "w-wide"));
 
         add(grid);

--- a/triggers/src/main/resources/META-INF/resources/uc20.css
+++ b/triggers/src/main/resources/META-INF/resources/uc20.css
@@ -3,6 +3,10 @@
         display: grid;
         gap: 1rem;
         margin-top: 1rem;
+        /* Stretch to the parent flex container's width — without this the
+           grid item collapses to its content's intrinsic width (~126px)
+           because flex items default to min-width: auto. */
+        width: 100%;
         /* Default to one column until the trigger applies a breakpoint
            class — covers the first frame before ResizeObserver fires. */
         grid-template-columns: 1fr;


### PR DESCRIPTION
UC20's SizeTrigger was tracking the grid div. The grid is a flex item inside the view's VerticalLayout; without an explicit width its min-width: auto collapses to the cards' intrinsic width (~126px), so the ResizeObserver kept reporting a narrow width and the breakpoint class stayed at w-narrow regardless of the real viewport size.

Two changes:
- SizeTrigger now tracks `this` (the view) instead of the grid. The view's width is the column we actually have to work with — observing the grid's post-layout width would be a chicken-and-egg with the class we're trying to set.
- CSS pins the grid to width: 100% so it stretches to fill its parent regardless of flex-item sizing quirks, and the three-column class actually has the room it claims.
