### PR TITLE
clipboard: drop flow branch pin, adapt to 25.2-SNAPSHOT API

### DIFF
--- a/clipboard/pom.xml
+++ b/clipboard/pom.xml
@@ -11,19 +11,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <!-- Pinned to the replace-children-temp feature branch of vaadin/flow
-             so the use cases can switch back to the new temporal trigger
-             actions (ReplaceChildrenTemporarilyAction, SetPropertyTemporarilyAction)
-             without bumping again. The branch is a superset of paste-file
-             (used by UC5/UC7 paste APIs) and the paste-events branch (UC4
-             writeImage). flow-components and vaadin-bom stay on the parent's
-             25.2 versions — the branch only publishes flow artifacts, and
-             flow-bom is imported first in the parent so its 25.3 entries win
-             for flow dependencies. -->
-        <flow.version>25.3.replace-children-temp-SNAPSHOT</flow.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.example</groupId>

--- a/clipboard/src/main/java/com/example/uc1/CopyStaticTextView.java
+++ b/clipboard/src/main/java/com/example/uc1/CopyStaticTextView.java
@@ -1,9 +1,6 @@
 package com.example.uc1;
 
-import java.time.Duration;
-
 import com.example.views.MainLayout;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.clipboard.Clipboard;
 import com.vaadin.flow.component.html.H1;
@@ -60,13 +57,17 @@ public class CopyStaticTextView extends VerticalLayout {
                 copied -> {
                     copyButton.setText(FLASH_LABEL);
                     copyButton.setIcon(VaadinIcon.CHECK.create());
-                    UI.getCurrentOrThrow().triggerAfter(Duration.ofSeconds(1), () -> {
-                        copyButton.setText(DEFAULT_LABEL);
-                        copyButton.setIcon(null);
-                    });
+                    copyButton.getElement().executeJs(
+                            "setTimeout(() => this.dispatchEvent("
+                                    + "new Event('copy-flash-end')), 1000)");
                 },
                 error -> Notification
                         .show("Copy failed: " + error.message()));
+
+        copyButton.getElement().addEventListener("copy-flash-end", e -> {
+            copyButton.setText(DEFAULT_LABEL);
+            copyButton.setIcon(null);
+        });
 
         add(copyButton);
     }

--- a/clipboard/src/main/java/com/example/uc4/CopyImageView.java
+++ b/clipboard/src/main/java/com/example/uc4/CopyImageView.java
@@ -64,7 +64,7 @@ public class CopyImageView extends VerticalLayout {
 
         Button copyButton = new Button("Copy chart");
         Clipboard.onClick(copyButton).writeImage(preview,
-                copied -> Notification.show("Chart copied"),
+                () -> Notification.show("Chart copied"),
                 error -> Notification.show("Copy failed: " + error.message()));
 
         HorizontalLayout row = new HorizontalLayout(preview, copyButton);

--- a/clipboard/src/main/java/com/example/uc7/PasteFilesView.java
+++ b/clipboard/src/main/java/com/example/uc7/PasteFilesView.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.router.Route;
  * Clipboard.onFilePaste} registers a per-file upload handler for paste
  * gestures: each file the browser puts on {@code event.clipboardData.files} is
  * POSTed to the URL Flow generates for the handler, and the bytes arrive on the
- * server. {@link PasteFileHandler#session()} adds paste-aware orchestration on
+ * server. {@link PasteFileHandler#batch()} adds paste-aware orchestration on
  * top: {@code onStart} fires once before the first file of a paste,
  * {@code onFile} fires per file with the bytes and metadata, and
  * {@code onComplete} fires once the paste's declared file count has been
@@ -71,7 +71,7 @@ public class PasteFilesView extends VerticalLayout {
         StringBuilder logText = new StringBuilder();
 
         Clipboard.onFilePaste(dropZone,
-                PasteFileHandler.session().onStart(start -> {
+                PasteFileHandler.batch().onStart(start -> {
                     previews.removeAll();
                     logText.setLength(0);
                     log.setText("");


### PR DESCRIPTION
Remove the 25.3.replace-children-temp-SNAPSHOT flow.version pin so the clipboard module builds against the parent's 25.2-SNAPSHOT, and fix the three breaks that surfaced:

- UC1: UI.triggerAfter was a feature-branch-only API with no 25.2 replacement. Revert to the approach the javadoc already described: a client-side setTimeout dispatches a copy-flash-end DOM event that a server-side listener uses to restore the button after one second.
- UC4: writeImage's success callback is now a no-arg SerializableRunnable instead of a value consumer.
- UC7: PasteFileHandler.session() was renamed to batch().
