### PR TITLE
triggers: Rework UC1, UC2, UC3 to demonstrate trigger-specific value

### DIFF
--- a/triggers/src/main/java/com/example/home/HomeView.java
+++ b/triggers/src/main/java/com/example/home/HomeView.java
@@ -50,14 +50,14 @@ public class HomeView extends BaseHomeView {
 
         Div cards = new Div();
         cards.addClassName("home-cards");
-        cards.add(homeCard("UC1", "Ctrl+S save shortcut",
-                "Custom ShortcutTrigger; preventDefault beats the browser's Save dialog.",
+        cards.add(homeCard("UC1", "Ctrl+S snapshot",
+                "ShortcutTrigger fires WriteToClipboardAction + a badge flip atomically in the user gesture — @Shortcut would have to round-trip.",
                 ShortcutSaveView.class));
-        cards.add(homeCard("UC2", "Submit + disable",
-                "Enter clicks Send via a synthetic ClickAction, then disables it.",
+        cards.add(homeCard("UC2", "Click image, dim siblings",
+                "One ClickTrigger fans three SetPropertyAction calls onto three non-HasEnabled <img> tiles in a single event.",
                 SubmitAndDisableView.class));
-        cards.add(homeCard("UC3", "Live signal",
-                "Counter mutates server-side; SignalInput mirrors on change.",
+        cards.add(homeCard("UC3", "Hidden share link",
+                "SignalInput reads a ValueSignal that's bound to nothing; WriteToClipboardAction copies it inside the gesture.",
                 LiveSignalCounterView.class));
         cards.add(homeCard("UC4", "Double-click copy",
                 "Built-in DoubleClickTrigger — the high-level Clipboard API is click-only.",

--- a/triggers/src/main/java/com/example/uc1/ShortcutSaveView.java
+++ b/triggers/src/main/java/com/example/uc1/ShortcutSaveView.java
@@ -10,58 +10,70 @@ import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.component.trigger.internal.CallbackAction;
+import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.component.trigger.internal.SetPropertyAction;
+import com.vaadin.flow.component.trigger.internal.WriteToClipboardAction;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
- * UC1 — Ctrl+S save shortcut.
+ * UC1 — Ctrl+S writes a snapshot of the notes to the clipboard, fully
+ * client-side.
  * <p>
- * A custom {@link ShortcutTrigger} listens for Ctrl+S (Cmd+S on macOS) on
- * the view's root. Its {@code preventDefault()} suppresses the browser's
- * built-in "Save Page" dialog so the keystroke reaches our handler instead.
- * A {@link CallbackAction} reads the field's current value via
- * {@link PropertyInput} and posts it to the server, which updates the
- * status badge.
+ * One {@link ShortcutTrigger} fires two atomic actions in the original
+ * user-gesture: {@link WriteToClipboardAction} reads the textarea's
+ * current value via {@link PropertyInput} and calls
+ * {@code navigator.clipboard.write}, and a {@link SetPropertyAction}
+ * flips the status badge to "✓ Snapshot in clipboard". Both run before
+ * the gesture's microtask queue drains; nothing round-trips to the
+ * server.
  * <p>
- * Ctrl+C is intentionally NOT used here — the browser's clipboard handler
- * fires before keyboard shortcut listeners can preventDefault, so
- * overriding it from JS is unreliable.
+ * The high-level alternative is Vaadin's {@code @Shortcut}, which can
+ * only invoke a server-side method — and the clipboard API rejects
+ * writes that don't happen inside the original user gesture, so a
+ * follow-up {@code executeJs} from the server doesn't get to write at
+ * all.
  */
 @Route(value = "uc1", layout = MainLayout.class)
-@PageTitle("UC1 — Ctrl+S save")
-@Menu(order = 1, title = "UC1 — Ctrl+S save")
+@PageTitle("UC1 — Ctrl+S snapshot to clipboard")
+@Menu(order = 1, title = "UC1 — Ctrl+S snapshot")
 @StyleSheet("uc1.css")
 public class ShortcutSaveView extends VerticalLayout {
 
     public ShortcutSaveView() {
         addClassName("uc1-view");
-        add(new H1("UC1 — Ctrl+S save"));
+        add(new H1("UC1 — Ctrl+S writes a snapshot to the clipboard"));
         add(new Paragraph(
-                "Edit the message and press Ctrl+S (or Cmd+S). The "
-                        + "ShortcutTrigger suppresses the browser's Save Page "
-                        + "dialog and posts the field's current value to a "
-                        + "server-side callback that updates the status badge."));
+                "Edit the notes and press Ctrl+S (or Cmd+S). One "
+                        + "ShortcutTrigger fires two pure client-side actions "
+                        + "atomically: WriteToClipboardAction copies the "
+                        + "current value, SetPropertyAction flips the badge. "
+                        + "preventDefault swallows the browser's Save Page "
+                        + "dialog. Nothing round-trips — paste anywhere to "
+                        + "confirm."));
 
-        TextField field = new TextField("Message");
-        field.setId("message");
-        field.setValue("Edit me, then press Ctrl+S");
-        field.addClassName("message-field");
+        TextArea notes = new TextArea("Notes");
+        notes.setId("notes");
+        notes.addClassName("notes-field");
+        notes.setValue("Draft notes — Ctrl+S backs them up to the clipboard.");
+        notes.setWidthFull();
+        notes.setMinHeight("9rem");
 
-        Span status = new Span("(not saved yet)");
+        Span status = new Span("(no snapshot yet)");
         status.setId("status");
         status.addClassName("status-badge");
 
-        new ShortcutTrigger(this, Key.KEY_S, KeyModifier.CONTROL)
-                .triggers(new CallbackAction<>(String.class,
-                        value -> status.setText("Saved at "
-                                + java.time.LocalTime.now().withNano(0)
-                                + ": " + value),
-                        new PropertyInput<>(field, "value", String.class)));
+        new ShortcutTrigger(this, Key.KEY_S, KeyModifier.CONTROL).triggers(
+                new WriteToClipboardAction(
+                        new PropertyInput<>(notes, "value", String.class),
+                        null),
+                new SetPropertyAction<>(status, "textContent",
+                        "✓ Snapshot in clipboard"),
+                new SetPropertyAction<>(status, "className",
+                        "status-badge copied"));
 
-        add(field, status);
+        add(notes, status);
     }
 }

--- a/triggers/src/main/java/com/example/uc2/SubmitAndDisableView.java
+++ b/triggers/src/main/java/com/example/uc2/SubmitAndDisableView.java
@@ -1,74 +1,101 @@
 package com.example.uc2;
 
-import com.example.ClickAction;
-import com.example.ShortcutTrigger;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import com.example.views.MainLayout;
 
-import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.SetPropertyAction;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 /**
- * UC2 — Submit on Enter, then disable the submit button.
+ * UC2 — Click an image to dim its siblings atomically.
  * <p>
- * Pressing Enter inside the field fires a {@link ShortcutTrigger} that chains
- * two actions: a {@link ClickAction} that synthesises a click on the submit
- * button (running its server-side handler) and a {@link SetPropertyAction}
- * that disables the button so a stray double-press can't re-submit. The
- * disable runs client-side immediately. The button's click listener also
- * calls {@code setEnabled(false)} server-side so the next render keeps the
- * disabled state.
+ * Three {@link Image} tiles. One {@link ClickTrigger} per tile fires
+ * three {@link SetPropertyAction} calls in sequence on the same gesture
+ * — mark self {@code selected}, set the other two to {@code dimmed} —
+ * so the three DOM mutations land before the next paint with no server
+ * round-trip between them. A "Reset" button fans out three more
+ * actions to clear all classes.
  * <p>
- * Order matters: click first, then disable — browsers block clicks on
- * already-disabled elements.
- * <p>
- * {@code ShortcutTrigger} and {@code ClickAction} are local shims in
- * {@code com.example}; both are gone from the published API.
+ * The framework analogue would attach three server-side click
+ * listeners and call {@code img.getElement().getClassList().add(...)}
+ * for each target; every click costs one round-trip and the
+ * mid-sequence states (one image selected, the others still pristine)
+ * are observable. Triggers ship the whole transition as one atomic
+ * client-side handler. The same applies to any non-{@code HasEnabled}
+ * target — {@link Image} doesn't have a {@code setEnabled}, but
+ * {@link SetPropertyAction} can write any DOM property regardless.
  */
 @Route(value = "uc2", layout = MainLayout.class)
-@PageTitle("UC2 — Submit + disable chain")
-@Menu(order = 2, title = "UC2 — Submit + disable")
+@PageTitle("UC2 — Click an image to dim its siblings")
+@Menu(order = 2, title = "UC2 — Image gallery select")
 @StyleSheet("uc2.css")
 public class SubmitAndDisableView extends VerticalLayout {
 
     public SubmitAndDisableView() {
         addClassName("uc2-view");
-        add(new H1("UC2 — Submit on Enter, then disable"));
+        add(new H1("UC2 — Click an image to dim its siblings"));
         add(new Paragraph(
-                "Type a message and press Enter. A ShortcutTrigger on the "
-                        + "field clicks \"Send\" (running its click handler) and "
-                        + "immediately disables it client-side, so an accidental "
-                        + "second Enter can't re-submit. The click listener also "
-                        + "disables the button server-side."));
+                "Click one tile: the other two fade to grayscale and the "
+                        + "selected one gets a primary border — all three DOM "
+                        + "mutations land in one event, no server round-trip "
+                        + "between them. Image isn't HasEnabled, but "
+                        + "SetPropertyAction writes any property on any "
+                        + "element. Reset clears everything in one trigger."));
 
-        TextField field = new TextField("Message");
-        field.setId("message");
-        field.addClassName("message-field");
+        Image a = tile("a", "ALPHA", "1976d2");
+        Image b = tile("b", "BETA", "d81b60");
+        Image c = tile("c", "GAMMA", "388e3c");
 
-        Span echo = new Span();
-        echo.setId("echo");
-        echo.addClassName("echo");
+        HorizontalLayout gallery = new HorizontalLayout(a, b, c);
+        gallery.addClassName("gallery");
 
-        Button send = new Button("Send");
-        send.setId("send");
-        send.addClickListener(e -> {
-            echo.setText("Sent: " + field.getValue());
-            send.setEnabled(false);
-        });
+        wire(a, b, c);
+        wire(b, a, c);
+        wire(c, a, b);
 
-        new ShortcutTrigger(field, Key.ENTER).triggers(new ClickAction(send),
-                new SetPropertyAction<>(send, "disabled", true));
+        Button reset = new Button("Reset");
+        reset.setId("reset");
+        new ClickTrigger(reset).triggers(
+                new SetPropertyAction<>(a, "className", ""),
+                new SetPropertyAction<>(b, "className", ""),
+                new SetPropertyAction<>(c, "className", ""));
 
-        add(new HorizontalLayout(field, send), echo);
+        add(gallery, reset);
+    }
+
+    private static void wire(Image self, Image other1, Image other2) {
+        new ClickTrigger(self).triggers(
+                new SetPropertyAction<>(self, "className", "selected"),
+                new SetPropertyAction<>(other1, "className", "dimmed"),
+                new SetPropertyAction<>(other2, "className", "dimmed"));
+    }
+
+    private static Image tile(String id, String label, String hexColor) {
+        String svg = "<svg xmlns='http://www.w3.org/2000/svg' "
+                + "viewBox='0 0 200 200'>"
+                + "<rect width='200' height='200' fill='#" + hexColor
+                + "'/>"
+                + "<text x='100' y='115' text-anchor='middle' fill='white' "
+                + "font-size='28' font-family='sans-serif' "
+                + "font-weight='600'>" + label + "</text>"
+                + "</svg>";
+        String dataUri = "data:image/svg+xml;base64,"
+                + Base64.getEncoder().encodeToString(
+                        svg.getBytes(StandardCharsets.UTF_8));
+        Image img = new Image(dataUri, label);
+        img.setId(id);
+        return img;
     }
 }

--- a/triggers/src/main/java/com/example/uc3/LiveSignalCounterView.java
+++ b/triggers/src/main/java/com/example/uc3/LiveSignalCounterView.java
@@ -1,5 +1,7 @@
 package com.example.uc3;
 
+import java.time.LocalTime;
+
 import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.button.Button;
@@ -9,55 +11,78 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.SignalInput;
 import com.vaadin.flow.component.trigger.internal.WriteToClipboardAction;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.signals.local.ValueSignal;
 
 /**
- * UC3 — Copy a value from a live signal that mutates over time.
+ * UC3 — Copy a share link that the UI never renders.
  * <p>
- * A server-side click handler on "Tick" increments the counter signal.
- * {@link SignalInput} mirrors the current value into a property on the
- * host element via an effect, so every signal change is reflected on the
- * next click without any round-trip on the gesture itself.
+ * The server keeps the full URL in a {@link ValueSignal} that is bound
+ * to <em>nothing</em>: no Span, no hidden TextField, no DOM element.
+ * Typing in the slug field updates the signal server-side via a normal
+ * value-change listener. On click, {@link WriteToClipboardAction} reads
+ * the signal at fire-time via {@link SignalInput} and writes
+ * {@code text/plain} inside the original user gesture — pure
+ * client-side, the value never crosses the DOM.
+ * <p>
+ * The framework analogue would have to either render the URL into a
+ * hidden field just to read it back, or round-trip from the click to a
+ * server-side method that calls {@code executeJs} for the clipboard —
+ * and that follow-up no longer counts as a user gesture, so the browser
+ * rejects the clipboard write. {@code SignalInput} skips both
+ * problems.
  */
 @Route(value = "uc3", layout = MainLayout.class)
-@PageTitle("UC3 — Live signal counter")
-@Menu(order = 3, title = "UC3 — Live signal")
+@PageTitle("UC3 — Copy a hidden share link")
+@Menu(order = 3, title = "UC3 — Hidden share link")
 @StyleSheet("uc3.css")
 public class LiveSignalCounterView extends VerticalLayout {
 
     public LiveSignalCounterView() {
         addClassName("uc3-view");
-        add(new H1("UC3 — Copy a live signal value"));
+        add(new H1("UC3 — Copy a share link that's never rendered"));
         add(new Paragraph(
-                "Press Tick to increment the counter. The Copy button reads "
-                        + "the current value via SignalInput — every signal change "
-                        + "updates the mirror, so the next click always copies the "
-                        + "latest value with no server round-trip."));
+                "Type a slug. A server-side ValueSignal<String> keeps the "
+                        + "full URL but isn't bound to any UI element — open "
+                        + "the page's DOM and you won't find it. Click Copy "
+                        + "and SignalInput reads the signal's current value "
+                        + "at the moment of the gesture. The confirmation "
+                        + "line below is updated by the onCopied callback "
+                        + "for evidence."));
 
-        ValueSignal<String> counter = new ValueSignal<>("0");
+        ValueSignal<String> shareLink = new ValueSignal<>(buildUrl(""));
 
-        Span display = new Span();
-        display.setId("counter");
-        display.addClassName("counter");
-        display.bindText(counter);
+        TextField slug = new TextField("Slug");
+        slug.setId("slug");
+        slug.setValueChangeMode(ValueChangeMode.EAGER);
+        slug.addValueChangeListener(
+                e -> shareLink.set(buildUrl(e.getValue())));
 
-        Button tick = new Button("Tick");
-        tick.setId("tick");
-        tick.addClickListener(e -> counter.set(
-                Integer.toString(Integer.parseInt(counter.peek()) + 1)));
+        Span confirmation = new Span("(no copy yet)");
+        confirmation.setId("confirmation");
+        confirmation.addClassName("confirmation");
 
-        Button copy = new Button("Copy current value");
+        Button copy = new Button("Copy share link");
         copy.setId("copy");
 
         new ClickTrigger(copy).triggers(new WriteToClipboardAction(
-                new SignalInput<>(copy, counter), null));
+                new SignalInput<>(copy, shareLink), null, copied -> confirmation
+                        .setText("Copied at "
+                                + LocalTime.now().withNano(0) + ": " + copied),
+                err -> confirmation
+                        .setText("Copy failed: " + err.message())));
 
-        add(new HorizontalLayout(tick, display), copy);
+        add(slug, new HorizontalLayout(copy, confirmation));
+    }
+
+    private static String buildUrl(String slug) {
+        return "https://example.com/r/" + slug + "?from=demo";
     }
 }

--- a/triggers/src/main/resources/META-INF/resources/uc1.css
+++ b/triggers/src/main/resources/META-INF/resources/uc1.css
@@ -1,7 +1,6 @@
 .uc1-view {
-    .message-field {
-        width: 22rem;
-        max-width: 100%;
+    .notes-field {
+        font-family: var(--lumo-font-family);
     }
 
     .status-badge {
@@ -12,5 +11,12 @@
         font-size: 0.9rem;
         background: var(--vaadin-background-container);
         border: 1px solid var(--vaadin-border-color);
+        transition: background-color 200ms, color 200ms, border-color 200ms;
+    }
+
+    .status-badge.copied {
+        background: var(--vaadin-color-success-container);
+        color: var(--vaadin-color-success);
+        border-color: var(--vaadin-color-success);
     }
 }

--- a/triggers/src/main/resources/META-INF/resources/uc2.css
+++ b/triggers/src/main/resources/META-INF/resources/uc2.css
@@ -1,12 +1,30 @@
 .uc2-view {
-    .message-field {
-        width: 22rem;
-        max-width: 100%;
+    .gallery {
+        gap: 1.5rem;
+        margin-top: 0.5rem;
     }
 
-    .echo {
-        font-family: monospace;
-        color: var(--vaadin-text-color-secondary);
-        min-height: 1.5rem;
+    .gallery img {
+        width: 180px;
+        height: 180px;
+        object-fit: cover;
+        border-radius: var(--vaadin-radius-l);
+        border: 3px solid transparent;
+        cursor: pointer;
+        transition: opacity 200ms, filter 200ms, border-color 200ms;
+    }
+
+    .gallery img.selected {
+        border-color: var(--vaadin-color-primary);
+    }
+
+    .gallery img.dimmed {
+        opacity: 0.25;
+        filter: grayscale(100%);
+    }
+
+    #reset {
+        align-self: flex-start;
+        margin-top: 1.5rem;
     }
 }

--- a/triggers/src/main/resources/META-INF/resources/uc3.css
+++ b/triggers/src/main/resources/META-INF/resources/uc3.css
@@ -1,14 +1,8 @@
 .uc3-view {
-    .counter {
+    .confirmation {
         font-family: monospace;
-        font-size: 1.6rem;
-        font-weight: 600;
-        min-width: 3rem;
-        display: inline-flex;
-        align-items: center;
-        padding: 0.1rem 0.6rem;
-        background: var(--vaadin-background-container);
-        border: 1px solid var(--vaadin-border-color);
-        border-radius: var(--vaadin-radius-m);
+        font-size: 0.9rem;
+        color: var(--vaadin-text-color-secondary);
+        align-self: center;
     }
 }

--- a/triggers/src/test/java/com/example/uc1/ShortcutSaveViewTest.java
+++ b/triggers/src/test/java/com/example/uc1/ShortcutSaveViewTest.java
@@ -7,7 +7,7 @@ import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.browserless.ViewPackages;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.textfield.TextArea;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,13 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ShortcutSaveViewTest extends SpringBrowserlessTest {
 
     @Test
-    void viewRendersWithFieldAndStatus() {
+    void viewRendersWithNotesAndStatus() {
         navigate(ShortcutSaveView.class);
 
-        assertTrue(findInView(H1.class).all().stream()
-                .anyMatch(h -> "UC1 — Ctrl+S save".equals(h.getText())));
-        assertNotNull(findInView(TextField.class).id("message"));
-        assertEquals("(not saved yet)",
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h ->
+                "UC1 — Ctrl+S writes a snapshot to the clipboard"
+                        .equals(h.getText())));
+        assertNotNull(findInView(TextArea.class).id("notes"));
+        assertEquals("(no snapshot yet)",
                 findInView(Span.class).id("status").getText());
     }
 }

--- a/triggers/src/test/java/com/example/uc2/SubmitAndDisableViewTest.java
+++ b/triggers/src/test/java/com/example/uc2/SubmitAndDisableViewTest.java
@@ -7,8 +7,7 @@ import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.browserless.ViewPackages;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.html.Image;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,27 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SubmitAndDisableViewTest extends SpringBrowserlessTest {
 
     @Test
-    void viewRendersFieldSendButtonAndEcho() {
+    void viewRendersThreeTilesAndResetButton() {
         navigate(SubmitAndDisableView.class);
 
-        assertTrue(findInView(H1.class).all().stream()
-                .anyMatch(h -> "UC2 — Submit on Enter, then disable"
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h ->
+                "UC2 — Click an image to dim its siblings"
                         .equals(h.getText())));
-        assertNotNull(findInView(TextField.class).id("message"));
-        assertNotNull(findInView(Button.class).id("send"));
-        assertNotNull(findInView(Span.class).id("echo"));
-    }
-
-    @Test
-    void clickingSendDisablesItServerSide() {
-        navigate(SubmitAndDisableView.class);
-        TextField field = findInView(TextField.class).id("message");
-        Button send = findInView(Button.class).id("send");
-        field.setValue("hello");
-        test(send).click();
-        assertTrue(!send.isEnabled(),
-                "click listener disables the button server-side");
-        assertEquals("Sent: hello",
-                findInView(Span.class).id("echo").getText());
+        assertNotNull(findInView(Image.class).id("a"));
+        assertNotNull(findInView(Image.class).id("b"));
+        assertNotNull(findInView(Image.class).id("c"));
+        assertEquals("Reset", findInView(Button.class).id("reset").getText());
     }
 }

--- a/triggers/src/test/java/com/example/uc3/LiveSignalCounterViewTest.java
+++ b/triggers/src/test/java/com/example/uc3/LiveSignalCounterViewTest.java
@@ -8,8 +8,10 @@ import com.vaadin.browserless.ViewPackages;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -17,23 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LiveSignalCounterViewTest extends SpringBrowserlessTest {
 
     @Test
-    void viewRendersAtZero() {
+    void viewRendersWithSlugAndConfirmation() {
         navigate(LiveSignalCounterView.class);
 
-        assertTrue(findInView(H1.class).all().stream()
-                .anyMatch(h -> "UC3 — Copy a live signal value"
+        assertTrue(findInView(H1.class).all().stream().anyMatch(h ->
+                "UC3 — Copy a share link that's never rendered"
                         .equals(h.getText())));
-        assertEquals("0", findInView(Span.class).id("counter").getText());
-    }
-
-    @Test
-    void tickIncrementsCounter() {
-        navigate(LiveSignalCounterView.class);
-        Button tick = findInView(Button.class).id("tick");
-        test(tick).click();
-        test(tick).click();
-        test(tick).click();
-        assertEquals("3", findInView(Span.class).id("counter").getText(),
-                "server-side click handler advances the signal");
+        assertNotNull(findInView(TextField.class).id("slug"));
+        assertNotNull(findInView(Button.class).id("copy"));
+        assertEquals("(no copy yet)",
+                findInView(Span.class).id("confirmation").getText());
     }
 }


### PR DESCRIPTION
The three lead-off use cases previously demonstrated patterns the high-level framework already covers cleanly: UC1 round-tripped Ctrl+S to a server callback (same as @Shortcut), UC2 disabled a Button on click (same as setEnabled(false) inside the click handler), UC3 copied a value from a signal that was bound to a visible Span.

Reframe each so they exercise something the framework can't do at all, or can only do with extra round-trips:

UC1 — Ctrl+S writes a clipboard snapshot of the textarea, fully client-side. ShortcutTrigger fires WriteToClipboardAction + SetPropertyAction(textContent) + SetPropertyAction(className) in one gesture. @Shortcut would have to invoke a server method, whose follow-up executeJs for clipboard runs outside the user-gesture window and is rejected by the browser.

UC2 — Three <img> tiles. Click one and the other two fade to grayscale, the selected one gains a primary border, all three DOM mutations applied atomically with no server round-trip between them. Image isn't HasEnabled, but SetPropertyAction writes any property on any element. A Reset button fans three more SetPropertyAction calls to clear all three classes.

UC3 — A ValueSignal<String> holds the full share URL but is bound to nothing in the DOM; typing in the slug field updates the signal via a server-side value-change listener. Copy reads the signal via SignalInput at fire-time and writes text/plain. The framework would need to either render the URL into a hidden field just to read it back, or executeJs from a server callback — and that follow-up clipboard write loses the user-gesture context.

Per-view CSS and browserless tests updated to match. All 24 tests green.
