### PR TITLE
fullscreen: Un-nest CSS for elements moved by component fullscreen

### DIFF
--- a/fullscreen/src/main/java/com/example/uc2/SlideshowView.java
+++ b/fullscreen/src/main/java/com/example/uc2/SlideshowView.java
@@ -34,7 +34,7 @@ import com.vaadin.flow.signals.Signal;
  * <p>
  * Page-level fullscreen — where the whole document is fullscreened, app
  * chrome included — is demonstrated separately in
- * {@link com.example.uc5.KioskExitDetectionView UC5}.
+ * {@link com.example.uc7.AppFullscreenView UC7}.
  */
 @Route(value = "uc2", layout = MainLayout.class)
 @Menu(order = 2, title = "UC2 — Slideshow")

--- a/fullscreen/src/main/resources/META-INF/resources/uc1.css
+++ b/fullscreen/src/main/resources/META-INF/resources/uc1.css
@@ -1,3 +1,34 @@
+/* Component#requestFullscreen() moves the stage out of the view into the
+   UI's fullscreen wrapper, so rules for the stage (and its contents) must
+   not be scoped under .uc1-view — they would stop matching while fullscreen.
+   Only elements that never leave the view are nested below. */
+.lightbox-stage {
+    background: black;
+    width: 100%;
+    height: 100%;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 1.5rem;
+}
+
+.lightbox-stage.active {
+    display: flex;
+    /* 100vh, not 100% — while fullscreen the stage's parent is the UI
+       wrapper, which has no defined height. */
+    height: 100vh;
+}
+
+.lightbox-stage > .lightbox-image {
+    width: 100%;
+    height: 100%;
+    background: var(--lightbox-image-bg);
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
 .uc1-view {
     .lightbox-grid {
         display: grid;
@@ -25,29 +56,5 @@
 
     .lightbox-thumb:hover {
         transform: scale(1.02);
-    }
-
-    .lightbox-stage {
-        background: black;
-        width: 100%;
-        height: 100%;
-        display: none;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-size: 1.5rem;
-    }
-
-    .lightbox-stage.active {
-        display: flex;
-    }
-
-    .lightbox-stage > .lightbox-image {
-        width: 100%;
-        height: 100%;
-        background: var(--lightbox-image-bg);
-        background-size: contain;
-        background-position: center;
-        background-repeat: no-repeat;
     }
 }

--- a/fullscreen/src/main/resources/META-INF/resources/uc2.css
+++ b/fullscreen/src/main/resources/META-INF/resources/uc2.css
@@ -1,33 +1,39 @@
+/* Component#requestFullscreen() moves the stage out of the view into the
+   UI's fullscreen wrapper, so rules for the stage must not be scoped under
+   .uc2-view — they would stop matching while presenting. Only elements that
+   never leave the view are nested below. */
+.slideshow {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: linear-gradient(135deg, #1d2030 0%, #2a3052 100%);
+    border-radius: var(--vaadin-radius-l);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.25rem;
+    /* Unitless so the line-height scales with font-size; the body's
+       length-valued line-height would otherwise stay ~20px and the
+       wrapped slide text would overlap at 2.25rem / 4rem. */
+    line-height: 1.2;
+    text-align: center;
+    padding: 2rem;
+    box-sizing: border-box;
+    max-width: 960px;
+}
+
+.slideshow.live {
+    aspect-ratio: auto;
+    width: 100%;
+    /* 100vh, not 100% — while fullscreen the stage's parent is the UI
+       wrapper, which has no defined height. */
+    height: 100vh;
+    max-width: none;
+    border-radius: 0;
+    font-size: 4rem;
+}
+
 .uc2-view {
-    .slideshow {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        background: linear-gradient(135deg, #1d2030 0%, #2a3052 100%);
-        border-radius: var(--vaadin-radius-l);
-        color: white;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 2.25rem;
-        /* Unitless so the line-height scales with font-size; the body's
-           length-valued line-height would otherwise stay ~20px and the
-           wrapped slide text would overlap at 2.25rem / 4rem. */
-        line-height: 1.2;
-        text-align: center;
-        padding: 2rem;
-        box-sizing: border-box;
-        max-width: 960px;
-    }
-
-    .slideshow.live {
-        aspect-ratio: auto;
-        width: 100%;
-        height: 100%;
-        max-width: none;
-        border-radius: 0;
-        font-size: 4rem;
-    }
-
     .slideshow-footer {
         text-align: center;
         margin-top: 1rem;

--- a/fullscreen/src/main/resources/META-INF/resources/uc3.css
+++ b/fullscreen/src/main/resources/META-INF/resources/uc3.css
@@ -1,50 +1,57 @@
+/* Component#requestFullscreen() moves the editor pane out of the view into
+   the UI's fullscreen wrapper, so rules for the pane and everything inside
+   it (editor area, footer, stats) must not be scoped under .uc3-view — they
+   would stop matching while fullscreen. Only elements that never leave the
+   view are nested below. */
+.editor-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 720px;
+    transition: max-width 200ms;
+}
+
+.editor-pane.fullscreen {
+    max-width: none;
+    width: 100%;
+    /* 100vh, not 100% — while fullscreen the pane's parent is the UI
+       wrapper, which has no defined height. */
+    height: 100vh;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    background: var(--vaadin-background-base);
+}
+
+.editor-area {
+    width: 100%;
+    min-height: 220px;
+    transition: min-height 200ms;
+}
+
+.editor-area.fullscreen {
+    flex: 1;
+    min-height: 0;
+    font-size: 1.15rem;
+}
+
+.editor-pane-footer {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.editor-stats {
+    margin-left: auto;
+    color: var(--vaadin-text-color-secondary);
+    font-size: 0.85rem;
+}
+
 .uc3-view {
-    .editor-pane {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        width: 100%;
-        max-width: 720px;
-        transition: max-width 200ms;
-    }
-
-    .editor-pane.fullscreen {
-        max-width: none;
-        width: 100%;
-        height: 100%;
-        padding: 1.5rem;
-        box-sizing: border-box;
-        background: var(--vaadin-background-base);
-    }
-
-    .editor-area {
-        width: 100%;
-        min-height: 220px;
-        transition: min-height 200ms;
-    }
-
-    .editor-area.fullscreen {
-        flex: 1;
-        min-height: 0;
-        font-size: 1.15rem;
-    }
-
     .editor-toolbar {
         display: flex;
         gap: 0.5rem;
         align-items: center;
         margin-bottom: 0.5rem;
-    }
-
-    .editor-pane-footer {
-        display: flex;
-        gap: 0.5rem;
-        align-items: center;
-    }
-
-    .editor-stats {
-        margin-left: auto;
-        color: var(--vaadin-text-color-secondary);
-        font-size: 0.85rem;
     }
 }

--- a/fullscreen/src/main/resources/META-INF/resources/uc5.css
+++ b/fullscreen/src/main/resources/META-INF/resources/uc5.css
@@ -1,114 +1,125 @@
+/* Component#requestFullscreen() moves the kiosk stage out of the view into
+   the UI's fullscreen wrapper, so rules for the stage and everything inside
+   it must not be scoped under .uc5-view — they would stop matching while the
+   kiosk is live. Only elements that never leave the view (the activity log)
+   are nested at the bottom. .unexpected-warning is used both in the view's
+   controls row and inside the staff panel, so it stays top-level too. */
+.kiosk-stage {
+    width: 100%;
+    min-height: 360px;
+    border-radius: var(--vaadin-radius-m);
+    background: linear-gradient(135deg, #0e1a2b 0%, #1a3358 100%);
+    color: white;
+    max-width: 960px;
+    overflow: hidden;
+    transition: background 300ms;
+}
+
+.kiosk-stage.live {
+    width: 100%;
+    height: 100vh;
+    background: linear-gradient(135deg, #02141a 0%, #053b48 100%);
+    max-width: none;
+    border-radius: 0;
+}
+
+.kiosk-shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 360px;
+    box-sizing: border-box;
+}
+
+.kiosk-stage.live .kiosk-shell {
+    min-height: 100vh;
+}
+
+.kiosk-header {
+    padding: 0.75rem 1.25rem;
+    background: rgba(0, 0, 0, 0.25);
+    box-sizing: border-box;
+}
+
+.kiosk-title {
+    font-weight: 600;
+    font-size: 1.1rem;
+    letter-spacing: 0.02em;
+}
+
+.kiosk-staff-btn {
+    color: white;
+    background: transparent;
+}
+
+.kiosk-content {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    box-sizing: border-box;
+}
+
+.kiosk-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+    text-align: center;
+    color: white;
+    width: 100%;
+    max-width: 480px;
+}
+
+/* Headings inherit a dark color from the platform theme; force them to be
+   readable on the kiosk's dark gradient. */
+.kiosk-panel h2,
+.kiosk-panel h3,
+.kiosk-panel p {
+    margin: 0;
+    color: white;
+}
+
+.kiosk-panel h2 {
+    font-size: 1.75rem;
+}
+
+.kiosk-stage.live .kiosk-panel h2 {
+    font-size: 2.5rem;
+}
+
+/* Lighten Vaadin input field labels and helpers so they stay legible
+   against the dark kiosk surface. The field's own input area keeps its
+   light background and dark value text — only the surrounding labels need
+   to flip. */
+.kiosk-panel vaadin-text-field,
+.kiosk-panel vaadin-password-field,
+.kiosk-panel vaadin-select {
+    --vaadin-input-field-label-color: rgba(255, 255, 255, 0.92);
+    --vaadin-input-field-helper-color: rgba(255, 255, 255, 0.7);
+    --vaadin-input-field-required-indicator-color:
+        rgba(255, 255, 255, 0.85);
+}
+
+.kiosk-staff-panel {
+    background: rgba(0, 0, 0, 0.35);
+    padding: 1.5rem;
+    border-radius: var(--vaadin-radius-m);
+}
+
+.kiosk-staff-hint {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.85rem;
+    font-style: italic;
+}
+
+.unexpected-warning {
+    color: var(--aura-red-text);
+    font-weight: 600;
+}
+
 .uc5-view {
-    .kiosk-stage {
-        width: 100%;
-        min-height: 360px;
-        border-radius: var(--vaadin-radius-m);
-        background: linear-gradient(135deg, #0e1a2b 0%, #1a3358 100%);
-        color: white;
-        max-width: 960px;
-        overflow: hidden;
-        transition: background 300ms;
-    }
-
-    .kiosk-stage.live {
-        width: 100%;
-        height: 100vh;
-        background: linear-gradient(135deg, #02141a 0%, #053b48 100%);
-        max-width: none;
-        border-radius: 0;
-    }
-
-    .kiosk-shell {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-        min-height: 360px;
-        box-sizing: border-box;
-    }
-
-    .kiosk-stage.live .kiosk-shell {
-        min-height: 100vh;
-    }
-
-    .kiosk-header {
-        padding: 0.75rem 1.25rem;
-        background: rgba(0, 0, 0, 0.25);
-        box-sizing: border-box;
-    }
-
-    .kiosk-title {
-        font-weight: 600;
-        font-size: 1.1rem;
-        letter-spacing: 0.02em;
-    }
-
-    .kiosk-staff-btn {
-        color: white;
-        background: transparent;
-    }
-
-    .kiosk-content {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1.5rem;
-        box-sizing: border-box;
-    }
-
-    .kiosk-panel {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        align-items: center;
-        text-align: center;
-        color: white;
-        width: 100%;
-        max-width: 480px;
-    }
-
-    /* Headings inherit a dark color from the platform theme; force them to be
-       readable on the kiosk's dark gradient. */
-    .kiosk-panel h2,
-    .kiosk-panel h3,
-    .kiosk-panel p {
-        margin: 0;
-        color: white;
-    }
-
-    .kiosk-panel h2 {
-        font-size: 1.75rem;
-    }
-
-    .kiosk-stage.live .kiosk-panel h2 {
-        font-size: 2.5rem;
-    }
-
-    /* Lighten Vaadin input field labels and helpers so they stay legible
-       against the dark kiosk surface. The field's own input area keeps its
-       light background and dark value text — only the surrounding labels need
-       to flip. */
-    .kiosk-panel vaadin-text-field,
-    .kiosk-panel vaadin-password-field,
-    .kiosk-panel vaadin-select {
-        --vaadin-input-field-label-color: rgba(255, 255, 255, 0.92);
-        --vaadin-input-field-helper-color: rgba(255, 255, 255, 0.7);
-        --vaadin-input-field-required-indicator-color:
-            rgba(255, 255, 255, 0.85);
-    }
-
-    .kiosk-staff-panel {
-        background: rgba(0, 0, 0, 0.35);
-        padding: 1.5rem;
-        border-radius: var(--vaadin-radius-m);
-    }
-
-    .kiosk-staff-hint {
-        color: rgba(255, 255, 255, 0.75);
-        font-size: 0.85rem;
-        font-style: italic;
-    }
-
     .kiosk-log {
         font-family: monospace;
         font-size: 0.85rem;
@@ -128,10 +139,5 @@
 
     .kiosk-log > div:last-child {
         border-bottom: none;
-    }
-
-    .unexpected-warning {
-        color: var(--aura-red-text);
-        font-weight: 600;
     }
 }

--- a/fullscreen/src/main/resources/META-INF/resources/uc6.css
+++ b/fullscreen/src/main/resources/META-INF/resources/uc6.css
@@ -1,42 +1,46 @@
+/* Component#requestFullscreen() moves the expanded card out of the view into
+   the UI's fullscreen wrapper, so rules for the card and its contents must
+   not be scoped under .uc6-view — they would stop matching while expanded.
+   Only the grid, which never leaves the view, is nested below. */
+.chart-card {
+    border: 1px solid var(--vaadin-border-color);
+    border-radius: var(--vaadin-radius-m);
+    background: var(--vaadin-background-container);
+    padding: 0.75rem 1rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.chart-card.expanded {
+    width: 100%;
+    height: 100vh;
+    box-sizing: border-box;
+    background: var(--vaadin-background-base);
+}
+
+.chart-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+}
+
+.chart-card-chart {
+    width: 100%;
+    height: 200px;
+}
+
+.chart-card.expanded .chart-card-chart {
+    flex: 1;
+    height: auto;
+}
+
 .uc6-view {
     .chart-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 1rem;
         max-width: 960px;
-    }
-
-    .chart-card {
-        border: 1px solid var(--vaadin-border-color);
-        border-radius: var(--vaadin-radius-m);
-        background: var(--vaadin-background-container);
-        padding: 0.75rem 1rem 1rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-    }
-
-    .chart-card.expanded {
-        width: 100%;
-        height: 100vh;
-        box-sizing: border-box;
-        background: var(--vaadin-background-base);
-    }
-
-    .chart-card-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-weight: 600;
-    }
-
-    .chart-card-chart {
-        width: 100%;
-        height: 200px;
-    }
-
-    .chart-card.expanded .chart-card-chart {
-        flex: 1;
-        height: auto;
     }
 }


### PR DESCRIPTION
Flow 25.2-SNAPSHOT (2026-05-30+) changed Component#requestFullscreen(): instead of calling element.requestFullscreen() in place, the client now moves the target into the UI's fullscreen wrapper, hides the view root and fullscreens document.documentElement (so theming and overlays keep working). The fullscreened element is therefore no longer a descendant of .ucN-view, and every rule scoped under it stopped matching — the slideshow, lightbox, editor pane, kiosk stage and chart cards rendered unstyled while fullscreen.

Move the rules for the fullscreened elements (and their descendants) to top level in uc1/uc2/uc3/uc5/uc6.css; keep only elements that never leave the view scoped under .ucN-view. Also switch fullscreen-state heights from 100% to 100vh — 100% used to resolve against the :fullscreen element itself, but the new parent (the UI wrapper) has no defined height.

While here, fix SlideshowView's javadoc to point at UC7 as the page-level fullscreen demo; UC5 uses component-level fullscreen.
