### PR TITLE
uc21: Add a button that downloads the same CSV as the shortcut

### DIFF
--- a/triggers/src/main/java/com/example/uc21/ShortcutDownloadView.java
+++ b/triggers/src/main/java/com/example/uc21/ShortcutDownloadView.java
@@ -8,12 +8,14 @@ import com.example.views.MainLayout;
 
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Pre;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.DownloadAction;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
@@ -53,10 +55,11 @@ public class ShortcutDownloadView extends VerticalLayout {
         addClassName("uc21-view");
         add(new H1("UC21 — Shortcut download"));
         add(new Paragraph(
-                "Press Ctrl/Cmd+Shift+D anywhere in this view. The shortcut "
-                        + "fires a DownloadAction whose handler generates the "
-                        + "CSV preview below on the fly; the browser permits "
-                        + "the download because the keystroke is the user "
+                "Press Ctrl/Cmd+Shift+D anywhere in this view, or click the "
+                        + "Download CSV button. Either gesture fires a "
+                        + "DownloadAction whose handler generates the CSV "
+                        + "preview below on the fly; the browser permits the "
+                        + "download because the keystroke or click is the user "
                         + "gesture."));
 
         add(new H2("Preview"));
@@ -72,5 +75,11 @@ public class ShortcutDownloadView extends VerticalLayout {
 
         new ShortcutTrigger(this, Key.KEY_D, KeyModifier.CONTROL,
                 KeyModifier.SHIFT).triggers(new DownloadAction(handler));
+
+        // The same handler bound to a click gesture — the trigger API lets one
+        // handler back any user-gesture trigger, keyboard shortcut or button.
+        Button download = new Button("Download CSV");
+        new ClickTrigger(download).triggers(new DownloadAction(handler));
+        add(download);
     }
 }

--- a/triggers/src/main/java/com/example/uc21/ShortcutDownloadView.java
+++ b/triggers/src/main/java/com/example/uc21/ShortcutDownloadView.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.server.streams.DownloadResponse;
 /**
  * UC21 — Keyboard shortcut triggers a server-handler download.
  * <p>
- * Press Ctrl/Cmd+Shift+D anywhere in the view. A {@link ShortcutTrigger} fires
+ * Press Ctrl+Shift+D anywhere in the view. A {@link ShortcutTrigger} fires
  * a {@link DownloadAction} whose {@link DownloadHandler} produces a CSV on the
  * fly. The gesture context is preserved through the trigger fire, so the
  * browser permits the download — calling
@@ -55,7 +55,7 @@ public class ShortcutDownloadView extends VerticalLayout {
         addClassName("uc21-view");
         add(new H1("UC21 — Shortcut download"));
         add(new Paragraph(
-                "Press Ctrl/Cmd+Shift+D anywhere in this view, or click the "
+                "Press Ctrl+Shift+D anywhere in this view, or click the "
                         + "Download CSV button. Either gesture fires a "
                         + "DownloadAction whose handler generates the CSV "
                         + "preview below on the fly; the browser permits the "

--- a/triggers/src/test/java/com/example/uc21/ShortcutDownloadViewTest.java
+++ b/triggers/src/test/java/com/example/uc21/ShortcutDownloadViewTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Pre;
 
@@ -24,5 +25,8 @@ class ShortcutDownloadViewTest extends SpringBrowserlessTest {
         Pre preview = findInView(Pre.class).first();
         assertNotNull(preview);
         assertTrue(preview.getText().contains("ada@example.com"));
+
+        assertTrue(findInView(Button.class).all().stream()
+                .anyMatch(b -> "Download CSV".equals(b.getText())));
     }
 }


### PR DESCRIPTION
Wire a ClickTrigger on a Download CSV button to a DownloadAction backed
by the same DownloadHandler as the Ctrl/Cmd+Shift+D shortcut, so either
gesture serves the identical file. Update the test to assert the button
renders.
