### PR TITLE
Replace .all().getFirst() with single()/first() in tests

### DIFF
--- a/fullscreen/src/test/java/com/example/uc3/DistractionFreeEditorViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc3/DistractionFreeEditorViewTest.java
@@ -60,7 +60,7 @@ class DistractionFreeEditorViewTest extends SpringBrowserlessTest {
         navigate(DistractionFreeEditorView.class);
         runPendingSignalsTasks();
 
-        TextArea editor = findInView(TextArea.class).all().getFirst();
+        TextArea editor = findInView(TextArea.class).single();
         test(editor).setValue("hello world this is fullscreen");
         runPendingSignalsTasks();
 

--- a/fullscreen/src/test/java/com/example/uc8/OverlaysFullscreenViewTest.java
+++ b/fullscreen/src/test/java/com/example/uc8/OverlaysFullscreenViewTest.java
@@ -46,7 +46,7 @@ class OverlaysFullscreenViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         @SuppressWarnings("unchecked")
-        Select<String> select = findInView(Select.class).all().getFirst();
+        Select<String> select = findInView(Select.class).single();
         select.setValue("Green");
         runPendingSignalsTasks();
 

--- a/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
+++ b/signals/src/test/java/com/example/usecase19/UseCase19ViewTest.java
@@ -67,7 +67,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         navigate(UseCase19View.class);
         runPendingSignalsTasks();
 
-        Card card = findInView(Card.class).all().getFirst();
+        Card card = findInView(Card.class).first();
 
         // IDLE state should carry the state-idle class (rendered via CSS)
         assertTrue(card.getClassNames().contains("state-idle"),
@@ -88,7 +88,7 @@ class UseCase19ViewTest extends SpringBrowserlessTest {
         runPendingSignalsTasks();
 
         // Cards in LOADING state should carry the state-loading class
-        Card card = findInView(Card.class).all().getFirst();
+        Card card = findInView(Card.class).first();
         assertTrue(card.getClassNames().contains("state-loading"),
                 "LOADING card should have state-loading class but was: "
                         + card.getClassNames());


### PR DESCRIPTION
ComponentQuery.single() asserts exactly one match and fails clearly when several exist, so it is the right tool when a test expects a unique component (uc3 TextArea, uc8 Select). UseCase19 renders one Card per data item, so it keeps "first of many" semantics via first() — still dropping the .all().getFirst() list allocation and expressing intent.
