### PR TITLE
triggers: Listen on window in SequenceTrigger and KeyboardEventTrigger

### DIFF
--- a/triggers/src/main/java/com/example/KeyboardEventTrigger.java
+++ b/triggers/src/main/java/com/example/KeyboardEventTrigger.java
@@ -88,10 +88,12 @@ public class KeyboardEventTrigger extends Trigger {
         }
         js.append("$0(e);");
         js.append("};");
-        js.append("this.addEventListener(").append(quotedEvent)
-                .append(",listener);");
-        js.append("return ()=>this.removeEventListener(").append(quotedEvent)
-                .append(",listener);");
+        // Listen on window in the capture phase: a view with no focusable
+        // children never receives bubbled keydown on the host element.
+        js.append("window.addEventListener(").append(quotedEvent)
+                .append(",listener,true);");
+        js.append("return ()=>window.removeEventListener(").append(quotedEvent)
+                .append(",listener,true);");
         return getHost().addJsInitializer(js.toString(), action);
     }
 

--- a/triggers/src/main/java/com/example/SequenceTrigger.java
+++ b/triggers/src/main/java/com/example/SequenceTrigger.java
@@ -69,8 +69,10 @@ public class SequenceTrigger extends Trigger {
         js.append("if(++i!==seq.length)return;i=0;");
         js.append("$0(e);");
         js.append("};");
-        js.append("this.addEventListener('keydown',listener);");
-        js.append("return ()=>this.removeEventListener('keydown',listener);");
+        // Listen on window in the capture phase: a view with no focusable
+        // children never receives bubbled keydown on the host element.
+        js.append("window.addEventListener('keydown',listener,true);");
+        js.append("return ()=>window.removeEventListener('keydown',listener,true);");
         return getHost().addJsInitializer(js.toString(), action);
     }
 }


### PR DESCRIPTION
Both shims installed their keydown listeners on the host element in the bubble phase. Views built around them (UC22 KeyEventLog, UC23 Konami code) hold no focusable children, so the host never receives the event and the trigger never fires.

Switch to window in the capture phase, mirroring ShortcutTrigger's existing install. The Playwright runs in this session dispatched events on the view element directly, which bypassed the focus path and masked the bug — the user caught it in the real browser.
